### PR TITLE
Be consistent with the default values.

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -1665,7 +1665,7 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
   position. The positioning is calculated relative to the <a title="text track cue line start alignment">start</a>,
   <a title="text track cue line middle alignment">middle</a>, or <a title="text track cue line end alignment">end</a>
   of the cue box, depending on the <a>text track cue line alignment</a> value -
-  <a title="text track cue line middle alignment">middle</a> by default.
+  <a title="text track cue line start alignment">start</a> by default.
   The position can be given either as a percentage of the video dimension
   or as a line number. Line numbers are based on the size of the first line of the
   cue. Positive line numbers count from the start of the video frame (the first


### PR DESCRIPTION
This NOTE was inconsistent.
Closes https://www.w3.org/Bugs/Public/show_bug.cgi?id=24315
