### PR TITLE
Don't let regions modify the "initial containing block"

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -3955,7 +3955,7 @@ Unicode paragraph of the cue. <a href="#refsBIDI">[BIDI]</a></p>
            <p>If 'text-align' is 'middle', ignore the <var>offset</var>.</p>
          </li>
 
-         <li><p>Apply the terms of the CSS specifications to <var>nodes</var> with the same constraints that are used when they are applied to <var>nodes</var> of a <var>cue</var> that is not part of a region, except that the initial containing block is <var>region</var>.</p>
+         <li><p>Apply the terms of the CSS specifications to <var>nodes</var> with the same constraints that are used when they are applied to <var>nodes</var> of a <var>cue</var> that is not part of a region.</p>
 
            <p>Let <var>boxes</var> be the boxes generated as descendants of the initial containing block, along with their positions.</p>
          </li>


### PR DESCRIPTION
https://www.w3.org/Bugs/Public/show_bug.cgi?id=24326

It's quite possible that regions rendering is now slightly broken,
but it was at least slightly broken before this commit also.
