### PR TITLE
Update CSS Selector Spec ref.

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -5588,7 +5588,7 @@ interface <dfn>VTTRegion</dfn> {
   <dd><cite><a href="http://tools.ietf.org/html/rfc3629">UTF-8, a transformation format of ISO 10646</a></cite>, F. Yergeau. IETF.</dd>
 
   <dt id="refsSELECTORS">[SELECTORS]</dt>
-  <dd><cite><a href="http://dev.w3.org/csswg/selectors4/">Selectors</a></cite>, E. Etemad, T. &Ccedil;elik, D. Glazman, I. Hickson, P. Linss, J. Williams. W3C.</dd>
+  <dd><cite><a href="http://www.w3.org/TR/selectors4/">Selectors</a></cite>, E. Etemad, T. Atkins Jr. W3C.</dd>
 
 <!--REFERENCES OFF-->
   </dl>
@@ -5610,6 +5610,7 @@ interface <dfn>VTTRegion</dfn> {
   Anna Cavender,
   Cyril Concolato,
   Rick Eyre,
+  fantasai,
   John Foliot,
   Lawrence Forooghian,
   Ralph Giles,


### PR DESCRIPTION
As requested by fantasai.
https://www.w3.org/Bugs/Public/show_bug.cgi?id=23788
## 

As for the :current use case in that bug - I think we can move that to v2.
