### PR TITLE
Fix bug-assist box position.

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -171,11 +171,16 @@
       clear: left;
     }
     /* fix bug entry form styling */
-    body > form {
+    #bug-assist-form {
       padding: 4px;
       border: 1px solid red;
       background-color: rgba(255, 255, 255, 0.6);
+      position: fixed;
       top: 5em !important;
+      right: 1em;
+      width: 115px;
+      opacity: 0.8;
+      text-align: right;
     }
     </style>
   </head>


### PR DESCRIPTION
In commit https://dvcs.w3.org/hg/text-tracks/rev/1c6d33305c80 the
styling of the bug-assist box seems to have been removed by the
bug-assist.js script. This patch re-introduces the most important
styles.
