### PR TITLE
Update the reference to the UTF-8 decode algorithm.

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -511,8 +511,15 @@ Region: id=bill width=50% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
   <section>
   <h3>Dependencies</h3>
 
-  <p>This specification relies upon the following terms defined in the
-  HTML standard. <a href="#refsHTML5">[HTML5]</a></p>
+  <p>This specification relies on several other underlying specifications.</p>
+
+  <p>The following term is defined in the Encoding standard: <a href="#refsENCODING">[ENCODING]</a></p>
+
+  <ul class="brief">
+   <li><a href="http://encoding.spec.whatwg.org/#utf-8-decode"><dfn>UTF-8 decode</dfn></a>
+  </ul>
+
+  <p>The following terms are defined in the HTML standard: <a href="#refsHTML5">[HTML5]</a></p>
 
   <ul class="brief">
    <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
@@ -523,8 +530,6 @@ Region: id=bill width=50% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
 #entry-script"><dfn>Entry script</dfn></a>
    <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
 #mime-type"><dfn>MIME type</dfn></a>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#utf-8-decode"><dfn>UTF-8 decode</dfn></a>
    <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
 #case-sensitive"><dfn>Case-sensitive</dfn></a>
    <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
@@ -5789,6 +5794,9 @@ interface <dfn>VTTRegionList</dfn> : EventTarget {
 
   <dt id="refsCSSVALUES">[CSSVALUES]</dt>
   <dd><cite><a href="http://dev.w3.org/csswg/css3-values/">CSS3 Values and Units</a></cite>, H. Lie, T. Atkins, E. Etemad. W3C.</dd>
+
+   <dt id="refsENCODING">[ENCODING]</dt>
+   <dd><cite><a href="http://encoding.spec.whatwg.org/">Encoding</a></cite>, A. van Kesteren, J. Bell. WHATWG.</dd>
 
   <dt id="refsHTML">[HTML]</dt>
   <dd><cite><a href="http://www.whatwg.org/specs/web-apps/current-work/">HTML</a></cite>, I. Hickson. WHATWG.</dd>


### PR DESCRIPTION
It now lives in the Encoding standard, not HTML.

The wording of the section was inspired by
http://www.whatwg.org/specs/web-apps/current-work/multipage/infrastructure.html#dependencies
