### PR TITLE
This paragraph is not necessary.

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -2520,10 +2520,6 @@ The Final Minute</pre>
          <li><p>If <var title="">linepos</var> does not contain at least one <a title="ASCII
          digits">ASCII digit</a>, then jump to the step labeled <i>next setting</i>.</p></li>
 
-         <li><p>If any character in <var title="">linepos</var> other
-         than the last character is a U+0025 PERCENT SIGN character
-         (%), then jump to the step labeled <i>next setting</i>.</p></li>
-
          <li>
            <dl>
             <dt><p>If the last character in <var title="">linepos</var> is


### PR DESCRIPTION
The check is redundant, because both the percentage string parsing and
the "Otherwise" branch will deal with such a condition.
(Thanks for noticing, Philip.)
