### PR TITLE
Fix almost all HTML validation errors.

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -206,7 +206,7 @@
 
     <p>If you wish to make comments or file bugs regarding this document in a manner
       that is tracked by the W3C, please submit them via <a
-      href="http://www.w3.org/Bugs/Public/enter_bug.cgi?product=TextTracks%20CG&component=WebVTT&short_desc=%5BWebVTT%5D%20">our
+      href="http://www.w3.org/Bugs/Public/enter_bug.cgi?product=TextTracks%20CG&amp;component=WebVTT&amp;short_desc=%5BWebVTT%5D%20">our
       public bug database</a>.</p>
 
   </section>
@@ -524,80 +524,43 @@ Region: id=bill width=50% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
   <p>The following terms are defined in the HTML standard: <a href="#refsHTML5">[HTML5]</a></p>
 
   <ul class="brief">
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#html-elements"><dfn>HTML elements</dfn></a>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#script's-document"><dfn>Script's document</dfn></a>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#entry-script"><dfn>Entry script</dfn></a>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#mime-type"><dfn>MIME type</dfn></a>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#case-sensitive"><dfn>Case-sensitive</dfn></a>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#collect-a-sequence-of-characters"><dfn>Collect a sequence of characters</dfn></a>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#ascii-digits"><dfn>ASCII digits</dfn></a>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#alphanumeric-ascii-characters"><dfn>Alphanumeric ASCII characters</dfn></a>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#space-character"><dfn>Space character</dfn></a>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#skip-whitespace"><dfn>Skip whitespace</dfn></a>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#supported-property-indices"><dfn>Supported property indices</dfn></a>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#determine-the-value-of-an-indexed-property"><dfn>Determine the value of an indexed property</dfn></a>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#split-a-string-on-spaces"><dfn>Split a string on spaces</dfn></a>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#html-namespace"><dfn>HTML namespace</dfn></a>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#media-element"><dfn>Media element</dfn></a>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#current-playback-position"><dfn>Current playback position</dfn></a>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#expose-a-user-interface-to-the-user"><dfn>Expose a user interface to the user</dfn></a>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#list-of-text-tracks"><dfn>List of text tracks</dfn></a>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#text-track"><dfn>Text track</dfn></a>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#text-track-kind"><dfn>Text track kind</dfn></a>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#text-track-mode"><dfn>Text track mode</dfn></a>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#text-track-disabled"><dfn>Text track disabled</dfn></a>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#text-track-showing"><dfn>Text track showing</dfn></a>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#text-track-cue"><dfn>Text track cue</dfn></a>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#text-track-list-of-cues"><dfn>Text track list of cues</dfn></a>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#text-track-cue-order"><dfn>Text track cue order</dfn></a>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#text-track-cue-identifier"><dfn>Text track cue identifier</dfn></a>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#text-track-cue-start-time"><dfn>Text track cue start time</dfn></a>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#text-track-cue-end-time"><dfn>Text track cue end time</dfn></a>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#text-track-cue-pause-on-exit-flag"><dfn>Text track cue pause-on-exit flag</dfn></a>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#text-track-cue-text"><dfn>Text track cue text</dfn></a>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#text-track-cue-active-flag"><dfn>Text track cue active flag</dfn></a>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#text-track-cue-display-state"><dfn>Text track cue display state</dfn></a>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#rules-for-updating-the-text-track-rendering"><dfn>Rules for updating the text track rendering</dfn></a>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#rules-for-rendering-the-cue-in-isolation"><dfn>Rules for rendering the cue in isolation</dfn></a>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#texttrackcue"><dfn><code>TextTrackCue</code></dfn></a> interface
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html
-#texttrack"><dfn><code>TextTrack</code></dfn></a> interface
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#html-elements"><dfn>HTML elements</dfn></a>
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#script's-document"><dfn>Script's document</dfn></a>
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#entry-script"><dfn>Entry script</dfn></a>
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#mime-type"><dfn>MIME type</dfn></a>
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#case-sensitive"><dfn>Case-sensitive</dfn></a>
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#collect-a-sequence-of-characters"><dfn>Collect a sequence of characters</dfn></a>
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#ascii-digits"><dfn>ASCII digits</dfn></a>
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#alphanumeric-ascii-characters"><dfn>Alphanumeric ASCII characters</dfn></a>
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#space-character"><dfn>Space character</dfn></a>
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#skip-whitespace"><dfn>Skip whitespace</dfn></a>
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#supported-property-indices"><dfn>Supported property indices</dfn></a>
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#determine-the-value-of-an-indexed-property"><dfn>Determine the value of an indexed property</dfn></a>
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#split-a-string-on-spaces"><dfn>Split a string on spaces</dfn></a>
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#html-namespace"><dfn>HTML namespace</dfn></a>
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#media-element"><dfn>Media element</dfn></a>
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#current-playback-position"><dfn>Current playback position</dfn></a>
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#expose-a-user-interface-to-the-user"><dfn>Expose a user interface to the user</dfn></a>
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#list-of-text-tracks"><dfn>List of text tracks</dfn></a>
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track"><dfn>Text track</dfn></a>
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-kind"><dfn>Text track kind</dfn></a>
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-mode"><dfn>Text track mode</dfn></a>
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-disabled"><dfn>Text track disabled</dfn></a>
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-showing"><dfn>Text track showing</dfn></a>
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-cue"><dfn>Text track cue</dfn></a>
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-list-of-cues"><dfn>Text track list of cues</dfn></a>
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-cue-order"><dfn>Text track cue order</dfn></a>
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-cue-identifier"><dfn>Text track cue identifier</dfn></a>
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-cue-start-time"><dfn>Text track cue start time</dfn></a>
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-cue-end-time"><dfn>Text track cue end time</dfn></a>
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-cue-pause-on-exit-flag"><dfn>Text track cue pause-on-exit flag</dfn></a>
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-cue-text"><dfn>Text track cue text</dfn></a>
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-cue-active-flag"><dfn>Text track cue active flag</dfn></a>
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-cue-display-state"><dfn>Text track cue display state</dfn></a>
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#rules-for-updating-the-text-track-rendering"><dfn>Rules for updating the text track rendering</dfn></a>
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#rules-for-rendering-the-cue-in-isolation"><dfn>Rules for rendering the cue in isolation</dfn></a>
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#texttrackcue"><dfn><code>TextTrackCue</code></dfn></a> interface
+   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#texttrack"><dfn><code>TextTrack</code></dfn></a> interface
   </ul>
   </section>
   </section>
@@ -766,7 +729,7 @@ Region: id=bill width=50% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
       </dl>
 
       <p>A <a>text track cue</a> has a default <a>text track cue line alignment</a> of <a
-      title="text track cue line start alignment">start</a>.</li></p>
+      title="text track cue line start alignment">start</a>.</p>
 
    </dd>
 
@@ -786,7 +749,7 @@ Region: id=bill width=50% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
      <a title="text track cue writing direction">writing direction</a>, otherwise to be interpreted
      as a percentage of the region width.</p>
 
-     <p>A <a>text track cue</a> has a <df>default text track cue text position</dfn> which is defined
+     <p>A <a>text track cue</a> has a <dfn>default text track cue text position</dfn> which is defined
      in terms of the value of the <a>text track cue text alignment</a>:</p>
 
      <ol>
@@ -2150,7 +2113,7 @@ The Final Minute</pre>
 
    <li><p><i>Cue creation</i>: Let <var title="">cue</var> be a new
    <a>text track cue</a> and initialize it with the following
-   attribute values:</p></li>
+   attribute values:</p>
 
     <ol>
      <li><p>Let <var title="">cue</var>'s <a>text track cue identifier</a> be the empty string.</p></li>
@@ -2182,6 +2145,8 @@ The Final Minute</pre>
 
      <li><p>Let <var title="">cue</var>'s <a>text track cue text</a> be the empty string.</p></li>
     </ol>
+
+   </li>
 
    <li><p>If <var title="">line</var> contains the three-character
    substring "<code title="">--></code>" (U+002D HYPHEN-MINUS, U+002D
@@ -2782,13 +2747,11 @@ The Final Minute</pre>
    <dl>
      <dt>If <a>text track cue text alignment</a> is <a title="text track cue left alignment">left</a> or
      <a title="text track cue start alignment">start</a></dt>
-     <dd>Let <a>text track cue text position</a> be 0%.</a></dd>
-     </dt>
+     <dd>Let <a>text track cue text position</a> be 0%.</dd>
 
      <dt>If <a>text track cue text alignment</a> is <a title="text track cue right alignment">right</a> or
      <a title="text track cue end alignment">end</a></dt>
-     <dd>Let <a>text track cue text position</a> be 100%.</a></dd>
-     </dt>
+     <dd>Let <a>text track cue text position</a> be 100%.</dd>
    </dl>
    </li>
 
@@ -2802,13 +2765,11 @@ The Final Minute</pre>
      <a title="text track cue start alignment">start</a></dt>
      <dd>Let <a>text track cue text position alignment</a> be
      <a title="text track cue text position start alignment">start alignment</a>.</dd>
-     </dt>
 
      <dt>If <a>text track cue text alignment</a> is <a title="text track cue right alignment">right</a> or
      <a title="text track cue end alignment">end</a></dt>
      <dd>Let <a>text track cue text position alignment</a> be
      <a title="text track cue text position end alignment">end alignment</a>.</dd>
-     </dt>
    </dl>
    </li>
 
@@ -4749,7 +4710,7 @@ Unicode paragraph of the cue. <a href="#refsBIDI">[BIDI]</a></p>
   must be set to 'border-box'.</p>
 
   <p>The 'overflow' property on the <a>WebVTT cue background box</a> must be set
-  to 'hidden'.</pa>
+  to 'hidden'.</p>
 
   <p>The 'font-style' property on <a title="WebVTT Italic
   Object">WebVTT Italic Objects</a> must be set to 'italic'.</p>


### PR DESCRIPTION
validator.nu also complains about the custom meta keywords bug.*,
but those are presumably used by bug-assist.js.
