### PR TITLE
Fix a broken internal reference.

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -4039,7 +4039,8 @@ Unicode paragraph of the cue. <a href="#refsBIDI">[BIDI]</a></p>
            <p>If 'text-align' is 'middle', ignore the <var>offset</var>.</p>
          </li>
 
-         <li><p>Apply the terms of the CSS specifications to <var>nodes</var> in the same way that they are applied to in step 10, substep 12 is applied to <var>nodes</var> of a <var>cue</var> that is not part of a region, except that the initial containing block is <var>region</var>.</p>
+         <li><p>Apply the terms of the CSS specifications to <var>nodes</var> with the same constraints that are used when they are applied to <var>nodes</var> of a <var>cue</var> that is not part of a region, except that the initial containing block is <var>region</var>.</p>
+
            <p>Let <var>boxes</var> be the boxes generated as descendants of the initial containing block, along with their positions.</p>
          </li>
 


### PR DESCRIPTION
Referencing step 10, substep 12 isn't accurate any longer.
This creates a less fragile reference.
Was probably broken since ea580809ffe50bec627317bd0216f952b18d4552 .
