### PR TITLE
The big cleanup: reformatting the source (patch 1)

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -3,86 +3,99 @@
   <head>
     <title>WebVTT: The Web Video Text Tracks Format</title>
     <meta charset='utf-8'>
-    <script src='respec/builds/respec-w3c-common.js' async class='remove'></script>
-    <script class='remove'>
-      var respecConfig = {
-          // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
-          specStatus:           "CG-DRAFT",
 
-          // the specification's short name, as in http://www.w3.org/TR/short-name/
-          shortName:            "webvtt",
-
-          // if your specification has a subtitle that goes below the main
-          // formal title, define it here
-          // subtitle   :  "",
-
-          // if you wish the publication date to be other than today, set this
-          // publishDate:  "2009-08-06",
-
-          // if the specification's copyright date is a range of years, specify
-          // the start date here:
-          copyrightStart: "2011",
-
-          // if there is a previously published draft, uncomment this and set its YYYY-MM-DD date
-          // and its maturity status
-          //previousPublishDate:  "2013-03-11",
-          //previousMaturity:  "WD",
-          //prevED: "http://dev.w3.org/html5/webvtt/",
-
-          // if there a publicly available Editor's Draft, this is the link
-          edDraftURI:           "http://dev.w3.org/html5/webvtt/",
-
-          // if this is a LCWD, uncomment and set the end of its review period
-          // lcEnd: "2009-08-05",
-
-          // editors, add as many as you like
-          // only "name" is required
-          editors:  [
-              { name: "Silvia Pfeiffer", url: "mailto:silviapfeiffer1@gmail.com",
-                company: "NICTA", companyURL: "http://nicta.com.au/" },
-              { name: "Philip J&auml;genstedt", url: "mailto:philipj@opera.com",
-                company: "Opera Software ASA", companyURL: "http://www.opera.com/" },
-              { name: "Ian Hickson", url: "mailto:ian@hixie.ch",
-                company: "Google", companyURL: "http://google.com/", note: "previous editor" },
-          ],
-
-          // authors, add as many as you like.
-          // This is optional, uncomment if you have authors as well as editors.
-          // only "name" is required. Same format as editors.
-
-          //authors:  [
-          //    { name: "Your Name", url: "http://example.org/",
-          //      company: "Your Company", companyURL: "http://example.com/" },
-          //],
-
-          // name of the WG
-          wg:           "Text Tracks Community Group",
-
-          // URI of the public WG page
-          wgURI:        "http://www.w3.org/community/texttracks/",
-
-          // name (without the @w3c.org) of the public mailing to which comments are due
-          wgPublicList: "public-texttracks",
-
-          // URI of the patent status for this WG, for Rec-track documents
-          // !!!! IMPORTANT !!!!
-          // This is important for Rec-track documents, do not copy a patent URI from a random
-          // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
-          // Team Contact.
-          wgPatentURI:  "",
-
-          // formatting
-          noIDLIn: "true",
-          noIDLSorting: "true",
-
-          doRDFa: false,
-      };
+    <script src='respec/builds/respec-w3c-common.js' async class='remove'>
     </script>
+    <script class='remove'>
+    var respecConfig = {
+      // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
+      specStatus:           "CG-DRAFT",
+
+      // the specification's short name, as in http://www.w3.org/TR/short-name/
+      shortName:            "webvtt",
+
+      // if your specification has a subtitle that goes below the main
+      // formal title, define it here
+      // subtitle   :  "",
+
+      // if you wish the publication date to be other than today, set this
+      // publishDate:  "2009-08-06",
+
+      // if the specification's copyright date is a range of years, specify
+      // the start date here:
+      copyrightStart: "2011",
+
+      // if there is a previously published draft, uncomment this and set its
+      // YYYY-MM-DD date and its maturity status
+      //previousPublishDate:  "2013-03-11",
+      //previousMaturity:  "WD",
+      //prevED: "http://dev.w3.org/html5/webvtt/",
+
+      // if there a publicly available Editor's Draft, this is the link
+      edDraftURI:           "http://dev.w3.org/html5/webvtt/",
+
+      // if this is a LCWD, uncomment and set the end of its review period
+      // lcEnd: "2009-08-05",
+
+      // editors, add as many as you like
+      // only "name" is required
+      editors:  [
+          { name: "Silvia Pfeiffer",
+            url: "mailto:silviapfeiffer1@gmail.com",
+            company: "NICTA",
+            companyURL: "http://nicta.com.au/" },
+          { name: "Philip J&auml;genstedt",
+            url: "mailto:philipj@opera.com",
+            company: "Opera Software ASA",
+            companyURL: "http://www.opera.com/" },
+          { name: "Ian Hickson",
+            url: "mailto:ian@hixie.ch",
+            company: "Google",
+            companyURL: "http://google.com/",
+            note: "previous editor" },
+      ],
+
+      // authors, add as many as you like.
+      // This is optional, uncomment if you have authors as well as editors.
+      // only "name" is required. Same format as editors.
+
+      //authors:  [
+      //    { name: "Your Name", url: "http://example.org/",
+      //      company: "Your Company", companyURL: "http://example.com/" },
+      //],
+
+      // name of the WG
+      wg:           "Text Tracks Community Group",
+
+      // URI of the public WG page
+      wgURI:        "http://www.w3.org/community/texttracks/",
+
+      // name (without the @w3c.org) of the public mailing to which comments are
+      // due
+      wgPublicList: "public-texttracks",
+
+      // URI of the patent status for this WG, for Rec-track documents
+      // !!!! IMPORTANT !!!!
+      // This is important for Rec-track documents, do not copy a patent URI
+      // from a random
+      // document unless you know what you're doing. If in doubt ask your
+      // friendly neighbourhood Team Contact.
+      wgPatentURI:  "",
+
+      // formatting
+      noIDLIn: "true",
+      noIDLSorting: "true",
+
+      doRDFa: false,
+    };
+    </script>
+
     <!-- script to register bugs -->
     <script src="https://dvcs.w3.org/hg/webcomponents/raw-file/tip/assets/scripts/bug-assist.js"></script>
     <meta name="bug.short_desc" content="[WebVTT] ">
     <meta name="bug.product" content="TextTracks CG">
     <meta name="bug.component" content="WebVTT">
+
     <style>
     body {
       line-height: 1.35;
@@ -184,33 +197,44 @@
     }
     </style>
   </head>
+
   <body>
+
   <section id='abstract'>
-    <p>This is the specification of WebVTT, the Web Video Text Tracks format.
+    <p>
+      This is the specification of WebVTT, the Web Video Text Tracks format.
     </p>
 
-    <p>If you wish to make comments or file bugs regarding this document in a manner
-      that is tracked by the W3C, please submit them via <a
+    <p>
+      If you wish to make comments or file bugs regarding this document in a
+      manner that is tracked by the W3C, please submit them via <a
       href="http://www.w3.org/Bugs/Public/enter_bug.cgi?product=TextTracks%20CG&amp;component=WebVTT&amp;short_desc=%5BWebVTT%5D%20">our
-      public bug database</a>.</p>
-
-  </section>
+      public bug database</a>.
+    </p>
+  </section><!-- END: abstract -->
 
   <section id='sotd'>
-    <p>This specification is being developed as a Living Specification. There is a plan to take a snapshot and publish it as a W3C Recommendation through the <a href="http://www.w3.org/AudioVideo/TT/">W3C Timed Text Working Group</a>.
+    <p>
+      This specification is being developed as a Living Specification. There is
+      a plan to take a snapshot and publish it as a W3C Recommendation through
+      the <a href="http://www.w3.org/AudioVideo/TT/">W3C Timed Text Working Group</a>.
     </p>
-  </section>
+  </section><!-- END: sotd -->
 
   <section>
   <h2>Introduction</h2>
 
   <p><i>This section is non-normative.</i></p>
 
-  <p>The <dfn>WebVTT</dfn> (Web Video Text Tracks) format is
-  intended for marking up external text track resources.</p>
+  <p>
+    The <dfn>WebVTT</dfn> (Web Video Text Tracks) format is
+    intended for marking up external text track resources.
+  </p>
 
-  <p>The main use for WebVTT files is captioning video content. Here
-  is a sample file that captions an interview:</p>
+  <p>
+    The main use for WebVTT files is captioning video content. Here
+    is a sample file that captions an interview:
+  </p>
 
   <pre>WEBVTT
 
@@ -258,16 +282,21 @@
 
   <p><i>This section is non-normative.</i></p>
 
-  <p>Line breaks in cues are honored. User agents will also insert extra line breaks if necessary to
-  fit the cue in the cue's width. In general, therefore, authors are encouraged to write cues all on
-  one line except when a line break is definitely necessary, and to not manually line-wrap for
-  aesthetic reasons alone.</p>
+  <p>
+    Line breaks in cues are honored. User agents will also insert extra line
+    breaks if necessary to fit the cue in the cue's width. In general,
+    therefore, authors are encouraged to write cues all on one line except when
+    a line break is definitely necessary, and to not manually line-wrap for
+    aesthetic reasons alone.
+  </p>
 
   <div class="example">
+    <p>
+      These captions on a public service announcement video demonstrate line
+      breaking:
+    </p>
 
-   <p>These captions on a public service announcement video demonstrate line breaking:</p>
-
-   <pre>WEBVTT
+    <pre>WEBVTT
 
 00:01.000 --> 00:04.000
 Never drink liquid nitrogen.
@@ -279,12 +308,15 @@ Never drink liquid nitrogen.
 00:10.000 --> 00:14.000
 The Organisation for Sample Public Service Announcements accepts no liability for the content of this advertisement, or for the consequences of any actions taken on the basis of the information provided.</pre>
 
-   <p>The first cue is simple, it will probably just display on one line. The second will take two
-   lines, one for each speaker. The third will wrap to fit the width of the video, possibly taking
-   multiple lines. For example, the three cues could look like this:</p>
+    <p>
+      The first cue is simple, it will probably just display on one line. The
+      second will take two lines, one for each speaker. The third will wrap to
+      fit the width of the video, possibly taking multiple lines. For example,
+      the three cues could look like this:
+    </p>
 
 <!-- 50 -->
-   <pre>           Never drink liquid nitrogen.
+    <pre>           Never drink liquid nitrogen.
 
         &mdash; It will perforate your stomach.
                 &mdash; You could die.
@@ -295,11 +327,14 @@ The Organisation for Sample Public Service Announcements accepts no liability fo
      consequences of any actions taken on the
         basis of the information provided.</pre>
 
-   <p>If the width of the cues is smaller, the first two cues could wrap as well, as in the following
-   example. Note how the second cue's explicit line break is still honored, however:</p>
+    <p>
+      If the width of the cues is smaller, the first two cues could wrap as
+      well, as in the following example. Note how the second cue's explicit line
+      break is still honored, however:
+    </p>
 
 <!-- 25 -->
-   <pre>       Never drink
+    <pre>       Never drink
     liquid nitrogen.
 
   &mdash; It will perforate
@@ -317,10 +352,12 @@ The Organisation for Sample Public Service Announcements accepts no liability fo
     the basis of the
   information provided.</pre>
 
-   <p>Also notice how the wrapping is done so as to keep the line lengths balanced.</p>
-
+    <p>
+      Also notice how the wrapping is done so as to keep the line lengths
+      balanced.
+    </p>
   </div>
-  </section>
+  </section><!-- END: Cues with multiple lines -->
 
   <section>
   <h3>Comments</h3>
@@ -329,15 +366,19 @@ The Organisation for Sample Public Service Announcements accepts no liability fo
 
   <p>Comments can be included in WebVTT files.</p>
 
-  <p>Comments are just blocks that are preceded by a blank line,
-  start with the word "<code title="">NOTE</code>" (followed by a
-  space or newline), and end at the first blank line.</p>
+  <p>
+    Comments are just blocks that are preceded by a blank line,
+    start with the word "<code title="">NOTE</code>" (followed by a
+    space or newline), and end at the first blank line.
+  </p>
 
   <div class="example">
+    <p>
+      Here, a one-line comment is used to note a possible problem with a
+      cue.
+    </p>
 
-   <p>Here, a one-line comment is used to note a possible problem with a cue.</p>
-
-   <pre>WEBVTT
+    <pre>WEBVTT
 
 00:01.000 --> 00:04.000
 Never drink liquid nitrogen.
@@ -347,14 +388,12 @@ NOTE I'm not sure the timing is right on the following cue.
 00:05.000 --> 00:09.000
 &mdash; It will perforate your stomach.
 &mdash; You could die.</pre>
-
   </div>
 
   <div class="example">
+    <p>In this example, the author has written many comments.</p>
 
-   <p>In this example, the author has written many comments.</p>
-
-   <pre>WEBVTT
+    <pre>WEBVTT
 
 NOTE
 This file was written by Jill. I hope
@@ -375,9 +414,8 @@ NOTE check next cue
 &mdash; You could die.
 
 NOTE end of file</pre>
-
   </div>
-  </section>
+  </section><!-- END: Comments -->
 
   <section>
   <h3>Other features</h3>
@@ -387,10 +425,9 @@ NOTE end of file</pre>
   <p>WebVTT also supports some less-often used features.</p>
 
   <div class="example">
+    <p>In this example, the cues have an identifier:</p>
 
-   <p>In this example, the cues have an identifier:</p>
-
-   <pre>WEBVTT
+    <pre>WEBVTT
 
 1
 00:00.000 --> 00:02.000
@@ -400,22 +437,25 @@ transcript credit
 00:04.000 --> 00:05.000
 Transcribed by Celestials&trade;</pre>
 
-   <p>This allows a style sheet to specifically target the cues (notice the use
-   of CSS character escape sequences):</p>
+    <p>
+      This allows a style sheet to specifically target the cues (notice the use
+      of CSS character escape sequences):
+    </p>
 
-   <pre>::cue(#\31) { color: green; }
+    <pre>::cue(#\31) { color: green; }
 ::cue(#transcript\ credit) { color: red; }</pre>
-
   </div>
 
   <div class="example">
+    <p>
+      In this example, each cue says who is talking using voice spans. In the
+      first cue, the span specifying the speaker is also annotated with two
+      classes, "first" and "loud". In the third cue, there is also some italics
+      text (not associated with a specific speaker). The last cue is annotated
+      with just the class "loud".
+    </p>
 
-   <p>In this example, each cue says who is talking using voice spans. In the first cue, the span
-   specifying the speaker is also annotated with two classes, "first" and "loud". In the third cue,
-   there is also some italics text (not associated with a specific speaker). The last cue is
-   annotated with just the class "loud".</p>
-
-   <pre>WEBVTT
+    <pre>WEBVTT
 
 00:00.000 --> 00:02.000
 &lt;v.first.loud Esme>It's a blue apple tree!
@@ -429,22 +469,26 @@ Transcribed by Celestials&trade;</pre>
 00:06.000 --> 00:08.000
 &lt;v.loud Mary>That's awesome!</pre>
 
-   <p>Notice that as a special exception, the voice spans don't have to be closed if they cover the
-   entire cue text.</p>
+    <p>
+      Notice that as a special exception, the voice spans don't have to be
+      closed if they cover the entire cue text.
+    </p>
 
-   <p>Style sheets can style these spans:</p>
+    <p>Style sheets can style these spans:</p>
 
-   <pre>::cue(v[voice="Esme"]) { color: blue }
+    <pre>::cue(v[voice="Esme"]) { color: blue }
 ::cue(v[voice="Mary"]) { color: green }
 ::cue(i) { font-style: italic }
 ::cue(.loud) { font-size: 2em }</pre>
-
   </div>
 
   <div class="example">
-  <p>This example shows how to position cues at explicit positions in the video viewport.</p>
+    <p>
+      This example shows how to position cues at explicit positions in the video
+      viewport.
+    </p>
 
-  <pre>WEBVTT
+    <pre>WEBVTT
 
 00:00:00.000 --> 00:00:04.000 position:10%,start align:start size:35%
 Where did he go?
@@ -455,14 +499,32 @@ I think he went down this lane.
 00:00:04.000 --> 00:00:06.500 position:45%,end align:middle size:35%
 What are you waiting for?</pre>
 
-  <p>The cues cover only 35% of the video viewport's width. The first cue has its <a title="text track cue box">cue box</a> left aligned at the 10% mark of the video viewport width and the text is left aligned within that box - probably underneath a speaker on the left of the video image. "start" alignment of the cue box is the default for start aligned text, so does not need to be specified in "position". The second cue has its <a title="text track cue box">cue box</a> right aligned at the 90% mark of the video viewport width. The same effect can be achieved with "position:55%,start", which explicitly positions the cue box. The third cue has middle aligned text within the same type of cue box as the first cue.</p>
+    <p>
+      The cues cover only 35% of the video viewport's width. The first cue has
+      its <a title="text track cue box">cue box</a> left aligned at the 10% mark
+      of the video viewport width and the text is left aligned within that box -
+      probably underneath a speaker on the left of the video image. "start"
+      alignment of the cue box is the default for start aligned text, so does
+      not need to be specified in "position". The second cue has its <a
+      title="text track cue box">cue box</a> right aligned at the 90% mark of
+      the video viewport width. The same effect can be achieved with
+      "position:55%,start", which explicitly positions the cue box. The third
+      cue has middle aligned text within the same type of cue box as the first
+      cue.
+    </p>
   </div>
 
   <div class="example">
-  <p>This example shows two regions containing rollup captions for two different speakers. Fred's cues scroll up in a region in the left half of the video, Bill's cues scroll up in a region on the right half of the video. Fred's first cue disappears at 12.5sec even though it is defined until 20sec because its region is limited to 3 lines and at 12.5sec a fourth cue appears:
-  </p>
+    <p>
+      This example shows two regions containing rollup captions for two
+      different speakers. Fred's cues scroll up in a region in the left half of
+      the video, Bill's cues scroll up in a region on the right half of the
+      video. Fred's first cue disappears at 12.5sec even though it is defined
+      until 20sec because its region is limited to 3 lines and at 12.5sec a
+      fourth cue appears:
+    </p>
 
-  <pre>WEBVTT
+    <pre>WEBVTT
 Region: id=fred width=40% lines=3 regionanchor=0%,100% viewportanchor=10%,90% scroll=up
 Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% scroll=up
 
@@ -484,73 +546,157 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
 00:00:12.500 --> 00:00:32.500 region:fred align:left
 &lt;v Fred>OK, let's go.</pre>
 
-  <p>Note that regions are only defined for horizontal cues.</p>
-
+    <p>Note that regions are only defined for horizontal cues.</p>
   </div>
+  </section><!-- END: Other features -->
 
-  </section>
-
-  </section>
+  </section><!-- END: Introduction -->
 
   <section>
   <h2>Conformance</h2>
 
-  <p class="todo">This section remains to be written. In the meantime, please see the HTML standard. <a href="#refsHTML5">[HTML5]</a></p>
+  <p class="todo">
+    This section remains to be written. In the meantime, please see the HTML
+    standard. <a href="#refsHTML5">[HTML5]</a>
+  </p>
 
   <section>
   <h3>Dependencies</h3>
 
   <p>This specification relies on several other underlying specifications.</p>
 
-  <p>The following term is defined in the Encoding standard: <a href="#refsENCODING">[ENCODING]</a></p>
+  <p>
+    The following term is defined in the Encoding standard:
+    <a href="#refsENCODING">[ENCODING]</a>
+  </p>
 
   <ul class="brief">
-   <li><a href="http://encoding.spec.whatwg.org/#utf-8-decode"><dfn>UTF-8 decode</dfn></a></li>
+    <li>
+      <a href="http://encoding.spec.whatwg.org/#utf-8-decode"><dfn>UTF-8 decode</dfn></a>
+    </li>
   </ul>
 
-  <p>The following terms are defined in the HTML standard: <a href="#refsHTML5">[HTML5]</a></p>
+  <p>
+    The following terms are defined in the HTML standard:
+    <a href="#refsHTML5">[HTML5]</a>
+  </p>
 
   <ul class="brief">
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#html-elements"><dfn>HTML elements</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#script's-document"><dfn>Script's document</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#entry-script"><dfn>Entry script</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#mime-type"><dfn>MIME type</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#case-sensitive"><dfn>Case-sensitive</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#collect-a-sequence-of-characters"><dfn>Collect a sequence of characters</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#ascii-digits"><dfn>ASCII digits</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#alphanumeric-ascii-characters"><dfn>Alphanumeric ASCII characters</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#space-character"><dfn>Space character</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#skip-whitespace"><dfn>Skip whitespace</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#supported-property-indices"><dfn>Supported property indices</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#determine-the-value-of-an-indexed-property"><dfn>Determine the value of an indexed property</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#split-a-string-on-spaces"><dfn>Split a string on spaces</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#html-namespace"><dfn>HTML namespace</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#media-element"><dfn>Media element</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#current-playback-position"><dfn>Current playback position</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#expose-a-user-interface-to-the-user"><dfn>Expose a user interface to the user</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#list-of-text-tracks"><dfn>List of text tracks</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track"><dfn>Text track</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-kind"><dfn>Text track kind</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-mode"><dfn>Text track mode</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-disabled"><dfn>Text track disabled</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-showing"><dfn>Text track showing</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-cue"><dfn>Text track cue</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-list-of-cues"><dfn>Text track list of cues</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-cue-order"><dfn>Text track cue order</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-cue-identifier"><dfn>Text track cue identifier</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-cue-start-time"><dfn>Text track cue start time</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-cue-end-time"><dfn>Text track cue end time</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-cue-pause-on-exit-flag"><dfn>Text track cue pause-on-exit flag</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-cue-text"><dfn>Text track cue text</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-cue-active-flag"><dfn>Text track cue active flag</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-cue-display-state"><dfn>Text track cue display state</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#rules-for-updating-the-text-track-rendering"><dfn>Rules for updating the text track rendering</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#rules-for-rendering-the-cue-in-isolation"><dfn>Rules for rendering the cue in isolation</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#texttrackcue"><dfn><code>TextTrackCue</code></dfn></a> interface</li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#texttrack"><dfn><code>TextTrack</code></dfn></a> interface</li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#html-elements"><dfn>HTML elements</dfn></a>
+    </li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#script's-document"><dfn>Script's document</dfn></a>
+    </li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#entry-script"><dfn>Entry script</dfn></a>
+    </li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#mime-type"><dfn>MIME type</dfn></a>
+    </li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#case-sensitive"><dfn>Case-sensitive</dfn></a>
+    </li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#collect-a-sequence-of-characters"><dfn>Collect a sequence of characters</dfn></a>
+    </li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#ascii-digits"><dfn>ASCII digits</dfn></a>
+    </li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#alphanumeric-ascii-characters"><dfn>Alphanumeric ASCII characters</dfn></a>
+    </li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#space-character"><dfn>Space character</dfn></a>
+    </li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#skip-whitespace"><dfn>Skip whitespace</dfn></a>
+    </li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#supported-property-indices"><dfn>Supported property indices</dfn></a>
+    </li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#determine-the-value-of-an-indexed-property"><dfn>Determine the value of an indexed property</dfn></a>
+    </li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#split-a-string-on-spaces"><dfn>Split a string on spaces</dfn></a>
+    </li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#html-namespace"><dfn>HTML namespace</dfn></a>
+    </li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#media-element"><dfn>Media element</dfn></a>
+    </li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#current-playback-position"><dfn>Current playback position</dfn></a>
+    </li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#expose-a-user-interface-to-the-user"><dfn>Expose a user interface to the user</dfn></a>
+    </li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#list-of-text-tracks"><dfn>List of text tracks</dfn></a>
+    </li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track"><dfn>Text track</dfn></a>
+    </li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-kind"><dfn>Text track kind</dfn></a>
+    </li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-mode"><dfn>Text track mode</dfn></a>
+    </li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-disabled"><dfn>Text track disabled</dfn></a>
+    </li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-showing"><dfn>Text track showing</dfn></a>
+    </li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-cue"><dfn>Text track cue</dfn></a>
+    </li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-list-of-cues"><dfn>Text track list of cues</dfn></a>
+    </li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-cue-order"><dfn>Text track cue order</dfn></a>
+    </li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-cue-identifier"><dfn>Text track cue identifier</dfn></a>
+    </li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-cue-start-time"><dfn>Text track cue start time</dfn></a>
+    </li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-cue-end-time"><dfn>Text track cue end time</dfn></a>
+    </li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-cue-pause-on-exit-flag"><dfn>Text track cue pause-on-exit flag</dfn></a>
+    </li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-cue-text"><dfn>Text track cue text</dfn></a>
+    </li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-cue-active-flag"><dfn>Text track cue active flag</dfn></a>
+    </li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#text-track-cue-display-state"><dfn>Text track cue display state</dfn></a>
+    </li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#rules-for-updating-the-text-track-rendering"><dfn>Rules for updating the text track rendering</dfn></a>
+    </li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#rules-for-rendering-the-cue-in-isolation"><dfn>Rules for rendering the cue in isolation</dfn></a>
+    </li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#texttrackcue"><dfn><code>TextTrackCue</code></dfn></a> interface
+    </li>
+    <li>
+      <a href="http://www.w3.org/html/wg/drafts/html/master/single-page.html#texttrack"><dfn><code>TextTrack</code></dfn></a> interface
+    </li>
   </ul>
-  </section>
-  </section>
+  </section><!-- END: Dependencies -->
+
+  </section><!-- END: Conformance -->
 
   <section>
   <h2>Data model</h2>
@@ -560,387 +706,629 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
   <section>
   <h3>Text Track Cues</h3>
 
-  <p>WebVTT cues are HTML <a title="text track cue">text track cues</a> that additionally
-  consist of the following: <a href="#refsHTML5">[HTML5]</a></p>
+  <p>
+    WebVTT cues are HTML <a title="text track cue">text track cues</a> that
+    additionally consist of the following: <a href="#refsHTML5">[HTML5]</a>
+  </p>
 
   <dl>
+    <dt><dfn title="text track cue box">A cue box</dfn></dt>
+    <dd>
+      <p>
+        The cue box of a <a>text track cue</a> is a box within which the text of
+        all lines of the cue is to be rendered.
+      </p>
 
-   <dt><dfn title="text track cue box">A cue box</dfn></dt>
-   <dd>
-     <p>The cue box of a <a>text track cue</a> is a box within which the text of all lines of the
-     cue is to be rendered.</p>
+      <p class="note">
+        The position of the <a title="text track cue box">cue box</a> within the
+        video frame's dimensions depends on the value of the
+        <a>text track cue text position</a> and the
+        <a>text track cue line position</a>.
+      </p>
 
-     <p class="note">The position of the <a title="text track cue box">cue box</a> within the video frame's dimensions depends
-     on the value of the <a>text track cue text position</a> and the <a>text track cue line position</a>.</p>
+      <p class="note">
+        Lines are wrapped within the <a title="text track cue box">cue box</a>'s
+        <a title="text track cue size">size</a> if lines lengths make this
+        necessary.
+      </p>
+    </dd>
 
-     <p class="note">Lines are wrapped within the <a title="text track cue box">cue box</a>'s
-     <a title="text track cue size">size</a> if lines lengths make this necessary.</p>
+    <dt>
+      <dfn title="text track cue writing direction">A writing direction</dfn>
+    </dt>
+    <dd>
+      <p>
+        A writing direction, either
+        <dfn title="text track cue horizontal writing direction">horizontal</dfn>
+        (a line extends horizontally and is positioned vertically, with
+        consecutive lines displayed below each other),
+        <dfn title="text track cue vertical growing left writing direction">vertical growing left</dfn>
+        (a line extends vertically and is positioned horizontally, with
+        consecutive lines displayed to the left of each
+        other<!-- used for east asian-->), or
+        <dfn title="text track cue vertical growing right writing direction">vertical growing right</dfn>
+        (a line extends vertically and is positioned horizontally, with
+        consecutive lines displayed to the right of each
+        other<!-- used for mongolian -->).
+      </p>
 
-   </dd>
+      <p>
+        The writing direction is a property of the text inside the
+        <a title="text track cue box">cue box</a> which influences the
+        interpretation of the positioning settings of the
+        <a title="text track cue box">cue box</a>.
+      </p>
 
-   <dt><dfn title="text track cue writing direction">A writing direction</dfn></dt>
-   <dd>
-    <p>A writing direction, either <dfn title="text track cue horizontal writing
-    direction">horizontal</dfn> (a line extends horizontally and is positioned vertically, with
-    consecutive lines displayed below each other), <dfn title="text track cue vertical growing left
-    writing direction">vertical growing left</dfn> (a line extends vertically and is positioned
-    horizontally, with consecutive lines displayed to the left of each other<!-- used for east
-    asian-->), or <dfn title="text track cue vertical growing right writing direction">vertical
-    growing right</dfn> (a line extends vertically and is positioned horizontally, with consecutive
-    lines displayed to the right of each other<!-- used for mongolian -->).</p>
+      <p>
+        If the <a title="text track cue writing direction">writing direction</a>
+        is
+        <a title="text track cue horizontal writing direction">horizontal</a>,
+        then the <a title="text track cue line position">line position</a>
+        percentages are relative to the height of the video, and
+        <a title="text track cue text position">text position</a> and
+        <a title="text track cue size">size</a> percentages are relative to the
+        width of the video.
+      </p>
 
-    <p>The writing direction is a property of the text inside the <a title="text track cue box">cue box</a> which
-    influences the interpretation of the positioning settings of the <a title="text track cue box">cue box</a>.</p>
+      <p>
+        Otherwise, <a title="text track cue line position">line position</a>
+        percentages are relative to the width of the video, and
+        <a title="text track cue text position">text position</a> and
+        <a title="text track cue size">size</a> percentages are relative to
+        the height of the video.
+      </p>
 
-    <p>If the <a title="text track cue writing direction">writing direction</a> is <a
-    title="text track cue horizontal writing direction">horizontal</a>, then the <a title="text
-    track cue line position">line position</a> percentages are relative to the height of the
-    video, and <a title="text track cue text position">text position</a> and <a title="text
-    track cue size">size</a> percentages are relative to the width of the video.</p>
+      <p>
+        The <a title="text track cue writing direction">writing direction</a>
+        defaults to
+        <a title="text track cue horizontal writing direction">horizontal</a>.
+      </p>
+    </dd>
 
-    <p>Otherwise, <a title="text track cue line position">line position</a> percentages are
-    relative to the width of the video, and <a title="text track cue text position">text
-    position</a> and <a title="text track cue size">size</a> percentages are relative to
-    the height of the video.</p>
+    <dt>
+      <dfn title="text track cue snap-to-lines flag">A snap-to-lines flag</dfn>
+    </dt>
+    <dd>
+      <p>
+        A boolean indicating whether the
+        <a title="text track cue line position">line's position</a> is a line
+        position (positioned to a multiple of the line dimensions of the first
+        line of the cue), or whether it is a percentage of the dimension of the
+        video.
+      </p>
 
-    <p>The <a title="text track cue writing direction">writing direction</a> defaults to
-    <a title="text track cue horizontal writing direction">horizontal</a>.</p>
+      <p>
+        Cues whose <a>text track cue snap-to-lines flag</a> is set will be
+        placed within the title-safe area on user agents that use overscan. Cues
+        with the flag unset will be positioned as requested (modulo overlap
+        avoidance if multiple cues are in the same place).
+      </p>
 
-   </dd>
+      <p>
+        By default, the
+        <a title="text track cue snap-to-lines flag">snap-to-lines flag</a>
+        is set to 'true'.
+      </p>
+    </dd>
 
-   <dt><dfn title="text track cue snap-to-lines flag">A snap-to-lines flag</dfn></dt>
-   <dd>
+    <dt>
+      <dfn title="text track cue line position">A cue line position</dfn>
+    </dt>
+    <dd>
+      <p>
+        The line position defines positioning of the
+        <a title="text track cue box">cue box</a>.
+      </p>
 
-    <p>A boolean indicating whether the <a title="text track cue line position">line's
-    position</a> is a line position (positioned to a multiple of the line dimensions of the first
-    line of the cue), or whether it is a percentage of the dimension of the video.</p>
+      <p>
+        A line position is either a number giving the position of the lines of
+        the cue, to be interpreted as defined by the
+        <a title="text track cue writing direction">writing direction</a>
+        and <a title="text track cue snap-to-lines flag">snap-to-lines flag</a>
+        of the cue, or the special value
+        <dfn title="text track cue automatic line position">auto</dfn>, which
+        means the position is to depend on the other
+        <a title="Text track cue active flag">active</a> cues.
+      </p>
 
-    <p>Cues whose <a>text track cue snap-to-lines flag</a> is set will be placed within the
-    title-safe area on user agents that use overscan. Cues with the flag unset will be positioned as
-    requested (modulo overlap avoidance if multiple cues are in the same place).</p>
-
-    <p>By default, the <a title="text track cue snap-to-lines flag">snap-to-lines flag</a>
-    is set to 'true'.</p>
-
-   </dd>
-
-   <dt><dfn title="text track cue line position">A cue line position</dfn></dt>
-   <dd>
-    <p>The line position defines positioning of the <a title="text track cue box">cue box</a>.</p>
-
-    <p>A line position is either a number giving the position of the lines of the cue, to be
-    interpreted as defined by the <a title="text track cue writing direction">writing direction</a>
-    and <a title="text track cue snap-to-lines flag">snap-to-lines flag</a> of the cue, or the special
-    value <dfn title="text track cue automatic line position">auto</dfn>, which means the position
-    is to depend on the other <a title="Text track cue active flag">active</a> cues.</p>
-
-    <p>A <a>text track cue</a> has a <dfn>text track cue computed line position</dfn> whose
-    value is that returned by the following algorithm, which is defined in terms of the other
-    aspects of the cue:</p>
-
-    <ol>
-
-     <li><p>If the <a>text track cue line position</a> is numeric, the <a>text track cue
-     snap-to-lines flag</a> of the <a>text track cue</a> is not set, and the <a>text
-     track cue line position</a> is negative or greater than 100, then return 100 and abort these
-     steps.</p></li>
-
-     <li><p>If the <a>text track cue line position</a> is numeric, return the value of the
-     <a>text track cue line position</a> and abort these steps. (Either the <a>text track
-     cue snap-to-lines flag</a> is set, so any value, not just those in the range 0..100, is
-     valid, or the value is in the range 0..100 and is thus valid regardless of the value of that
-     flag.)</p></li>
-
-     <li><p>If the <a>text track cue snap-to-lines flag</a> of the <a>text track cue</a>
-     is not set, return the value 100 and abort these steps. (The <a>text track cue line
-     position</a> is the special value <a title="text track cue automatic line
-     position">auto</a>.)</p></li>
-
-     <li><p>Let <var title="">cue</var> be the <a>text track cue</a>.</p></li>
-
-     <li><p>If <var title="">cue</var> is not in a <a title="text track list of cues">list of
-     cues</a> of a <a>text track</a>, or if that <a>text track</a> is not in the
-     <a>list of text tracks</a> of a <a>media element</a>, return &#x2212;1 and abort
-     these steps.</p></li>
-
-     <li><p>Let <var title="">track</var> be the <a>text track</a> whose <a title="text
-     track list of cues">list of cues</a> the <var title="">cue</var> is in.</p></li>
-
-     <li><p>Let <var title="">n</var> be the number of <a title="text track">text tracks</a>
-     whose <a>text track mode</a> is <a title="text track showing">showing</a> and that
-     are in the <a>media element</a>'s <a>list of text tracks</a> before <var
-     title="">track</var>.</p></li>
-
-     <li><p>Increment <var title="">n</var> by one.</p></li>
-
-     <li><p>Negate <var title="">n</var>.</p></li>
-
-     <li><p>Return <var title="">n</var>.</p></li>
-
-    </ol>
-
-   </dd>
-
-   <dt><dfn title="text track cue line alignment">A cue line alignment</dfn></dt>
-   <dd>
-     <p>An alignment for the <a title="text track cue box">cue box</a>'s <a title="text track cue line position">line position</a>,
-     one of:</p>
-
-      <dl>
-
-       <dt><dfn title="text track cue line start alignment">Start alignment</dfn></dt>
-       <dd>The <a title="text track cue box">cue box</a>'s top side (for
-       <a title="text track cue horizontal writing direction">horizontal</a> cues),
-       left side (for
-       <a title="text track cue vertical growing right writing direction">vertical growing right</a>),
-       or right side (for
-       <a title="text track cue vertical growing left writing direction">vertical growing left</a>)
-       is aligned at the <a title="text track cue line position">line position</a>.
-       </dd>
-
-       <dt><dfn title="text track cue line middle alignment">Middle alignment</dfn></dt>
-       <dd>The <a title="text track cue box">cue box</a> is centered at the
-       <a title="text track cue line position">line position</a>.
-       </dd>
-
-       <dt><dfn title="text track cue line end alignment">End alignment</dfn></dt>
-       <dd>The <a title="text track cue box">cue box</a>'s bottom side (for
-        <a title="text track cue horizontal writing direction">horizontal</a> cues),
-        right side (for
-        <a title="text track cue vertical growing right writing direction">vertical growing right</a>),
-        or left side (for
-        <a title="text track cue vertical growing left writing direction">vertical growing left</a>)
-        is aligned at the <a title="text track cue line position">line position</a>.
-       </dd>
-
-      </dl>
-
-      <p>A <a>text track cue</a> has a default <a>text track cue line alignment</a> of <a
-      title="text track cue line start alignment">start</a>.</p>
-
-   </dd>
-
-   <dt><dfn title="text track cue size">A size</dfn></dt>
-   <dd>
-    <p>A number giving the size of the <a title="text track cue box">cue box</a>, to be interpreted as a percentage of the video,
-    as defined by the <a title="text track cue writing direction">writing direction</a>.</p>
-
-    <p>By default, the <a>text track cue size</a> is 100%.</p>
-
-   </dd>
-
-   <dt><dfn title="text track cue text position">A text position</dfn></dt>
-   <dd>
-     <p>A number giving the position of the <a title="text track cue box">cue box</a>. If the cue is not within
-     a region, the value is to be interpreted as a percentage of the video, as defined by the
-     <a title="text track cue writing direction">writing direction</a>, otherwise to be interpreted
-     as a percentage of the region width.</p>
-
-     <p>A <a>text track cue</a> has a <dfn>default text track cue text position</dfn> which is defined
-     in terms of the value of the <a>text track cue text alignment</a>:</p>
-
-     <ol>
-
-       <li>For <a title="text track cue left alignment">left aligned</a> or
-       <a title="text track cue start alignment">start aligned</a> cues: 0%.</li>
-
-       <li>For <a title="text track cue middle alignment">middle aligned</a> cues: 50%.</li>
-
-       <li>For <a title="text track cue right alignment">right aligned</a> or
-       <a title="text track cue end alignment">end aligned</a> cues: 100%.</li>
-
-     </ol>
-
-     <p class="note">Since the default value of the <a>text track cue text alignment</a> is
-     <a title="text track cue middle alignment">middle</a>, if there is no
-     <a>text track cue text alignment</a> setting for a cue, the <a>text track cue text position</a>
-     defaults to 50%.</p>
-
-     <p class="note">Even for <a title="text track cue horizontal writing direction">horizontal</a>
-     cues with right-to-left <i>paragraph direction</i> text, the <a title="text track cue box">cue box</a>
-     is positioned from the left edge of the video frame. This allows defining a rendering space template
-     which can be filled with either left-to-right or right-to-left <i>paragraph direction</i> text. If you
-     define such a <a title="text track cue box">cue box</a> template with
-     <a title="text track cue start alignment">start</a> or <a title="text track cue end alignment">end</a>
-     aligned text, make sure to control its <a title="text track cue size">size</a> unless you want
-     text to flip from one side of the video frame to the other.</p>
-
-   </dd>
-
-   <dt><dfn title="text track cue text position alignment">A text position alignment</dfn></dt>
-   <dd>
-     <p>An alignment for the <a title="text track cue box">cue box</a> in the dimension of the
-     <a title="text track cue writing direction">writing direction</a>, describing which part of the
-     <a title="text track cue box">cue box</a> is aligned to the <a title="text track cue text position">text position</a>,
-     one of:</p>
-
-      <dl>
-
-       <dt><dfn title="text track cue text position start alignment">Start alignment</dfn></dt>
-       <dd>The <a title="text track cue box">cue box</a>'s left side (for
-       <a title="text track cue horizontal writing direction">horizontal</a> cues) or top
-       side (otherwise) is aligned at the <a title="text track cue text position">text position</a>.
-       </dd>
-
-       <dt><dfn title="text track cue text position middle alignment">Middle alignment</dfn></dt>
-       <dd>The <a title="text track cue box">cue box</a> is centered at the <a title="text track cue text position">text position</a>.
-       </dd>
-
-       <dt><dfn title="text track cue text position end alignment">End alignment</dfn></dt>
-       <dd>The <a title="text track cue box">cue box</a>'s right side (for
-        <a title="text track cue horizontal writing direction">horizontal</a> cues) or bottom
-        side (otherwise) is aligned at the <a title="text track cue text position">text position</a>.
-       </dd>
-
-      </dl>
-
-      <p>A <a>text track cue</a> has a <dfn>default text track cue text position alignment</dfn>
-      which is defined in terms of the value of the <a>text track cue text alignment</a>:</p>
+      <p>
+        A <a>text track cue</a> has a
+        <dfn>text track cue computed line position</dfn> whose value is that
+        returned by the following algorithm, which is defined in terms of the
+        other aspects of the cue:
+      </p>
 
       <ol>
+        <li>
+          <p>
+            If the <a>text track cue line position</a> is numeric, the
+            <a>text track cue snap-to-lines flag</a> of the
+            <a>text track cue</a> is not set, and the
+            <a>text track cue line position</a> is negative or greater than 100,
+            then return 100 and abort these steps.
+          </p>
+        </li>
 
-        <li>For <a title="text track cue left alignment">left</a> or
-        <a title="text track cue start alignment">start</a> aligned cues:
-        <a title="text track cue text position start alignment">start</a>.</li>
+        <li>
+          <p>
+            If the <a>text track cue line position</a> is numeric, return the
+            value of the <a>text track cue line position</a> and abort these
+            steps. (Either the <a>text track cue snap-to-lines flag</a> is set,
+            so any value, not just those in the range 0..100, is valid, or the
+            value is in the range 0..100 and is thus valid regardless of the
+            value of that flag.)
+          </p>
+        </li>
 
-        <li>For <a title="text track cue middle alignment">middle</a> aligned cues:
-        <a title="text track cue text position middle alignment">middle</a>.</li>
+        <li>
+          <p>
+            If the <a>text track cue snap-to-lines flag</a> of the
+            <a>text track cue</a> is not set, return the value 100 and abort
+            these steps. (The <a>text track cue line position</a> is the special
+            value
+            <a title="text track cue automatic line position">auto</a>.)
+          </p>
+        </li>
 
-        <li>For <a title="text track cue right alignment">right</a> or
-        <a title="text track cue end alignment">end</a> aligned cues:
-        <a title="text track cue text position end alignment">end</a>.</li>
+        <li>
+          <p>Let <var title="">cue</var> be the <a>text track cue</a>.</p>
+        </li>
 
+        <li>
+          <p>
+            If <var title="">cue</var> is not in a
+            <a title="text track list of cues">list of cues</a> of a
+            <a>text track</a>, or if that <a>text track</a> is not in the
+            <a>list of text tracks</a> of a <a>media element</a>, return
+            &#x2212;1 and abort these steps.
+          </p>
+        </li>
+
+        <li>
+          <p>
+            Let <var title="">track</var> be the <a>text track</a> whose
+            <a title="text track list of cues">list of cues</a> the
+            <var title="">cue</var> is in.
+          </p>
+        </li>
+
+        <li>
+          <p>
+            Let <var title="">n</var> be the number of
+            <a title="text track">text tracks</a> whose <a>text track mode</a>
+            is <a title="text track showing">showing</a> and that are in the
+            <a>media element</a>'s <a>list of text tracks</a> before
+            <var title="">track</var>.
+          </p>
+        </li>
+
+        <li><p>Increment <var title="">n</var> by one.</p></li>
+
+        <li><p>Negate <var title="">n</var>.</p></li>
+
+        <li><p>Return <var title="">n</var>.</p></li>
+      </ol>
+    </dd>
+
+    <dt>
+      <dfn title="text track cue line alignment">A cue line alignment</dfn>
+    </dt>
+    <dd>
+      <p>
+        An alignment for the <a title="text track cue box">cue box</a>'s
+        <a title="text track cue line position">line position</a>, one of:
+      </p>
+
+      <dl>
+        <dt>
+          <dfn title="text track cue line start alignment">Start alignment</dfn>
+        </dt>
+        <dd>
+          <p>
+            The <a title="text track cue box">cue box</a>'s top side (for
+            <a title="text track cue horizontal writing direction">horizontal</a>
+            cues), left side (for
+            <a title="text track cue vertical growing right writing direction">vertical growing right</a>),
+            or right side (for
+            <a title="text track cue vertical growing left writing direction">vertical growing left</a>)
+            is aligned at the
+            <a title="text track cue line position">line position</a>.
+          </p>
+        </dd>
+
+        <dt>
+          <dfn title="text track cue line middle alignment">Middle alignment</dfn>
+        </dt>
+        <dd>
+          <p>
+            The <a title="text track cue box">cue box</a> is centered at the
+            <a title="text track cue line position">line position</a>.
+          </p>
+        </dd>
+
+        <dt>
+          <dfn title="text track cue line end alignment">End alignment</dfn>
+        </dt>
+        <dd>
+          <p>
+            The <a title="text track cue box">cue box</a>'s bottom side (for
+            <a title="text track cue horizontal writing direction">horizontal</a>
+            cues), right side (for
+            <a title="text track cue vertical growing right writing direction">vertical growing right</a>),
+            or left side (for
+            <a title="text track cue vertical growing left writing direction">vertical growing left</a>)
+            is aligned at the
+            <a title="text track cue line position">line position</a>.
+          </p>
+        </dd>
+      </dl>
+
+      <p>
+        A <a>text track cue</a> has a default
+        <a>text track cue line alignment</a> of
+        <a title="text track cue line start alignment">start</a>.
+      </p>
+    </dd>
+
+    <dt><dfn title="text track cue size">A size</dfn></dt>
+    <dd>
+      <p>
+        A number giving the size of the
+        <a title="text track cue box">cue box</a>, to be interpreted as a
+        percentage of the video, as defined by the
+        <a title="text track cue writing direction">writing direction</a>.
+      </p>
+
+      <p>By default, the <a>text track cue size</a> is 100%.</p>
+    </dd>
+
+    <dt><dfn title="text track cue text position">A text position</dfn></dt>
+    <dd>
+      <p>
+        A number giving the position of the
+        <a title="text track cue box">cue box</a>. If the cue is not within
+        a region, the value is to be interpreted as a percentage of the video,
+        as defined by the
+        <a title="text track cue writing direction">writing direction</a>,
+        otherwise to be interpreted as a percentage of the region width.
+      </p>
+
+      <p>
+        A <a>text track cue</a> has a
+        <dfn>default text track cue text position</dfn> which is defined
+        in terms of the value of the <a>text track cue text alignment</a>:
+      </p>
+
+      <ol>
+        <li>
+          <p>
+            For <a title="text track cue left alignment">left aligned</a> or
+            <a title="text track cue start alignment">start aligned</a> cues:
+            0%.
+          </p>
+        </li>
+
+        <li>
+          <p>
+            For <a title="text track cue middle alignment">middle aligned</a>
+            cues: 50%.
+          </p>
+        </li>
+
+        <li>
+          <p>
+            For <a title="text track cue right alignment">right aligned</a> or
+            <a title="text track cue end alignment">end aligned</a> cues:
+            100%.
+          </p>
+        </li>
       </ol>
 
-      <p class="note">Since the <a>text track cue text position</a> always measures from the left
-      of the video (for <a title="text track cue horizontal writing direction">horizontal</a> cues)
-      or the top (otherwise), the <a>text track cue text position alignment</a>
-      <a title="text track cue text position start alignment">start value</a> varies between left and
-      top for horizontal and vertical cues, but not between left and right even for changing
-      <i>paragraph direction</i>.</p>
+      <p class="note">
+        Since the default value of the <a>text track cue text alignment</a> is
+        <a title="text track cue middle alignment">middle</a>, if there is no
+        <a>text track cue text alignment</a> setting for a cue, the
+        <a>text track cue text position</a>
+        defaults to 50%.
+      </p>
 
-   </dd>
+      <p class="note">
+        Even for
+        <a title="text track cue horizontal writing direction">horizontal</a>
+        cues with right-to-left <i>paragraph direction</i> text, the
+        <a title="text track cue box">cue box</a> is positioned from the left
+        edge of the video frame. This allows defining a rendering space template
+        which can be filled with either left-to-right or right-to-left
+        <i>paragraph direction</i> text. If you define such a
+        <a title="text track cue box">cue box</a> template with
+        <a title="text track cue start alignment">start</a> or
+        <a title="text track cue end alignment">end</a> aligned text, make sure
+        to control its <a title="text track cue size">size</a> unless you want
+        text to flip from one side of the video frame to the other.
+      </p>
+    </dd>
 
-   <dt><dfn title="text track cue text alignment">A text alignment</dfn></dt>
-   <dd>
+    <dt>
+      <dfn title="text track cue text position alignment">A text position alignment</dfn>
+    </dt>
+    <dd>
+      <p>
+        An alignment for the <a title="text track cue box">cue box</a> in the
+        dimension of the
+        <a title="text track cue writing direction">writing direction</a>,
+        describing which part of the <a title="text track cue box">cue box</a>
+        is aligned to the
+        <a title="text track cue text position">text position</a>, one of:
+      </p>
 
-    <p>An alignment for all lines of text within the <a title="text track cue box">cue box</a>, in the dimension of the
-    <a title="text track cue writing direction">writing direction</a> and the
-    <i>paragraph direction</i> <a href="#refsBIDI">[BIDI]</a>, one of:</p>
+      <dl>
+        <dt>
+          <dfn title="text track cue text position start alignment">Start alignment</dfn>
+        </dt>
+        <dd>
+          <p>
+            The <a title="text track cue box">cue box</a>'s left side (for
+            <a title="text track cue horizontal writing direction">horizontal</a>
+            cues) or top side (otherwise) is aligned at the
+            <a title="text track cue text position">text position</a>.
+          </p>
+        </dd>
 
-    <dl>
+        <dt>
+          <dfn title="text track cue text position middle alignment">Middle alignment</dfn>
+        </dt>
+        <dd>
+          <p>
+            The <a title="text track cue box">cue box</a> is centered at the
+            <a title="text track cue text position">text position</a>.
+          </p>
+        </dd>
 
-     <dt><dfn title="text track cue start alignment">Start alignment</dfn></dt>
-     <dd>The text is aligned towards the <i>paragraph direction</i> start side of the <a title="text track cue box">cue box</a>.</dd>
+        <dt>
+          <dfn title="text track cue text position end alignment">End alignment</dfn>
+        </dt>
+        <dd>
+          <p>
+            The <a title="text track cue box">cue box</a>'s right side (for
+            <a title="text track cue horizontal writing direction">horizontal</a>
+            cues) or bottom side (otherwise) is aligned at the
+            <a title="text track cue text position">text position</a>.
+          </p>
+        </dd>
+      </dl>
 
-     <dt><dfn title="text track cue middle alignment">Middle alignment</dfn></dt>
-     <dd>The text is aligned centered between the box's start and end sides.</dd>
+      <p>
+        A <a>text track cue</a> has a
+        <dfn>default text track cue text position alignment</dfn>
+        which is defined in terms of the value of the
+        <a>text track cue text alignment</a>:
+      </p>
 
-     <dt><dfn title="text track cue end alignment">End alignment</dfn></dt>
-     <dd>The text is aligned towards the <i>paragraph direction</i> end side of the <a title="text track cue box">cue box</a>.</dd>
+      <ol>
+        <li>
+          <p>
+            For <a title="text track cue left alignment">left</a> or
+            <a title="text track cue start alignment">start</a> aligned cues:
+            <a title="text track cue text position start alignment">start</a>.
+          </p>
+        </li>
 
-     <dt><dfn title="text track cue left alignment">Left alignment</dfn></dt>
-     <dd>The text is aligned to the box's left side.</dd>
+        <li>
+          <p>
+            For <a title="text track cue middle alignment">middle</a> aligned
+            cues:
+            <a title="text track cue text position middle alignment">middle</a>.
+          </p>
+        </li>
 
-     <dt><dfn title="text track cue right alignment">Right alignment</dfn></dt>
-     <dd>The text is aligned to the box's right side.</dd>
+        <li>
+          <p>
+            For <a title="text track cue right alignment">right</a> or
+            <a title="text track cue end alignment">end</a> aligned cues:
+            <a title="text track cue text position end alignment">end</a>.
+          </p>
+        </li>
+      </ol>
 
-    </dl>
+      <p class="note">
+        Since the <a>text track cue text position</a> always measures from the
+        left of the video (for
+        <a title="text track cue horizontal writing direction">horizontal</a>
+        cues) or the top (otherwise), the
+        <a>text track cue text position alignment</a>
+        <a title="text track cue text position start alignment">start value</a>
+        varies between left and top for horizontal and vertical cues, but not
+        between left and right even for changing <i>paragraph direction</i>.
+      </p>
+    </dd>
 
-    <p>By default, the value of the <a>text track cue text alignment</a> is
-    <a title="text track cue middle alignment">middle aligned</a>.</p>
+    <dt>
+      <dfn title="text track cue text alignment">A text alignment</dfn>
+    </dt>
+    <dd>
+      <p>
+        An alignment for all lines of text within the
+        <a title="text track cue box">cue box</a>, in the dimension of the
+        <a title="text track cue writing direction">writing direction</a> and
+        the <i>paragraph direction</i> <a href="#refsBIDI">[BIDI]</a>, one
+        of:
+      </p>
 
-   </dd>
+      <dl>
+        <dt>
+          <dfn title="text track cue start alignment">Start alignment</dfn>
+        </dt>
+        <dd>
+          <p>
+            The text is aligned towards the <i>paragraph direction</i> start
+            side of the <a title="text track cue box">cue box</a>.
+          </p>
+        </dd>
 
-   <dt><dfn title="text track cue region">A region</dfn></dt>
-   <dd>
-    <p>An optional <a>text track region</a> to which a cue belongs.</p>
-   </dd>
+        <dt>
+          <dfn title="text track cue middle alignment">Middle alignment</dfn>
+        </dt>
+        <dd>
+          <p>
+            The text is aligned centered between the box's start and end
+            sides.
+          </p>
+        </dd>
 
+        <dt>
+          <dfn title="text track cue end alignment">End alignment</dfn>
+        </dt>
+        <dd>
+          <p>
+            The text is aligned towards the <i>paragraph direction</i> end side
+            of the <a title="text track cue box">cue box</a>.
+          </p>
+        </dd>
+
+        <dt>
+          <dfn title="text track cue left alignment">Left alignment</dfn>
+        </dt>
+        <dd><p>The text is aligned to the box's left side.</p></dd>
+
+        <dt>
+          <dfn title="text track cue right alignment">Right alignment</dfn>
+        </dt>
+        <dd><p>The text is aligned to the box's right side.</p></dd>
+      </dl>
+
+      <p>
+        By default, the value of the <a>text track cue text alignment</a> is
+        <a title="text track cue middle alignment">middle aligned</a>.
+      </p>
+    </dd>
+
+    <dt><dfn title="text track cue region">A region</dfn></dt>
+    <dd>
+      <p>An optional <a>text track region</a> to which a cue belongs.</p>
+    </dd>
   </dl>
 
-  <p>The associated <a>rules for updating the text track rendering</a> of WebVTT <a
-  title="text track cue">text track cues</a> are the <a>rules for updating the display of
-  WebVTT text tracks</a>.</p>
+  <p>
+    The associated <a>rules for updating the text track rendering</a> of WebVTT
+    <a title="text track cue">text track cues</a> are the
+    <a>rules for updating the display of WebVTT text tracks</a>.
+  </p>
 
   <div class="impl">
-
-  <p>When a WebVTT <a>text track cue</a> whose <a title="text track cue active flag">active
-  flag</a> is set has its <a title="text track cue writing direction">writing
-  direction</a>, <a title="text track cue snap-to-lines flag">snap-to-lines flag</a>, <a
-  title="text track cue line position">line position</a>, <a title="text track cue text
-  position">text position</a>, <a title="text track cue size">size</a>, <a title="text
-  track cue text alignment">alignment</a>, <a title="text track cue region">region</a>,
-  or <a title="text track cue text">text</a> change value, then the user agent must empty
-  the <a>text track cue display state</a>, and then immediately run the <a>text track</a>'s
-  <a>rules for updating the display of WebVTT text tracks</a>.</p>
-
+    <p>
+      When a WebVTT <a>text track cue</a> whose
+      <a title="text track cue active flag">active flag</a> is set has its
+      <a title="text track cue writing direction">writing direction</a>,
+      <a title="text track cue snap-to-lines flag">snap-to-lines flag</a>,
+      <a title="text track cue line position">line position</a>,
+      <a title="text track cue text position">text position</a>,
+      <a title="text track cue size">size</a>,
+      <a title="text track cue text alignment">alignment</a>,
+      <a title="text track cue region">region</a>, or
+      <a title="text track cue text">text</a> change value, then the user agent
+      must empty the <a>text track cue display state</a>, and then immediately
+      run the <a>text track</a>'s
+      <a>rules for updating the display of WebVTT text tracks</a>.
+    </p>
   </div>
 
-  </section>
+  </section><!-- END: Text track cues -->
 
   <section>
   <h3>Text Track Regions</h3>
 
-  <p>A <dfn title="text track region">text track region</dfn> represents a subpart of the video viewport and provides a rendering area for <a title="text track cue">text track cues</a>.</p>
+  <p>
+    A <dfn title="text track region">text track region</dfn> represents a
+    subpart of the video viewport and provides a rendering area for
+    <a title="text track cue">text track cues</a>.
+  </p>
 
   <p>Each <a title="text track region">text track region</a> consists of:</p>
 
   <dl>
+    <dt><dfn title="text track region identifier">An identifier</dfn></dt>
+    <dd><p>An arbitrary string.</p></dd>
 
-   <dt><dfn title="text track region identifier">An identifier</dfn></dt>
-   <dd>
-    <p>An arbitrary string.</p>
-   </dd>
+    <dt><dfn title="text track region width">A width</dfn></dt>
+    <dd>
+      <p>
+        A number giving the width of the box within which the text of each line
+        of the containing cues is to be rendered, to be interpreted as a
+        percentage of the video width. Defaults to 100.
+      </p>
+    </dd>
 
-   <dt><dfn title="text track region width">A width</dfn></dt>
-   <dd>
-    <p>A number giving the width of the box within which the text of each line of the containing cues is to be rendered, to be interpreted as a percentage of the video width. Defaults to 100.</p>
-   </dd>
+    <dt><dfn title="text track region lines">A lines value</dfn></dt>
+    <dd>
+      <p>
+        A number giving the number of lines of the box within which the text of
+        each line of the containing cues is to be rendered. Defaults to 3.
+      </p>
+    </dd>
 
-   <dt><dfn title="text track region lines">A lines value</dfn></dt>
-   <dd>
-    <p>A number giving the number of lines of the box within which the text of each line of the containing cues is to be rendered. Defaults to 3.</p>
-   </dd>
+    <dt><dfn title="text track region anchor">A region anchor point</dfn></dt>
+    <dd>
+      <p>
+        Two numbers giving the x and y coordinates within the region which is
+        anchored to the video viewport and does not change location even when
+        the region does, e.g. because of font size changes. Defaults to (0,100),
+        i.e. the bottom left corner of the region.
+      </p>
+    </dd>
 
-   <dt><dfn title="text track region anchor">A region anchor point</dfn></dt>
-   <dd>
-    <p>Two numbers giving the x and y coordinates within the region which is anchored to the video viewport and does not change location even when the region does, e.g. because of font size changes. Defaults to (0,100), i.e. the bottom left corner of the region.</p>
-   </dd>
+    <dt>
+      <dfn title="text track region viewport anchor">A region viewport anchor point</dfn>
+    </dt>
+    <dd>
+      <p>
+        Two numbers giving the x and y coordinates within the video viewport to
+        which the region anchor point is anchored. Defaults to (0,100), i.e. the
+        bottom left corner of the viewport.
+      </p>
+    </dd>
 
-   <dt><dfn title="text track region viewport anchor">A region viewport anchor point</dfn></dt>
-   <dd>
-    <p>Two numbers giving the x and y coordinates within the video viewport to which the region anchor point is anchored. Defaults to (0,100), i.e. the bottom left corner of the viewport.</p>
-   </dd>
+    <dt><dfn title="text track region scroll">A scroll value</dfn></dt>
+    <dd>
+      <p>One of the following:</p>
 
-   <dt><dfn title="text track region scroll">A scroll value</dfn></dt>
-   <dd>
-    <p>One of the following:</p>
-    <dl>
-      <dt><dfn title="text track region scroll none">None</dfn></dt>
-      <dd>Indicates that the cues in the region are not to scroll and instead stay fixed at the location they were first painted in.</dd>
+      <dl>
+        <dt><dfn title="text track region scroll none">None</dfn></dt>
+        <dd>
+          <p>
+            Indicates that the cues in the region are not to scroll and instead
+            stay fixed at the location they were first painted in.
+          </p>
+        </dd>
 
-      <dt><dfn title="text track region scroll up">Up</dfn></dt>
-      <dd>Indicates that the cues in the region will be added at the bottom of the region and push any already displayed cues in the region up until all lines of the new cue are visible in the region.</dd>
-      <!-- in the future we may introduce scroll="down"-->
-    </dl>
-   </dd>
+        <dt><dfn title="text track region scroll up">Up</dfn></dt>
+        <dd>
+          <p>
+            Indicates that the cues in the region will be added at the bottom of
+            the region and push any already displayed cues in the region up
+            until all lines of the new cue are visible in the region.
+          </p>
+        </dd>
+        <!-- in the future we may introduce scroll="down"-->
+      </dl>
+    </dd>
   </dl>
 
   <p>For parsing, we also need the following:</p>
 
   <dl>
-  <dt><dfn title="text track list of regions">A text track list of regions</dfn></dt>
-
-  <dd>
-
-   <p>A list of zero or more <a title="text track region">text track regions</a>.</p>
-
-  </dd>
+    <dt>
+      <dfn title="text track list of regions">A text track list of regions</dfn>
+    </dt>
+    <dd>
+      <p>
+        A list of zero or more
+        <a title="text track region">text track regions</a>.
+      </p>
+    </dd>
   </dl>
-  </section>
+  </section><!-- END: Text track regions -->
 
-  </section>
+  </section><!-- END: Data model -->
 
   <section>
   <h2>The WebVTT file format: Syntax</h2>
@@ -948,272 +1336,407 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
   <section>
   <h3>WebVTT file structure</h3>
 
-  <p>A <dfn>WebVTT file</dfn> must consist of a <a>WebVTT file
-  body</a> encoded as UTF-8 and labeled with the <a>MIME
-  type</a> <code>text/vtt</code>. <a href="#refsRFC3629">[RFC3629]</a></p>
+  <p>
+    A <dfn>WebVTT file</dfn> must consist of a <a>WebVTT file body</a> encoded
+    as UTF-8 and labeled with the <a>MIME type</a> <code>text/vtt</code>.
+    <a href="#refsRFC3629">[RFC3629]</a>
+  </p>
 
-  <p>A <dfn>WebVTT file body</dfn> consists of the following
-  components, in the following order:</p>
+  <p>
+    A <dfn>WebVTT file body</dfn> consists of the following components, in the
+    following order:
+  </p>
 
   <ol>
+    <li><p>An optional U+FEFF BYTE ORDER MARK (BOM) character.</p></li>
 
-   <li>An optional U+FEFF BYTE ORDER MARK (BOM) character.</li>
+    <li><p>The string "<code title="">WEBVTT</code>".</p></li>
 
-   <li>The string "<code title="">WEBVTT</code>".</li>
+    <li>
+      <p>
+        Optionally, either a U+0020 SPACE character or a U+0009 CHARACTER
+        TABULATION (tab) character followed by any number of characters that are
+        not U+000A LINE FEED (LF) or U+000D CARRIAGE RETURN (CR) characters.
+      </p>
+    </li> <!-- allows for Emacs line -->
 
-   <li>Optionally, either a U+0020 SPACE character or a U+0009
-   CHARACTER TABULATION (tab) character followed by any number of
-   characters that are not U+000A LINE FEED (LF) or U+000D CARRIAGE
-   RETURN (CR) characters.</li> <!-- allows for Emacs line -->
+    <li>
+      <p>
+        Exactly one
+        <a title="WebVTT line terminator">WebVTT line terminators</a> to
+        terminate the line with the file magic and separate it from the rest of
+        the body.
+      </p>
+    </li>
 
-   <li>Exactly one <a title="WebVTT line terminator">WebVTT line terminators</a> to
-   terminate the line with the file magic and separate it from the rest of the body.</li>
+    <li>
+      <p>
+        Zero or more
+        <a title="WebVTT metadata header">WebVTT metadata headers</a>.
+      </p>
+    </li>
 
-   <li>Zero or more <a title="WebVTT metadata header">WebVTT metadata headers</a>.</li>
+    <li>
+      <p>
+        One or more
+        <a title="WebVTT line terminator">WebVTT line terminators</a> to
+        terminate the header block and separate the cues from the file header.
+      </p>
+    </li>
 
-   <li>One or more <a title="WebVTT line terminator">WebVTT line terminators</a> to
-   terminate the header block and separate the cues from the file header.</li>
+    <li>
+      <p>
+        Zero or more <a title="WebVTT cue">WebVTT cues</a> and
+        <a title="WebVTT comment">WebVTT comments</a> separated from each other
+        by one or more
+        <a title="WebVTT line terminator">WebVTT line terminators</a>.
+      </p>
+    </li>
 
-   <li>Zero or more <a title="WebVTT cue">WebVTT cues</a> and <a title="WebVTT
-   comment">WebVTT comments</a> separated from each other by one or more <a title="WebVTT
-   line terminator">WebVTT line terminators</a>.</li>
-
-   <li>Zero or more <a title="WebVTT line terminator">WebVTT line
-   terminators</a>.</li>
-
+    <li>
+      <p>
+        Zero or more
+        <a title="WebVTT line terminator">WebVTT line terminators</a>.
+      </p>
+    </li>
   </ol>
 
-  <p>A <dfn>WebVTT line terminator</dfn> consists of one of the
-  following:</p>
+  <p>A <dfn>WebVTT line terminator</dfn> consists of one of the following:</p>
 
   <ul class="brief">
-   <li>A U+000D CARRIAGE RETURN U+000A LINE FEED (CRLF) character pair.</li>
-   <li>A single U+000A LINE FEED (LF) character.</li>
-   <li>A single U+000D CARRIAGE RETURN (CR) character.</li>
+    <li>
+     <p>A U+000D CARRIAGE RETURN U+000A LINE FEED (CRLF) character pair.</p>
+    </li>
+    <li><p>A single U+000A LINE FEED (LF) character.</p></li>
+    <li><p>A single U+000D CARRIAGE RETURN (CR) character.</p></li>
   </ul>
 
-  <p>A <dfn>WebVTT metadata header</dfn> consists of the following components, in
-  the given order:</p>
+  <p>
+    A <dfn>WebVTT metadata header</dfn> consists of the following components, in
+    the given order:
+  </p>
 
   <ol>
-    <li>A <a>WebVTT metadata header name</a>.</li>
-    <li>A U+003A COLON (colon) character.</li>
-    <li>A <a>WebVTT metadata header value</a>.</li>
-    <li>A <a>WebVTT line terminator</a>.</li>
+    <li><p>A <a>WebVTT metadata header name</a>.</p></li>
+    <li><p>A U+003A COLON (colon) character.</p></li>
+    <li><p>A <a>WebVTT metadata header value</a>.</p></li>
+    <li><p>A <a>WebVTT line terminator</a>.</p></li>
   </ol>
 
-  <p>A <dfn>WebVTT metadata header name</dfn> and
-  a <dfn>WebVTT metadata header value</dfn>
-  each consist of any sequence of zero or more characters other than
-  U+000A LINE FEED (LF) characters and U+000D CARRIAGE RETURN (CR) characters
-  except that the entire resulting string must not contain the substring
-  "<code>--&gt;</code>" (U+002D HYPHEN-MINUS, U+002D HYPHEN-MINUS,
-  U+003E GREATER-THAN SIGN).</p>
+  <p>
+    A <dfn>WebVTT metadata header name</dfn> and a
+    <dfn>WebVTT metadata header value</dfn> each consist of any sequence of zero
+    or more characters other than U+000A LINE FEED (LF) characters and U+000D
+    CARRIAGE RETURN (CR) characters except that the entire resulting string must
+    not contain the substring "<code>--&gt;</code>" (U+002D HYPHEN-MINUS, U+002D
+    HYPHEN-MINUS, U+003E GREATER-THAN SIGN).
+  </p>
 
-  <p>A <dfn>WebVTT cue</dfn> consists of the following components, in
-  the given order:</p>
+  <p>
+    A <dfn>WebVTT cue</dfn> consists of the following components, in the given
+    order:
+  </p>
 
   <ol>
-   <li>Optionally, a <a>WebVTT cue identifier</a> followed by a <a>WebVTT line terminator</a>.</li>
-   <li><a>WebVTT cue timings</a>.</li>
-   <li>Optionally, one or more U+0020 SPACE characters or U+0009 CHARACTER TABULATION (tab) characters followed by a <a>WebVTT cue settings list</a>.</li>
-   <li>A <a>WebVTT line terminator</a>.</li>
-   <li>The <dfn>cue payload</dfn>: either <a>WebVTT cue text</a>, <a>WebVTT chapter title text</a>, or <a>WebVTT metadata text</a>, but it must not contain the substring "<code title="">--></code>" (U+002D HYPHEN-MINUS, U+002D HYPHEN-MINUS, U+003E GREATER-THAN SIGN).</li>
-   <li>A <a>WebVTT line terminator</a>.</li>
+    <li>
+      <p>
+        Optionally, a <a>WebVTT cue identifier</a> followed by a
+        <a>WebVTT line terminator</a>.
+      </p>
+    </li>
+    <li><p><a>WebVTT cue timings</a>.</p></li>
+    <li>
+      <p>
+        Optionally, one or more U+0020 SPACE characters or U+0009 CHARACTER
+        TABULATION (tab) characters followed by a
+        <a>WebVTT cue settings list</a>.
+      </p>
+    </li>
+    <li><p>A <a>WebVTT line terminator</a>.</p></li>
+    <li>
+      <p>
+        The <dfn>cue payload</dfn>: either <a>WebVTT cue text</a>,
+        <a>WebVTT chapter title text</a>, or <a>WebVTT metadata text</a>, but it
+        must not contain the substring "<code title="">--></code>" (U+002D
+        HYPHEN-MINUS, U+002D HYPHEN-MINUS, U+003E GREATER-THAN SIGN).
+      </p>
+    </li>
+    <li><p>A <a>WebVTT line terminator</a>.</p></li>
   </ol>
 
-  <p class="note">A <a>WebVTT cue</a> corresponds to one piece
-  of time-aligned text or data in the <a>WebVTT file</a>, for
-  example one subtitle. The <a>cue payload</a> is the text or
-  data associated with the cue.</p>
+  <p class="note">
+    A <a>WebVTT cue</a> corresponds to one piece of time-aligned text or data in
+    the <a>WebVTT file</a>, for example one subtitle. The <a>cue payload</a> is
+    the text or data associated with the cue.
+  </p>
 
-  <p>A <dfn>WebVTT cue identifier</dfn> is any sequence of one or more
-  characters not containing the substring "<code title="">--&gt;</code>"
-  (U+002D HYPHEN-MINUS, U+002D HYPHEN-MINUS, U+003E GREATER-THAN
-  SIGN), nor containing any U+000A LINE FEED (LF) characters or U+000D
-  CARRIAGE RETURN (CR) characters.</p>
+  <p>
+    A <dfn>WebVTT cue identifier</dfn> is any sequence of one or more characters
+    not containing the substring "<code title="">--&gt;</code>" (U+002D
+    HYPHEN-MINUS, U+002D HYPHEN-MINUS, U+003E GREATER-THAN SIGN), nor containing
+    any U+000A LINE FEED (LF) characters or U+000D CARRIAGE RETURN (CR)
+    characters.
+  </p>
 
-  <p class="note">A <a>WebVTT cue identifier</a> can be used to
-  reference a specific cue, for example from script or CSS.</p>
+  <p class="note">
+    A <a>WebVTT cue identifier</a> can be used to reference a specific cue, for
+    example from script or CSS.
+  </p>
 
-  <p>The <dfn>WebVTT cue timings</dfn> part of a <a>WebVTT
-  cue</a> consists of the following components, in the given
-  order:</p>
+  <p>
+    The <dfn>WebVTT cue timings</dfn> part of a <a>WebVTT cue</a> consists of
+    the following components, in the given order:
+  </p>
 
   <ol>
+    <!-- we could allow leading and trailing spaces and tabs, and make
+    the space between the arrow either optional or allow multiple
+    spaces or tabs -->
 
-   <!-- we could allow leading and trailing spaces and tabs, and make
-   the space between the arrow either optional or allow multiple
-   spaces or tabs -->
+    <li>
+      <p>
+        A <a>WebVTT timestamp</a> representing the start time offset of the cue.
+        The time represented by this <a>WebVTT timestamp</a> must be greater
+        than or equal to the start time offsets of all previous cues in the
+        file.
+      </p>
+    </li>
 
-   <li>A <a>WebVTT timestamp</a> representing the start time
-   offset of the cue. The time represented by this <a>WebVTT
-   timestamp</a> must be greater than or equal to the start time
-   offsets of all previous cues in the file.</li>
+    <li>
+      <p>
+        One or more U+0020 SPACE characters or U+0009 CHARACTER TABULATION (tab)
+        characters.
+      </p>
+    </li>
 
-   <li>One or more U+0020 SPACE characters or U+0009 CHARACTER
-   TABULATION (tab) characters.</li>
+    <li>
+      <p>
+        The string "<code title="">--></code>" (U+002D HYPHEN-MINUS, U+002D
+        HYPHEN-MINUS, U+003E GREATER-THAN SIGN).
+      </p>
+    </li>
 
-   <li>The string "<code title="">--></code>" (U+002D HYPHEN-MINUS,
-   U+002D HYPHEN-MINUS, U+003E GREATER-THAN SIGN).</li>
+    <li>
+      <p>
+        One or more U+0020 SPACE characters or U+0009 CHARACTER TABULATION (tab)
+        characters.
+      </p>
+    </li>
 
-   <li>One or more U+0020 SPACE characters or U+0009 CHARACTER
-   TABULATION (tab) characters.</li>
-
-   <li>A <a>WebVTT timestamp</a> representing the end time
-   offset of the cue. The time represented by this <a>WebVTT
-   timestamp</a> must be greater than the start time offset of the
-   cue.</li>
-
+    <li>
+      <p>
+        A <a>WebVTT timestamp</a> representing the end time offset of the cue.
+        The time represented by this <a>WebVTT timestamp</a> must be greater
+        than the start time offset of the cue.
+      </p>
+    </li>
   </ol>
 
-  <p class="note">The <a>WebVTT cue timings</a> give the start
-  and end offsets of the <a>WebVTT cue</a>. Different cues can
-  overlap. Cues are always listed ordered by their start time.</p>
+  <p class="note">
+    The <a>WebVTT cue timings</a> give the start and end offsets of the
+    <a>WebVTT cue</a>. Different cues can overlap. Cues are always listed
+    ordered by their start time.
+  </p>
 
-  <p>A <dfn>WebVTT timestamp</dfn> can be either a
-  <a title="complete WebVTT timestamp">WebVTT timestamp representing
-  hours, minutes, seconds and thousandths of a second</a> or a
-  <a title="partial WebVTT timestamp">WebVTT timestamp representing
-  a time in seconds and fractions of a second</a>.</p>
+  <p>
+    A <dfn>WebVTT timestamp</dfn> can be either a
+    <a title="complete WebVTT timestamp">WebVTT timestamp representing hours,
+    minutes, seconds and thousandths of a second</a> or a
+    <a title="partial WebVTT timestamp">WebVTT timestamp representing a time in
+    seconds and fractions of a second</a>.
+  </p>
 
-  <p class="note">A <a>WebVTT timestamp</a> is always interpreted
-  relative to the <a>current playback position</a> of the media data
-  that the WebVTT file is to be synchronized with, which always starts
-  at 0.</p>
+  <p class="note">
+    A <a>WebVTT timestamp</a> is always interpreted relative to the
+    <a>current playback position</a> of the media data that the WebVTT file is
+    to be synchronized with, which always starts at 0.
+  </p>
 
-  <p>A <dfn title="complete WebVTT timestamp">WebVTT timestamp representing hours <var
-  title="">hours</var>, minutes <var title="">minutes</var>, seconds
-  <var title="">seconds</var>, and thousandths of a second <var
-  title="">seconds-frac</var></dfn>, consists of the following components,
-  in the given order:</p>
+  <p>
+    A
+    <dfn title="complete WebVTT timestamp">WebVTT timestamp representing hours <var title="">hours</var>, minutes <var title="">minutes</var>, seconds <var title="">seconds</var>, and thousandths of a second <var title="">seconds-frac</var></dfn>,
+    consists of the following components, in the given order:
+  </p>
 
   <ol>
+    <li>Optionally (required if <var title="">hour</var> is non-zero):
+      <ol>
+        <li>
+          <p>
+            Two or more <a>ASCII digits</a>, representing the
+            <var title="">hours</var> as a base ten integer.
+          </p>
+        </li>
 
-   <li>
-    Optionally (required if <var title="">hour</var> is non-zero):
+        <li><p>A U+003A COLON character (:)</p></li>
+      </ol>
+    </li>
 
-    <ol>
+    <li>
+      <p>
+        Two <a>ASCII digits</a>, representing the <var title="">minutes</var> as
+        a base ten integer in the range
+        0&nbsp;&le;&nbsp;<var title="">minutes</var>&nbsp;&le;&nbsp;59.
+      </p>
+    </li>
 
-     <li>Two or more <a>ASCII digits</a>, representing the <var title="">hours</var> as a base
-     ten integer.</li>
+    <li><p>A U+003A COLON character (:)</p></li>
 
-     <li>A U+003A COLON character (:)</li>
+    <li>
+      <p>
+        Two <a>ASCII digits</a>, representing the <var title="">seconds</var> as
+        a base ten integer in the range
+        0&nbsp;&le;&nbsp;<var title="">seconds</var>&nbsp;&le;&nbsp;59.
+      </p>
+    </li>
 
-    </ol>
+    <li><p>A U+002E FULL STOP character (.).</p></li>
 
-   </li>
-
-   <li>Two <a>ASCII digits</a>, representing the <var title="">minutes</var> as a base ten
-   integer in the range 0&nbsp;&le;&nbsp;<var title="">minutes</var>&nbsp;&le;&nbsp;59.</li>
-
-   <li>A U+003A COLON character (:)</li>
-
-   <li>Two <a>ASCII digits</a>, representing the <var title="">seconds</var> as a base ten
-   integer in the range 0&nbsp;&le;&nbsp;<var title="">seconds</var>&nbsp;&le;&nbsp;59.</li>
-
-   <li>A U+002E FULL STOP character (.).</li>
-
-   <li>Three <a>ASCII digits</a>, representing the thousandths of a second <var
-   title="">seconds-frac</var> as a base ten integer.</li>
-
+    <li>
+      <p>
+        Three <a>ASCII digits</a>, representing the thousandths of a second
+        <var title="">seconds-frac</var> as a base ten integer.
+      </p>
+    </li>
   </ol>
 
-  <p>A <dfn title="partial WebVTT timestamp">WebVTT timestamp representing a time
-  in seconds and fractions of a second</dfn> is a <a>WebVTT timestamp</a>
-  representing hours <var title="">hours</var>, minutes <var title="">minutes</var>, seconds
-  <var title="">seconds</var>, and thousandths of a second <var
-  title="">seconds-frac</var>, calculated as follows:</p>
+  <p>
+    A
+    <dfn title="partial WebVTT timestamp">WebVTT timestamp representing a time in seconds and fractions of a second</dfn>
+    is a <a>WebVTT timestamp</a> representing hours <var title="">hours</var>,
+    minutes <var title="">minutes</var>, seconds <var title="">seconds</var>,
+    and thousandths of a second <var title="">seconds-frac</var>, calculated as
+    follows:
+  </p>
 
   <ol>
+    <li>
+     <p>Let <var title="">seconds</var> be the integer part of the time.</p>
+    </li>
 
-   <li><p>Let <var title="">seconds</var> be the integer part of the
-   time.</p></li>
+    <li>
+      <p>
+        Let <var title="">seconds-frac</var> be the fractional component of the
+        time, expressed as the digits of the decimal fraction given to three
+        decimal digits.
+      </p>
+    </li>
 
-   <li><p>Let <var title="">seconds-frac</var> be the fractional
-   component of the time, expressed as the digits of the decimal
-   fraction given to three decimal digits.</p></li>
+    <li>
+      <p>
+        If <var title="">seconds</var> is greater than 59, then let
+        <var title="">minutes</var> be the integer component of
+        <var title="">seconds</var> divided by sixty, and then let
+        <var title="">seconds</var> be the remainder of dividing
+        <var title="">seconds</var> divided by sixty. Otherwise, let
+        <var title="">minutes</var> be zero.
+      </p>
+    </li>
 
-   <li><p>If <var title="">seconds</var> is greater than 59, then let
-   <var title="">minutes</var> be the integer component of <var
-   title="">seconds</var> divided by sixty, and then let <var
-   title="">seconds</var> be the remainder of dividing <var
-   title="">seconds</var> divided by sixty. Otherwise, let <var
-   title="">minutes</var> be zero.</p></li>
-
-   <li><p>If <var title="">minutes</var> is greater than 59, then let
-   <var title="">hours</var> be the integer component of <var
-   title="">minutes</var> divided by sixty, and then let <var
-   title="">minutes</var> be the remainder of dividing <var
-   title="">minutes</var> divided by sixty. Otherwise, let <var
-   title="">hours</var> be zero.</p></li>
-
+    <li>
+      <p>
+        If <var title="">minutes</var> is greater than 59, then let
+        <var title="">hours</var> be the integer component of
+        <var title="">minutes</var> divided by sixty, and then let
+        <var title="">minutes</var> be the remainder of dividing
+        <var title="">minutes</var> divided by sixty. Otherwise, let
+        <var title="">hours</var> be zero.
+      </p>
+    </li>
   </ol>
 
-  <p>A <dfn>WebVTT cue settings list</dfn> consist of a sequence of zero or more
-  <dfn title="WebVTT cue setting">WebVTT cue settings</dfn> in any order, separated from each other
-  by one or more U+0020 SPACE characters or U+0009 CHARACTER TABULATION (tab) characters.
-  Each setting consists of the following components, in the order given:</p>
+  <p>
+    A <dfn>WebVTT cue settings list</dfn> consist of a sequence of zero or more
+    <dfn title="WebVTT cue setting">WebVTT cue settings</dfn> in any order,
+    separated from each other by one or more U+0020 SPACE characters or U+0009
+    CHARACTER TABULATION (tab) characters. Each setting consists of the
+    following components, in the order given:
+  </p>
 
   <ol>
-    <li>A <a title="WebVTT cue setting name">WebVTT cue setting name</a>.</li>
-    <li>An optional U+003A COLON (colon) character.</li>
-    <li>An optional <a title="WebVTT cue setting value">WebVTT cue setting value</a>.</li>
+    <li>
+      <p>A <a title="WebVTT cue setting name">WebVTT cue setting name</a>.</p>
+    </li>
+    <li><p>An optional U+003A COLON (colon) character.</p></li>
+    <li>
+      <p>
+        An optional
+        <a title="WebVTT cue setting value">WebVTT cue setting value</a>.
+      </p>
+    </li>
   </ol>
 
-  <p>A <dfn>WebVTT cue setting name</dfn> and a <dfn>WebVTT cue setting value</dfn>
-  each consist of any sequence of zero or more characters other than
-  U+000A LINE FEED (LF) characters and U+000D CARRIAGE RETURN (CR) characters
-  except that the entire resulting string must not contain the substring
-  "<code>--&gt;</code>" (U+002D HYPHEN-MINUS, U+002D HYPHEN-MINUS,
-  U+003E GREATER-THAN SIGN).</p>
+  <p>
+    A <dfn>WebVTT cue setting name</dfn> and a
+    <dfn>WebVTT cue setting value</dfn> each consist of any sequence of zero or
+    more characters other than U+000A LINE FEED (LF) characters and U+000D
+    CARRIAGE RETURN (CR) characters except that the entire resulting string must
+    not contain the substring "<code>--&gt;</code>" (U+002D HYPHEN-MINUS, U+002D
+    HYPHEN-MINUS, U+003E GREATER-THAN SIGN).
+  </p>
 
   <p>A <dfn>WebVTT percentage</dfn> consists of the following components:</p>
 
   <ol>
-   <li>One or more <a>ASCII digits</a>.</li>
-   <li>
-     Optionally:
-     <ol>
-       <li>A U+002E DOT character (.).</li>
-       <li>One or more <a>ASCII digits</a>.</li>
-     </ol>
-   </li>
-   <li>A U+0025 PERCENT SIGN character (%).</li>
+    <li><p>One or more <a>ASCII digits</a>.</p></li>
+    <li>
+      Optionally:
+      <ol>
+        <li><p>A U+002E DOT character (.).</p></li>
+        <li><p>One or more <a>ASCII digits</a>.</p></li>
+      </ol>
+    </li>
+    <li><p>A U+0025 PERCENT SIGN character (%).</p></li>
   </ol>
 
-  </section><!-- end file structure -->
+  </section><!-- END: WebVTT file structure -->
 
   <section>
   <h3>WebVTT comments</h3>
 
-  <p>A <dfn>WebVTT comment</dfn> consists of the  following components, in
-  the given order:</p>
+  <p>
+    A <dfn>WebVTT comment</dfn> consists of the  following components, in the
+    given order:
+  </p>
 
   <ol>
-   <li>The <a>case-sensitive</a> string "<code title="">NOTE</code>".</li>
-   <li>
-    Optionally, the following components, in the given order:
-    <ol>
-     <li>
-      Either:
-      <ul>
-       <li>A U+0020 SPACE character or U+0009 CHARACTER TABULATION (tab) character.</li>
-       <li>A <a>WebVTT line terminator</a>.</li>
-      </ul>
-     </li>
-     <li>Any sequence of zero or more characters other than U+000A LINE FEED (LF) characters and
-     U+000D CARRIAGE RETURN (CR) characters, each optionally separated from the next by a
-     <a>WebVTT line terminator</a>, except that the entire resulting string must not contain
-     the substring "<code title="">--&gt;</code>" (U+002D HYPHEN-MINUS, U+002D HYPHEN-MINUS, U+003E GREATER-THAN SIGN).</li>
-    </ol>
-   </li>
-   <li>A <a>WebVTT line terminator</a>.</li>
+    <li>
+      <p>The <a>case-sensitive</a> string "<code title="">NOTE</code>".</p>
+    </li>
+    <li>
+      Optionally, the following components, in the given order:
+      <ol>
+        <li>
+          Either:
+          <ul>
+            <li>
+              <p>
+                A U+0020 SPACE character or U+0009 CHARACTER TABULATION (tab)
+                character.
+              </p>
+            </li>
+            <li><p>A <a>WebVTT line terminator</a>.</p></li>
+          </ul>
+        </li>
+        <li>
+          <p>
+            Any sequence of zero or more characters other than U+000A LINE FEED
+            (LF) characters and U+000D CARRIAGE RETURN (CR) characters, each
+            optionally separated from the next by a
+            <a>WebVTT line terminator</a>, except that the entire resulting
+            string must not contain the substring "<code title="">--&gt;</code>"
+            (U+002D HYPHEN-MINUS, U+002D HYPHEN-MINUS, U+003E GREATER-THAN
+            SIGN).
+          </p>
+        </li>
+      </ol>
+    </li>
+    <li><p>A <a>WebVTT line terminator</a>.</p></li>
   </ol>
 
   <p class="note">A <a>WebVTT comment</a> is ignored by the parser.</p>
 
-  </section><!-- end comments -->
+  </section><!-- END: WebVTT comments -->
 
   <section>
   <h3>Types of WebVTT cue payload</h3>
@@ -1221,229 +1744,390 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
   <section>
   <h4>WebVTT metadata text</h4>
 
-  <p><dfn>WebVTT metadata text</dfn> consists of any sequence of zero
-  or more characters other than U+000A LINE FEED (LF) characters and
-  U+000D CARRIAGE RETURN (CR) characters, each optionally separated
-  from the next by a <a>WebVTT line terminator</a>. (In other
-  words, any text that does not have two consecutive <a
-  title="WebVTT line terminator">WebVTT line terminators</a> and
-  does not start or end with a <a>WebVTT line
-  terminator</a>.)</p>
+  <p>
+    <dfn>WebVTT metadata text</dfn> consists of any sequence of zero or more
+    characters other than U+000A LINE FEED (LF) characters and U+000D CARRIAGE
+    RETURN (CR) characters, each optionally separated from the next by a
+    <a>WebVTT line terminator</a>. (In other words, any text that does not have
+    two consecutive
+    <a title="WebVTT line terminator">WebVTT line terminators</a> and does not
+    start or end with a <a>WebVTT line terminator</a>.)
+  </p>
 
-  <p><a>WebVTT metadata text</a> cues are only
-  useful for scripted applications (using the <code
-  title="dom-TextTrack-kind-metadata">metadata</code> <a>text
-  track kind</a>).</p>
-
-  </section>
+  <p>
+    <a>WebVTT metadata text</a> cues are only useful for scripted applications
+    (using the <code title="dom-TextTrack-kind-metadata">metadata</code>
+    <a>text track kind</a>).
+  </p>
+  </section><!-- END: WebVTT metadata text -->
 
   <section>
   <h4>WebVTT cue text</h4>
 
-  <p><dfn>WebVTT cue text</dfn> is <a>cue payload</a>
-  that consists of zero or more <a>WebVTT cue components</a>, in any order,
-  each optionally separated from the next by a <a>WebVTT line terminator</a>.</p>
+  <p>
+    <dfn>WebVTT cue text</dfn> is <a>cue payload</a> that consists of zero or
+    more <a>WebVTT cue components</a>, in any order, each optionally separated
+    from the next by a <a>WebVTT line terminator</a>.
+  </p>
 
   <p>The <dfn>WebVTT cue components</dfn> are:</p>
 
   <ul>
+    <li><p>A <a>WebVTT cue class span</a>.</p></li>
+    <li><p>A <a>WebVTT cue italics span</a>.</p></li>
+    <li><p>A <a>WebVTT cue bold span</a>.</p></li>
+    <li><p>A <a>WebVTT cue underline span</a>.</p></li>
+    <li><p>A <a>WebVTT cue ruby span</a>.</p></li>
+    <li><p>A <a>WebVTT cue voice span</a>.</p></li>
+    <li><p>A <a>WebVTT cue language span</a>.</p></li>
 
-   <li>A <a>WebVTT cue class span</a>.</li>
-   <li>A <a>WebVTT cue italics span</a>.</li>
-   <li>A <a>WebVTT cue bold span</a>.</li>
-   <li>A <a>WebVTT cue underline span</a>.</li>
-   <li>A <a>WebVTT cue ruby span</a>.</li>
-   <li>A <a>WebVTT cue voice span</a>.</li>
-   <li>A <a>WebVTT cue language span</a>.</li>
+    <li><p>A <a>WebVTT cue timestamp</a>.</p></li>
 
-   <li>A <a>WebVTT cue timestamp</a>.</li>
+    <li>
+      <p>A <a>WebVTT cue text span</a>, representing the text of the cue.</p>
+    </li>
 
-   <li>A <a>WebVTT cue text span</a>, representing the text of the cue.</li>
-
-   <li>A <a>WebVTT cue amp escape</a>, representing a "&amp;" character in the text of the cue.</li>
-   <li>A <a>WebVTT cue lt escape</a>, representing a "&lt;" character in the text of the cue.</li>
-   <li>A <a>WebVTT cue gt escape</a>, representing a "&gt;" character in the text of the cue.</li>
-   <li>A <a>WebVTT cue lrm escape</a>, representing a U+200E LEFT-TO-RIGHT MARK Unicode bidirectional formatting character in the text of the cue.</li>
-   <li>A <a>WebVTT cue rlm escape</a>, representing a U+200F RIGHT-TO-LEFT MARK Unicode bidirectional formatting character in the text of the cue.</li>
-   <li>A <a>WebVTT cue nbsp escape</a>, representing a U+00A0 NO-BREAK SPACE character in the text of the cue.</li>
-
+    <li>
+      <p>
+        A <a>WebVTT cue amp escape</a>, representing a "&amp;" character in the
+        text of the cue.
+      </p>
+    </li>
+    <li>
+      <p>
+        A <a>WebVTT cue lt escape</a>, representing a "&lt;" character in the
+        text of the cue.
+      </p>
+    </li>
+    <li>
+      <p>
+        A <a>WebVTT cue gt escape</a>, representing a "&gt;" character in the
+        text of the cue.
+      </p>
+    </li>
+    <li>
+      <p>
+        A <a>WebVTT cue lrm escape</a>, representing a U+200E LEFT-TO-RIGHT MARK
+        Unicode bidirectional formatting character in the text of the cue.
+      </p>
+    </li>
+    <li>
+      <p>
+        A <a>WebVTT cue rlm escape</a>, representing a U+200F RIGHT-TO-LEFT MARK
+        Unicode bidirectional formatting character in the text of the cue.
+      </p>
+    </li>
+    <li>
+      <p>
+        A <a>WebVTT cue nbsp escape</a>, representing a U+00A0 NO-BREAK SPACE
+        character in the text of the cue.
+      </p>
+    </li>
   </ul>
 
-  <p><dfn>WebVTT cue internal text</dfn> consists of an optional
-  <a>WebVTT line terminator</a>, followed by zero or more
-  <a>WebVTT cue components</a>, in any order, each optionally
-  followed by a <a>WebVTT line terminator</a>.</p>
+  <p>
+    <dfn>WebVTT cue internal text</dfn> consists of an optional
+    <a>WebVTT line terminator</a>, followed by zero or more
+    <a>WebVTT cue components</a>, in any order, each optionally
+    followed by a <a>WebVTT line terminator</a>.
+  </p>
 
-  <p>A <dfn>WebVTT cue class span</dfn> consists of a <a>WebVTT cue
-  span start tag</a> "<code title="">c</code>" that disallows an
-  annotation, <a>WebVTT cue internal text</a> representing cue
-  text, and a <a>WebVTT cue span end tag</a> "<code
-  title="">c</code>".</p>
+  <p>
+    A <dfn>WebVTT cue class span</dfn> consists of a
+    <a>WebVTT cue span start tag</a> "<code title="">c</code>" that disallows an
+    annotation, <a>WebVTT cue internal text</a> representing cue text, and a
+    <a>WebVTT cue span end tag</a> "<code title="">c</code>".
+  </p>
 
-  <p>A <dfn>WebVTT cue italics span</dfn> consists of a <a>WebVTT
-  cue span start tag</a> "<code title="">i</code>" that disallows
-  an annotation, <a>WebVTT cue internal text</a> representing
-  the italicized text, and a <a>WebVTT cue span end tag</a>
-  "<code title="">i</code>".</p>
+  <p>
+    A <dfn>WebVTT cue italics span</dfn> consists of a
+    <a>WebVTT cue span start tag</a> "<code title="">i</code>" that disallows
+    an annotation, <a>WebVTT cue internal text</a> representing the italicized
+    text, and a <a>WebVTT cue span end tag</a> "<code title="">i</code>".
+  </p>
 
-  <p>A <dfn>WebVTT cue bold span</dfn> consists of a <a>WebVTT cue
-  span start tag</a> "<code title="">b</code>" that disallows an
-  annotation, <a>WebVTT cue internal text</a> representing the
-  boldened text, and a <a>WebVTT cue span end tag</a> "<code
-  title="">b</code>".</p>
+  <p>
+    A <dfn>WebVTT cue bold span</dfn> consists of a
+    <a>WebVTT cue span start tag</a> "<code title="">b</code>" that disallows an
+    annotation, <a>WebVTT cue internal text</a> representing the boldened text,
+    and a <a>WebVTT cue span end tag</a> "<code title="">b</code>".
+  </p>
 
-  <p>A <dfn>WebVTT cue underline span</dfn> consists of a <a>WebVTT
-  cue span start tag</a> "<code title="">u</code>" that disallows
-  an annotation, <a>WebVTT cue internal text</a> representing
-  the underlined text, and a <a>WebVTT cue span end tag</a>
-  "<code title="">u</code>".</p>
+  <p>
+    A <dfn>WebVTT cue underline span</dfn> consists of a
+    <a>WebVTT cue span start tag</a> "<code title="">u</code>" that disallows an
+    annotation, <a>WebVTT cue internal text</a> representing the underlined
+    text, and a <a>WebVTT cue span end tag</a> "<code title="">u</code>".
+  </p>
 
-  <p>A <dfn>WebVTT cue ruby span</dfn> consists of the following
-  components, in the order given:</p>
-
-  <ol>
-   <li>A <a>WebVTT cue span start tag</a> "<code title="">ruby</code>" that disallows an annotation.</li>
-   <li>
-    One or more occurrences of the following group of components, in the order given:
-    <ol>
-     <li><a>WebVTT cue internal text</a>, representing the ruby base.</li>
-     <li>A <a>WebVTT cue span start tag</a> "<code title="">rt</code>" that disallows an annotation.</li>
-     <li>A <dfn>WebVTT cue ruby text span</dfn>: <a>WebVTT cue internal text</a>, representing the ruby text component of the ruby annotation.</li>
-     <li>A <a>WebVTT cue span end tag</a> "<code title="">rt</code>".
-     If this is the last occurrence of this group of components in the
-     <a>WebVTT cue ruby span</a>, then this last end tag string
-     may be omitted.</li>
-    </ol>
-   </li>
-   <li>If the last end tag string was not omitted: Optionally, a <a>WebVTT line terminator</a>.</li>
-   <li>If the last end tag string was not omitted: Zero or more U+0020 SPACE characters or U+0009 CHARACTER TABULATION (tab) characters, each optionally followed by a <a>WebVTT line terminator</a>.</li>
-   <li>A <a>WebVTT cue span end tag</a> "<code title="">ruby</code>".</li>
-  </ol>
-
-  <p>A <dfn>WebVTT cue voice span</dfn> consists of the following
-  components, in the order given:</p>
-
-  <ol>
-   <li>A <a>WebVTT cue span start tag</a> "<code title="">v</code>" that requires an annotation; the annotation represents the name of the voice.</li>
-   <li><a>WebVTT cue internal text</a>.</li>
-   <li>A <a>WebVTT cue span end tag</a> "<code title="">v</code>". If this <a>WebVTT cue voice span</a> is the only <a title="WebVTT cue components">component</a> of its <a>WebVTT cue text</a> sequence, then the end tag may be omitted for brevity.</li>
-  </ol>
-
-  <p>A <dfn>WebVTT cue language span</dfn> consists of the following
-  components, in the order given:</p>
-
-  <ol>
-   <li>A <a>WebVTT cue span start tag</a> "<code title="">lang</code>" that requires an annotation; the annotation represents the language of the following component, and must be a valid BCP 47 language tag. <a href="#refsBCP47">[BCP47]</a></li>
-   <li><a>WebVTT cue internal text</a>.</li>
-   <li>A <a>WebVTT cue span end tag</a> "<code title="">lang</code>".</li>
-  </ol>
-
-  <p>A <dfn>WebVTT cue span start tag</dfn> has a <var title="">tag
-  name</var> and either <!--allows,--> requires<!--,--> or disallows
-  an annotation, and consists of the following components, in the
-  order given:</p>
+  <p>
+    A <dfn>WebVTT cue ruby span</dfn> consists of the following components, in
+    the order given:
+  </p>
 
   <ol>
 
-   <li>A U+003C LESS-THAN SIGN character (&lt;).</li>
-
-   <li>The <var title="">tag name</var>.</li>
-
-   <li>
-    Zero or more occurrences of the following sequence:
-
-    <ol>
-
-     <li>U+002E FULL STOP character (.)</li>
-
-     <li>One or more characters other than U+0009 CHARACTER TABULATION
-     (tab) characters, U+000A LINE FEED (LF) characters, U+000D
-     CARRIAGE RETURN (CR) characters, U+0020 SPACE characters, U+0026
-     AMPERSAND characters (&amp;), U+003C LESS-THAN SIGN characters
-     (&lt;), U+003E GREATER-THAN SIGN characters (>), and U+002E FULL
-     STOP characters (.), representing a class that describes the cue
-     span's significance.</li>
-
-    </ol>
-
-   </li>
-
-   <li>
-    <p>If the start tag requires an annotation:
-    a U+0020 SPACE character or a U+0009 CHARACTER TABULATION (tab)
-    character, followed by one or more of the following components,
-    the concatenation of their representations having a value that
-    contains at least one character other than U+0020 SPACE and U+0009
-    CHARACTER TABULATION (tab) characters:</p>
-
-    <ul>
-     <li><a>WebVTT cue span start tag annotation text</a>, representing the text of the annotation.</li>
-     <li>A <a>WebVTT cue amp escape</a>, representing a "&amp;" character in the text of the annotation.</li>
-     <li>A <a>WebVTT cue lt escape</a>, representing a "&lt;" character in the text of the annotation.</li>
-     <li>A <a>WebVTT cue gt escape</a>, representing a "&gt;" character in the text of the annotation.</li>
-     <li>A <a>WebVTT cue lrm escape</a>, representing a U+200E LEFT-TO-RIGHT MARK Unicode bidirectional formatting character in the text of the cue.</li>
-     <li>A <a>WebVTT cue rlm escape</a>, representing a U+200F RIGHT-TO-LEFT MARK Unicode bidirectional formatting character in the text of the cue.</li>
-     <li>A <a>WebVTT cue nbsp escape</a>, representing a U+00A0 NO-BREAK SPACE character in the text of the cue.</li>
-    </ul>
-
-   </li>
-
-   <li>A U+003E GREATER-THAN SIGN character (&gt;).</li>
-
+    <li>
+      <p>
+        A <a>WebVTT cue span start tag</a> "<code title="">ruby</code>" that
+        disallows an annotation.
+      </p>
+    </li>
+    <li>
+      One or more occurrences of the following group of components, in the
+      order given:
+      <ol>
+        <li>
+          <p><a>WebVTT cue internal text</a>, representing the ruby base.</p>
+        </li>
+        <li>
+          <p>
+            A <a>WebVTT cue span start tag</a> "<code title="">rt</code>" that
+            disallows an annotation.
+          </p>
+        </li>
+        <li>
+          <p>
+            A <dfn>WebVTT cue ruby text span</dfn>:
+            <a>WebVTT cue internal text</a>, representing the ruby text
+            component of the ruby annotation.
+          </p>
+        </li>
+        <li>
+          <p>
+            A <a>WebVTT cue span end tag</a> "<code title="">rt</code>".
+            If this is the last occurrence of this group of components in the
+            <a>WebVTT cue ruby span</a>, then this last end tag string
+            may be omitted.
+          </p>
+        </li>
+      </ol>
+    </li>
+    <li>
+      <p>
+        If the last end tag string was not omitted: Optionally, a
+        <a>WebVTT line terminator</a>.
+      </p>
+    </li>
+    <li>
+      <p>
+        If the last end tag string was not omitted: Zero or more U+0020 SPACE
+        characters or U+0009 CHARACTER TABULATION (tab) characters, each
+        optionally followed by a <a>WebVTT line terminator</a>.
+      </p>
+    </li>
+    <li>
+      <p>A <a>WebVTT cue span end tag</a> "<code title="">ruby</code>".</p>
+    </li>
   </ol>
 
-  <p>A <dfn>WebVTT cue span end tag</dfn> has a <var title="">tag
-  name</var> and consists of the following components, in the order
-  given:</p>
+  <p>
+    A <dfn>WebVTT cue voice span</dfn> consists of the following components, in
+    the order given:
+  </p>
 
   <ol>
-   <li>A U+003C LESS-THAN SIGN character (&lt;).</li>
-   <li>U+002F SOLIDUS character (/).</li>
-   <li>The <var title="">tag name</var>.</li>
-   <li>A U+003E GREATER-THAN SIGN character (&gt;).</li>
+    <li>
+      <p>
+        A <a>WebVTT cue span start tag</a> "<code title="">v</code>" that
+        requires an annotation; the annotation represents the name of the
+        voice.
+      </p>
+    </li>
+    <li><p><a>WebVTT cue internal text</a>.</p></li>
+    <li>
+      <p>
+        A <a>WebVTT cue span end tag</a> "<code title="">v</code>". If this
+        <a>WebVTT cue voice span</a> is the only
+        <a title="WebVTT cue components">component</a> of its
+        <a>WebVTT cue text</a> sequence, then the end tag may be omitted for
+        brevity.
+      </p>
+    </li>
   </ol>
 
-  <p>A <dfn>WebVTT cue timestamp</dfn> consists of a U+003C LESS-THAN
-  SIGN character (&lt;), followed by a <a>WebVTT timestamp</a>
-  representing the time that the given point in the cue becomes
-  active, followed by a U+003E GREATER-THAN SIGN character (>). The
-  time represented by the <a>WebVTT timestamp</a> must be
-  greater than the times represented by any previous <a
-  title="WebVTT cue timestamp">WebVTT cue timestamps</a> in the
-  cue, as well as greater than the cue's start time offset, and less
-  than the cue's end time offset.</p>
+  <p>
+    A <dfn>WebVTT cue language span</dfn> consists of the following components,
+    in the order given:
+  </p>
 
-  <p>A <dfn>WebVTT cue text span</dfn> consists of one or more
-  characters other than U+000A LINE FEED (LF) characters, U+000D
-  CARRIAGE RETURN (CR) characters, U+0026 AMPERSAND characters (&amp;),
-  and U+003C LESS-THAN SIGN characters (&lt;).</p>
+  <ol>
+    <li>
+      <p>
+        A <a>WebVTT cue span start tag</a> "<code title="">lang</code>" that
+        requires an annotation; the annotation represents the language of the
+        following component, and must be a valid BCP 47 language tag.
+        <a href="#refsBCP47">[BCP47]</a>
+      </p>
+    </li>
+    <li><p><a>WebVTT cue internal text</a>.</p></li>
+    <li>
+      <p>A <a>WebVTT cue span end tag</a> "<code title="">lang</code>".</p>
+    </li>
+  </ol>
 
-  <p><dfn>WebVTT cue span start tag annotation text</dfn> consists of
-  one or more characters other than U+000A LINE FEED (LF) characters,
-  U+000D CARRIAGE RETURN (CR) characters, U+0026 AMPERSAND characters
-  (&amp;), and U+003E GREATER-THAN SIGN characters (&gt;).</p>
+  <p>
+    A <dfn>WebVTT cue span start tag</dfn> has a <var title="">tag name</var>
+    and either <!--allows,--> requires<!--,--> or disallows an annotation, and
+    consists of the following components, in the order given:
+  </p>
 
-  <p>A <dfn>WebVTT cue amp escape</dfn> is the five character string
-  "<code title="">&amp;amp;</code>".</p>
+  <ol>
+    <li><p>A U+003C LESS-THAN SIGN character (&lt;).</p></li>
 
-  <p>A <dfn>WebVTT cue lt escape</dfn> is the four character string
-  "<code title="">&amp;lt;</code>".</p>
 
-  <p>A <dfn>WebVTT cue gt escape</dfn> is the four character string
-  "<code title="">&amp;gt;</code>".</p>
+    <li><p>The <var title="">tag name</var>.</p></li>
 
-  <p>A <dfn>WebVTT cue lrm escape</dfn> is the five character string
-  "<code title="">&amp;lrm;</code>".</p>
+    <li>
+      Zero or more occurrences of the following sequence:
 
-  <p>A <dfn>WebVTT cue rlm escape</dfn> is the five character string
-  "<code title="">&amp;rlm;</code>".</p>
+      <ol>
+        <li><p>U+002E FULL STOP character (.)</p></li>
 
-  <p>A <dfn>WebVTT cue nbsp escape</dfn> is the six character string
-  "<code title="">&amp;nbsp;</code>".</p>
+        <li>
+          <p>
+            One or more characters other than U+0009 CHARACTER TABULATION (tab)
+            characters, U+000A LINE FEED (LF) characters, U+000D CARRIAGE RETURN
+            (CR) characters, U+0020 SPACE characters, U+0026 AMPERSAND
+            characters (&amp;), U+003C LESS-THAN SIGN characters (&lt;), U+003E
+            GREATER-THAN SIGN characters (>), and U+002E FULL STOP characters
+            (.), representing a class that describes the cue span's
+            significance.
+          </p>
+        </li>
+      </ol>
+    </li>
 
-  </section><!-- end of cue text -->
+    <li>
+      <p>
+        If the start tag requires an annotation: a U+0020 SPACE character or a
+        U+0009 CHARACTER TABULATION (tab) character, followed by one or more of
+        the following components, the concatenation of their representations
+        having a value that contains at least one character other than U+0020
+        SPACE and U+0009 CHARACTER TABULATION (tab) characters:
+      </p>
 
-  </section><!-- end cue payload types -->
+      <ul>
+        <li>
+          <p>
+            <a>WebVTT cue span start tag annotation text</a>, representing the
+            text of the annotation.
+          </p>
+        </li>
+        <li>
+          <p>
+            A <a>WebVTT cue amp escape</a>, representing a "&amp;" character in
+            the text of the annotation.
+          </p>
+        </li>
+        <li>
+          <p>
+            A <a>WebVTT cue lt escape</a>, representing a "&lt;" character in
+            the text of the annotation.
+          </p>
+        </li>
+        <li>
+          <p>
+            A <a>WebVTT cue gt escape</a>, representing a "&gt;" character in
+            the text of the annotation.
+          </p>
+        </li>
+        <li>
+          <p>
+            A <a>WebVTT cue lrm escape</a>, representing a U+200E LEFT-TO-RIGHT
+            MARK Unicode bidirectional formatting character in the text of the
+            cue.
+          </p>
+        </li>
+        <li>
+          <p>
+            A <a>WebVTT cue rlm escape</a>, representing a U+200F RIGHT-TO-LEFT
+            MARK Unicode bidirectional formatting character in the text of the
+            cue.
+          </p>
+        </li>
+        <li>
+          <p>
+            A <a>WebVTT cue nbsp escape</a>, representing a U+00A0 NO-BREAK
+            SPACE character in the text of the cue.
+          </p>
+        </li>
+      </ul>
+    </li>
+
+    <li><p>A U+003E GREATER-THAN SIGN character (&gt;).</p></li>
+  </ol>
+
+  <p>
+    A <dfn>WebVTT cue span end tag</dfn> has a <var title="">tag name</var> and
+    consists of the following components, in the order given:
+  </p>
+
+  <ol>
+    <li><p>A U+003C LESS-THAN SIGN character (&lt;).</p></li>
+    <li><p>U+002F SOLIDUS character (/).</p></li>
+    <li><p>The <var title="">tag name</var>.</p></li>
+    <li><p>A U+003E GREATER-THAN SIGN character (&gt;).</p></li>
+  </ol>
+
+  <p>
+    A <dfn>WebVTT cue timestamp</dfn> consists of a U+003C LESS-THAN SIGN
+    character (&lt;), followed by a <a>WebVTT timestamp</a> representing the
+    time that the given point in the cue becomes active, followed by a U+003E
+    GREATER-THAN SIGN character (>). The time represented by the
+    <a>WebVTT timestamp</a> must be greater than the times represented by any
+    previous <a title="WebVTT cue timestamp">WebVTT cue timestamps</a> in the
+    cue, as well as greater than the cue's start time offset, and less than the
+    cue's end time offset.
+  </p>
+
+  <p>
+    A <dfn>WebVTT cue text span</dfn> consists of one or more characters other
+    than U+000A LINE FEED (LF) characters, U+000D CARRIAGE RETURN (CR)
+    characters, U+0026 AMPERSAND characters (&amp;), and U+003C LESS-THAN SIGN
+    characters (&lt;).
+  </p>
+
+  <p>
+    <dfn>WebVTT cue span start tag annotation text</dfn> consists of one or more
+    characters other than U+000A LINE FEED (LF) characters, U+000D CARRIAGE
+    RETURN (CR) characters, U+0026 AMPERSAND characters (&amp;), and U+003E
+    GREATER-THAN SIGN characters (&gt;).
+  </p>
+
+  <p>
+    A <dfn>WebVTT cue amp escape</dfn> is the five character string
+    "<code title="">&amp;amp;</code>".
+  </p>
+
+  <p>
+    A <dfn>WebVTT cue lt escape</dfn> is the four character string
+    "<code title="">&amp;lt;</code>".
+  </p>
+
+  <p>
+    A <dfn>WebVTT cue gt escape</dfn> is the four character string
+    "<code title="">&amp;gt;</code>".
+  </p>
+
+  <p>
+    A <dfn>WebVTT cue lrm escape</dfn> is the five character string
+    "<code title="">&amp;lrm;</code>".
+  </p>
+
+  <p>
+    A <dfn>WebVTT cue rlm escape</dfn> is the five character string
+    "<code title="">&amp;rlm;</code>".
+  </p>
+
+  <p>
+    A <dfn>WebVTT cue nbsp escape</dfn> is the six character string
+    "<code title="">&amp;nbsp;</code>".
+  </p>
+
+  </section><!-- END: WebVTT cue text -->
+
+  </section><!-- END: Types of WebVTT cue payload -->
 
   <section>
   <h3>WebVTT cue settings</h3>
@@ -1451,306 +2135,483 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
   <section>
   <h4>WebVTT region definition</h4>
 
-  <p>A <a>WebVTT cue settings list</a> may contain a reference to a
-  <a title="text track region">text track region</a>. To define
-  a region, a <a>WebVTT region metadata header</a> is specified.</p>
+  <p>
+    A <a>WebVTT cue settings list</a> may contain a reference to a
+    <a title="text track region">text track region</a>. To define a region, a
+    <a>WebVTT region metadata header</a> is specified.
+  </p>
 
-  <p>A <dfn>WebVTT region metadata header</dfn> is a special kind of
-  <a>WebVTT metadata header</a> where both of the following apply:</p>
+  <p>
+    A <dfn>WebVTT region metadata header</dfn> is a special kind of
+    <a>WebVTT metadata header</a> where both of the following apply:
+  </p>
 
   <ul>
-    <li>The <a>WebVTT metadata header name</a> is the string "<code>Region</code>".</li>
-    <li>The <a>WebVTT metadata header value</a> is a <a>WebVTT region setting list</a>.
+    <li>
+      <p>
+        The <a>WebVTT metadata header name</a> is the string
+        "<code>Region</code>".
+      </p>
+    </li>
+    <li>
+      <p>
+        The <a>WebVTT metadata header value</a> is a
+        <a>WebVTT region setting list</a>.
+      </p>
     </li>
   </ul>
 
-  <p>A <dfn>WebVTT region</dfn> represents its <a title="WebVTT region setting list">WebVTT region settings</a>.</p>
+  <p>
+    A <dfn>WebVTT region</dfn> represents its
+    <a title="WebVTT region setting list">WebVTT region settings</a>.
+  </p>
 
-  <p>The <dfn>WebVTT region setting list</dfn> of a <a>WebVTT region metadata header</a> consists of zero or more of the following components, in any order, separated from each other by one or more U+0020 SPACE characters or U+0009 CHARACTER TABULATION (tab) characters. Each component must not be included more than once per <a>WebVTT region setting list</a> string.</p>
+  <p>
+    The <dfn>WebVTT region setting list</dfn> of a
+    <a>WebVTT region metadata header</a> consists of zero or more of the
+    following components, in any order, separated from each other by one or more
+    U+0020 SPACE characters or U+0009 CHARACTER TABULATION (tab) characters.
+    Each component must not be included more than once per
+    <a>WebVTT region setting list</a> string.
+  </p>
 
   <ul>
-   <li>A <a>WebVTT region identifier</a>.</li> <!-- id:fred -->
-   <li>A <a>WebVTT region width setting</a>.</li> <!-- width:80.5% -->
-   <li>A <a>WebVTT region lines setting</a>.</li> <!-- lines:3 -->
-   <li>A <a>WebVTT region anchor setting</a>.</li> <!-- regionanchor:0%,100% -->
-   <li>A <a>WebVTT region viewport anchor setting</a>.</li> <!-- viewportanchor:10.5%,90.5% -->
-   <li>A <a>WebVTT region scroll setting</a>.</li> <!-- scroll:up -->
+    <li><p>A <a>WebVTT region identifier</a>.</p></li> <!-- id:fred -->
+    <li><p>A <a>WebVTT region width setting</a>.</p></li> <!-- width:80.5% -->
+    <li><p>A <a>WebVTT region lines setting</a>.</p></li> <!-- lines:3 -->
+    <li><p>A <a>WebVTT region anchor setting</a>.</p></li>
+    <!-- regionanchor:0%,100% -->
+    <li><p>A <a>WebVTT region viewport anchor setting</a>.</p></li>
+    <!-- viewportanchor:10.5%,90.5% -->
+    <li><p>A <a>WebVTT region scroll setting</a>.</p></li> <!-- scroll:up -->
   </ul>
 
-  <p class="note">The <a>WebVTT region setting list</a> gives configuration
-  options regarding the dimensions, positioning and anchoring of the region. For
-  example, it allows a group of cues within a region to be anchored in the center of the
-  region and the center of the video viewport. In this example, when the font size grows,
-  the region grows uniformly in all directions from the center.</p>
+  <p class="note">
+    The <a>WebVTT region setting list</a> gives configuration options regarding
+    the dimensions, positioning and anchoring of the region. For example, it
+    allows a group of cues within a region to be anchored in the center of the
+    region and the center of the video viewport. In this example, when the font
+    size grows, the region grows uniformly in all directions from the center.
+  </p>
 
-  <p>A <dfn>WebVTT region identifier</dfn> consists of the
-  following components, in the order given:</p>
+  <p>
+    A <dfn>WebVTT region identifier</dfn> consists of the following components,
+    in the order given:
+  </p>
+
   <ol>
     <li><p>The string "<code>id</code>".</p></li>
     <li><p>A U+003D EQUALS SIGN character (=).</p></li>
-    <li><p>An arbitrary string of one or more characters other than U+0020 SPACE
-    or U+0009 CHARACTER TABULATION character. The string must not contain the substring
-    "<code>--></code>" (U+002D HYPHEN-MINUS, U+002D HYPHEN-MINUS,
-    U+003E GREATER-THAN SIGN).</p></li>
+    <li>
+      <p>
+        An arbitrary string of one or more characters other than U+0020 SPACE or
+        U+0009 CHARACTER TABULATION character. The string must not contain the
+        substring "<code>--></code>" (U+002D HYPHEN-MINUS, U+002D HYPHEN-MINUS,
+        U+003E GREATER-THAN SIGN).
+      </p>
+    </li>
   </ol>
-  <p class ="note">The <a>WebVTT region identifier</a> gives
-  a name to the region so it can be referenced by the cues that belong to the region.</p>
 
-  <p>A <dfn >WebVTT region width setting</dfn> consists of the
-  following components, in the order given:</p>
+  <p class ="note">
+    The <a>WebVTT region identifier</a> gives a name to the region so it can be
+    referenced by the cues that belong to the region.
+  </p>
+
+  <p>
+    A <dfn >WebVTT region width setting</dfn> consists of the following
+    components, in the order given:
+  </p>
+
   <ol>
-   <li><p>The string "<code>width</code>".</p></li>
-   <li><p>A U+003D EQUALS SIGN character (=).</p></li>
-   <li><p>A <a>WebVTT percentage</a>.</p></li>
+    <li><p>The string "<code>width</code>".</p></li>
+    <li><p>A U+003D EQUALS SIGN character (=).</p></li>
+    <li><p>A <a>WebVTT percentage</a>.</p></li>
   </ol>
-  <p class ="note">The <a>WebVTT region width setting</a> provides
-  a fixed width as a percentage of the video width for the region into which cues are
-  rendered and based on which alignment is calculated.</p>
 
-  <p>A <dfn>WebVTT region lines setting</dfn> consists of the
-  following components, in the order given:</p>
+  <p class ="note">
+    The <a>WebVTT region width setting</a> provides a fixed width as a
+    percentage of the video width for the region into which cues are rendered
+    and based on which alignment is calculated.
+  </p>
+
+  <p>
+    A <dfn>WebVTT region lines setting</dfn> consists of the following
+    components, in the order given:
+  </p>
+
   <ol>
-   <li><p>The string "<code>lines</code>".</p></li>
-   <li><p>A U+003D EQUALS SIGN character (=).</p></li>
-   <li><p>One or more <a>ASCII digits</a>.</p></li>
+    <li><p>The string "<code>lines</code>".</p></li>
+    <li><p>A U+003D EQUALS SIGN character (=).</p></li>
+    <li><p>One or more <a>ASCII digits</a>.</p></li>
   </ol>
-  <p class ="note">The <a>WebVTT region lines setting</a> provides
-  a fixed height as a number of lines for the region into which cues are rendered. As such, it
-  defines the height of the roll-up region if it is a scroll region.</p>
 
-  <p>A <dfn>WebVTT region anchor setting</dfn> consists of the
-  following components, in the order given:</p>
+  <p class ="note">
+    The <a>WebVTT region lines setting</a> provides a fixed height as a number
+    of lines for the region into which cues are rendered. As such, it defines
+    the height of the roll-up region if it is a scroll region.
+  </p>
+
+  <p>
+    A <dfn>WebVTT region anchor setting</dfn> consists of the following
+    components, in the order given:
+  </p>
+
   <ol>
-   <li><p>The string "<code>regionanchor</code>".</p></li>
-   <li><p>A U+003D EQUALS SIGN character (=).</p></li>
-   <li><p>A <a>WebVTT percentage</a>.</p></li>
-   <li><p>A U+002C COMMA character (,).</p></li>
-   <li><p>A <a>WebVTT percentage</a>.</p></li>
+    <li><p>The string "<code>regionanchor</code>".</p></li>
+    <li><p>A U+003D EQUALS SIGN character (=).</p></li>
+    <li><p>A <a>WebVTT percentage</a>.</p></li>
+    <li><p>A U+002C COMMA character (,).</p></li>
+    <li><p>A <a>WebVTT percentage</a>.</p></li>
   </ol>
-  <p class ="note">The <a>WebVTT region anchor setting</a> provides
-  a tuple of two percentages that specify the point within the region box that is fixed in
-  location. The first percentage measures the x-dimension and the second percentage
-  y-dimension from the top left corner of the region box. If no
-  <a>WebVTT region anchor setting</a> is given, the anchor
-  defaults to 0%, 100% (i.e. the bottom left corner).</p>
 
-  <p>A <dfn>WebVTT region viewport anchor setting</dfn>
-  consists of the following components, in the order given:</p>
+  <p class ="note">
+    The <a>WebVTT region anchor setting</a> provides a tuple of two percentages
+    that specify the point within the region box that is fixed in location. The
+    first percentage measures the x-dimension and the second percentage
+    y-dimension from the top left corner of the region box. If no
+    <a>WebVTT region anchor setting</a> is given, the anchor defaults to 0%,
+    100% (i.e. the bottom left corner).
+  </p>
+
+  <p>
+    A <dfn>WebVTT region viewport anchor setting</dfn> consists of the following
+    components, in the order given:
+  </p>
+
   <ol>
-   <li><p>The string "<code>viewportanchor</code>".</p></li>
-   <li><p>A U+003D EQUALS SIGN character (=).</p></li>
-   <li><p>A <a>WebVTT percentage</a>.</p></li>
-   <li><p>A U+002C COMMA character (,).</p></li>
-   <li><p>A <a>WebVTT percentage</a>.</p></li>
+    <li><p>The string "<code>viewportanchor</code>".</p></li>
+    <li><p>A U+003D EQUALS SIGN character (=).</p></li>
+    <li><p>A <a>WebVTT percentage</a>.</p></li>
+    <li><p>A U+002C COMMA character (,).</p></li>
+    <li><p>A <a>WebVTT percentage</a>.</p></li>
   </ol>
-  <p class ="note">The <a>WebVTT region viewport
-  anchor setting</a> provides a tuple of two percentages that specify the point within
-  the video viewport that the region anchor point is anchored to. The first percentage
-  measures the x-dimension and the second percentage measures the y-dimension from the
-  top left corner of the video viewport box. If no viewport anchor is given, it defaults
-  to 0%, 100% (i.e. the bottom left corner).</p>
 
-  <p class ="note">For browsers, the region maps to an absolute positioned CSS box relative
-  to the video viewport, i.e. there is a relative positioned box that represents the video
-  viewport relative to which the regions are absolutely positioned. Overflow is hidden.</p>
+  <p class ="note">
+    The <a>WebVTT region viewport anchor setting</a> provides a tuple of two
+    percentages that specify the point within the video viewport that the region
+    anchor point is anchored to. The first percentage measures the x-dimension
+    and the second percentage measures the y-dimension from the top left corner
+    of the video viewport box. If no viewport anchor is given, it defaults to
+    0%, 100% (i.e. the bottom left corner).
+  </p>
 
-  <p>A <dfn>WebVTT region scroll setting</dfn> consists of the
-  following components, in the order given:</p>
+  <p class ="note">
+    For browsers, the region maps to an absolute positioned CSS box relative to
+    the video viewport, i.e. there is a relative positioned box that represents
+    the video viewport relative to which the regions are absolutely positioned.
+    Overflow is hidden.
+  </p>
+
+  <p>
+    A <dfn>WebVTT region scroll setting</dfn> consists of the following
+    components, in the order given:
+  </p>
+
   <ol>
     <li><p>The string "<code>scroll</code>".</p></li>
     <li><p>A U+003D EQUALS SIGN character (=).</p></li>
     <li><p>The string "<code>up</code>".</p></li>
   </ol>
-  <p class ="note">The <a>WebVTT region scroll setting</a>
-  specifies whether cues rendered into the region are allowed to move out of their initial
-  rendering place and roll up, i.e. move towards the top of the video viewport. If the
-  scroll setting is omitted, cues do not move from their rendered position.</p>
 
-  <p class="note">Cues are added to a region one line at a time below existing cue lines.
-  When an existing rendered cue line is removed, and it was above another already rendered
-  cue line, that cue line moves into its space, thus scrolling in the given direction. If
-  there is not enough space for a new cue line to be added to a region, the top-most cue
-  line is pushed off the visible region (thus slowly becoming invisible as it moves into
-  overflow:hidden). This eventually makes space for the new cue line and allows it to be
-  added.</p>
+  <p class ="note">
+    The <a>WebVTT region scroll setting</a> specifies whether cues rendered into
+    the region are allowed to move out of their initial rendering place and roll
+    up, i.e. move towards the top of the video viewport. If the scroll setting
+    is omitted, cues do not move from their rendered position.
+  </p>
 
-  <p class="note">When there is no scroll direction, cue lines are added in the empty line
-  closest to the line in the bottom of the region. If no empty line is available, the oldest
-  line is replaced.</p>
+  <p class="note">
+    Cues are added to a region one line at a time below existing cue lines. When
+    an existing rendered cue line is removed, and it was above another already
+    rendered cue line, that cue line moves into its space, thus scrolling in the
+    given direction. If there is not enough space for a new cue line to be added
+    to a region, the top-most cue line is pushed off the visible region (thus
+    slowly becoming invisible as it moves into overflow:hidden). This eventually
+    makes space for the new cue line and allows it to be added.
+  </p>
 
-  </section>
+  <p class="note">
+    When there is no scroll direction, cue lines are added in the empty line
+    closest to the line in the bottom of the region. If no empty line is
+    available, the oldest line is replaced.
+  </p>
+
+  </section><!-- END: WebVTT region definition -->
 
   <section>
   <h4>WebVTT cue settings</h4>
 
-  <p>A <a>WebVTT cue settings list</a> consists of zero or more of the following settings. Each
-  setting must not be included more than once per <a>WebVTT cue settings list</a>.</p>
-
-  <ul class="brief">
-   <li>A <a>WebVTT vertical text cue setting</a>.</li> <!-- vertical:rl/lr [writing direction] -->
-   <li>A <a>WebVTT line position cue setting</a>.</li> <!-- line:100% line:1 line:-1
-                                                       [snap-to-lines & line position & line alignment] -->
-   <li>A <a>WebVTT size cue setting</a>.</li>          <!-- size:100% -->
-   <li>A <a>WebVTT text position cue setting</a>.</li> <!-- position:100%
-                                                       [text position & text position alignment] -->
-   <li>A <a>WebVTT alignment cue setting</a>.</li>     <!-- align:start/middle/end/left/right
-                                                       [text alignment] -->
-   <li>A <a>WebVTT region cue setting</a>.</li>        <!-- region:fred [region id] -->
-  </ul>
-
-  <p class="note">A <a>WebVTT cue settings list</a> gives configuration
-  options regarding the position and alignment of the cue box and the cue text within. For
-  example, it allows a cue box to be aligned to the left or positioned at the top right with
-  the cue text within middle aligned.</p>
-
-  <p>A <dfn>WebVTT vertical text cue setting</dfn> is a <a>WebVTT cue setting</a> that
-  consists of the following components, in the order given:</p>
-
-  <ol>
-   <li>The string "<code title="">vertical</code>" as the <a>WebVTT cue setting name</a>.</li>
-   <li><p>A U+003A COLON character (:).</p></li>
-   <li>One of the following strings as the <a>WebVTT cue setting value</a>: "<code title="">rl</code>", "<code title="">lr</code>".</li>
-  </ol>
-
-  <p class="note">A <a>WebVTT vertical text cue setting</a>
-  configures the cue to use vertical text layout rather than
-  horizontal text layout. Vertical text layout is sometimes used in
-  Japanese, for example. The default is horizontal layout.</p>
-
-  <p>A <dfn>WebVTT line position cue setting</dfn> consists of the
-  following components, in the order given:</p>
-
-  <ol>
-   <li><p>The string "<code title="">line</code>" as the <a>WebVTT cue setting name</a>.</p></li>
-   <li><p>A U+003A COLON character (:).</p></li>
-   <li>
-     As the <a>WebVTT cue setting value</a>:
-     <ol>
-     <li>
-      a position value, either:
-      <dl>
-       <dt>To represent a specific position relative to the video frame</dt>
-       <dd>
-        <p>A <a>WebVTT percentage</a>.</p>
-       </dd>
-       <dt>Or to represent a line number</dt>
-       <dd>
-        <ol>
-         <li>Optionally a U+002D HYPHEN-MINUS character (-).</li>
-         <li>One or more <a>ASCII digits</a>.</li>
-        </ol>
-       </dd>
-      </dl>
-    </li>
-    <li>
-      An optional alignment value consisting of the following components:
-      <ol>
-      <li>A U+002C COMMA character (,).</li>
-      <li>One of the following strings: <code title="">start</code>, <code title="">middle</code>,
-        <code title="">end</code></li>
-      </ol>
-    </li>
-    </ol>
-   </li>
-  </ol>
-
-  <p class="note">A <a>WebVTT line position cue setting</a> configures the position of the cue box
-  in the direction opposite to the <a title="text track cue writing direction">writing direction</a>.
-  For horizontal cues, this is the vertical
-  position. The positioning is calculated relative to the <a title="text track cue line start alignment">start</a>,
-  <a title="text track cue line middle alignment">middle</a>, or <a title="text track cue line end alignment">end</a>
-  of the cue box, depending on the <a>text track cue line alignment</a> value -
-  <a title="text track cue line start alignment">start</a> by default.
-  The position can be given either as a percentage of the video dimension
-  or as a line number. Line numbers are based on the size of the first line of the
-  cue. Positive line numbers count from the start of the video frame (the first
-  line is numbered 0), negative line numbers from the end of the
-  frame (the last line is numbered &#x2212;1).</p>
-
-  <p>A <dfn>WebVTT size cue setting</dfn> consists of the
-  following components, in the order given:</p>
-
-  <ol>
-   <li><p>The string "<code title="">size</code>" as the <a>WebVTT cue setting name</a>.</p></li>
-   <li><p>A U+003A COLON character (:).</p></li>
-   <li><p>As the <a>WebVTT cue setting value</a>: a
-     <a>WebVTT percentage</a>.</p></li>
-  </ol>
-
-  <p class="note">A <a>WebVTT size cue setting</a> configures
-  the size of the <a title="text track cue box">cue box</a> in the same direction as the
-  <a>WebVTT text position cue setting</a>. For horizontal cues, this is the width
-  of the <a title="text track cue box">cue box</a>. It is given as a percentage of the width of the
-  frame.</p>
-
-  <p>A <dfn>WebVTT text position cue setting</dfn> consists of the
-  following components, in the order given:</p>
-
-  <ol>
-   <li><p>The string "<code title="">position</code>" as the <a>WebVTT cue setting name</a>.</p></li>
-   <li><p>A U+003A COLON character (:).</p></li>
-   <li>
-   As the <a>WebVTT cue setting value</a>:
-   <ol>
-    <li>a position value consisting of: a <a>WebVTT percentage</a>.</li>
-    <li>
-    an optional alignment value consisting of:
-    <ol>
-     <li>A U+002C COMMA character (,).</li>
-     <li>One of the following strings: <code title="">start</code>, <code title="">middle</code>,
-       <code title="">end</code></li>
-    </ol>
-    </li>
-   </ol>
-   </li>
-  </ol>
-
-  <p class="note">A <a>WebVTT text position cue setting</a> configures the position of the
-  <a title="text track cue box">cue box</a> in the direction orthogonal to
-  the <a>WebVTT line position cue setting</a>. For horizontal
-  cues, this is the horizontal position. The text position is given as a percentage of the video frame.
-  The positioning is calculated relative to the <a title="text track cue text position start alignment">start</a>,
-  <a title="text track cue text position middle alignment">middle</a>, or
-  <a title="text track cue text position end alignment">end</a>
-  of the cue box, depending on the <a>default text track cue text position alignment</a> value, which is
-  overridden by the <a>WebVTT text position cue setting</a> alignment value.
+  <p>
+    A <a>WebVTT cue settings list</a> consists of zero or more of the following
+    settings. Each setting must not be included more than once per
+    <a>WebVTT cue settings list</a>.
   </p>
 
-  <p>A <dfn>WebVTT alignment cue setting</dfn> consists of the
-  following components, in the order given:</p>
+  <ul class="brief">
+    <li><p>A <a>WebVTT vertical text cue setting</a>.</p></li>
+    <!-- vertical:rl/lr [writing direction] -->
+    <li><p>A <a>WebVTT line position cue setting</a>.</p></li>
+    <!-- line:100% line:1 line:-1
+         [snap-to-lines & line position & line alignment] -->
+    <li><p>A <a>WebVTT size cue setting</a>.</p></li>
+    <!-- size:100% -->
+    <li><p>A <a>WebVTT text position cue setting</a>.</p></li>
+    <!-- position:100%
+        [text position & text position alignment] -->
+    <li><p>A <a>WebVTT alignment cue setting</a>.</p></li>
+    <!-- align:start/middle/end/left/right
+        [text alignment] -->
+    <li><p>A <a>WebVTT region cue setting</a>.</p></li>
+    <!-- region:fred [region id] -->
+  </ul>
+
+  <p class="note">
+    A <a>WebVTT cue settings list</a> gives configuration options regarding the
+    position and alignment of the cue box and the cue text within. For example,
+    it allows a cue box to be aligned to the left or positioned at the top right
+    with the cue text within middle aligned.
+  </p>
+
+  <p>
+    A <dfn>WebVTT vertical text cue setting</dfn> is a <a>WebVTT cue setting</a>
+    that consists of the following components, in the order given:
+  </p>
 
   <ol>
-   <li><p>The string "<code title="">align</code>" as the <a>WebVTT cue setting name</a>.</p></li>
-   <li><p>A U+003A COLON character (:).</p></li>
-   <li>One of the following strings as the <a>WebVTT cue setting value</a>: "<code title="">start</code>", "<code title="">middle</code>", "<code title="">end</code>", "<code title="">left</code>", "<code title="">right</code>"</li>
-  </ol>
-
-  <p class="note">A <a>WebVTT alignment cue setting</a>
-  configures the alignment of the text within the cue. The keywords
-  are relative to the text direction; for left-to-right English text,
-  "<code title="">start</code>" means left-aligned.</p>
-
-  <p>A <dfn>WebVTT region cue setting</dfn> consists of the
-  following components, in the order given:</p>
-
-  <ol>
-    <li><p>The string "<code>region</code>" as the <a>WebVTT cue setting name</a>.</p></li>
+    <li>
+      <p>
+        The string "<code title="">vertical</code>" as the
+        <a>WebVTT cue setting name</a>.
+      </p>
+    </li>
     <li><p>A U+003A COLON character (:).</p></li>
-    <li><p>As the <a>WebVTT cue setting value</a>: an arbitrary string of one or more characters other than U+0020 SPACE or U+0009 CHARACTER TABULATION character. The string must not contain the substring "<code>--></code>" (U+002D HYPHEN-MINUS, U+002D HYPHEN-MINUS, U+003E GREATER-THAN SIGN).</p></li>
+    <li>
+      <p>
+        One of the following strings as the <a>WebVTT cue setting value</a>:
+        "<code title="">rl</code>", "<code title="">lr</code>".
+      </p>
+    </li>
   </ol>
 
-  <p class ="note">A <a>WebVTT region cue setting</a>
-  configures a cue to become part of a region by referencing the region's identifier unless
-  the cue has a <a title="WebVTT vertical text cue setting">"vertical"</a>,
-  <a title="WebVTT line position cue setting">"line"</a> or
-  <a title="WebVTT size cue setting">"size"</a> cue setting. If a cue is
-  part of a region, its cue settings for <a title="WebVTT line position cue setting">"position"</a>
-  and <a title="WebVTT alignment cue setting">"align"</a> are applied to the line boxes
-  in the cue relative to the region box.</p>
+  <p class="note">
+    A <a>WebVTT vertical text cue setting</a> configures the cue to use vertical
+    text layout rather than horizontal text layout. Vertical text layout is
+    sometimes used in Japanese, for example. The default is horizontal
+    layout.
+  </p>
 
-  </section>
+  <p>
+    A <dfn>WebVTT line position cue setting</dfn> consists of the following
+    components, in the order given:
+  </p>
 
-  </section><!-- end cue settings -->
+  <ol>
+    <li>
+      <p>
+        The string "<code title="">line</code>" as the
+        <a>WebVTT cue setting name</a>.
+      </p>
+    </li>
+    <li><p>A U+003A COLON character (:).</p></li>
+    <li>
+      As the <a>WebVTT cue setting value</a>:
+      <ol>
+        <li>a position value, either:
+          <dl>
+            <dt>
+              To represent a specific position relative to the video frame
+            </dt>
+            <dd>
+              <p>A <a>WebVTT percentage</a>.</p>
+            </dd>
+  
+            <dt>Or to represent a line number</dt>
+            <dd>
+              <ol>
+                <li><p>Optionally a U+002D HYPHEN-MINUS character (-).</p></li>
+                <li><p>One or more <a>ASCII digits</a>.</p></li>
+              </ol>
+            </dd>
+          </dl>
+
+        </li>
+        <li>An optional alignment value consisting of the following components:
+          <ol>
+            <li><p>A U+002C COMMA character (,).</p></li>
+            <li>
+              <p>
+                One of the following strings: <code title="">start</code>,
+                <code title="">middle</code>, <code title="">end</code>
+              </p>
+            </li>
+          </ol>
+        </li>
+      </ol>
+    </li>
+  </ol>
+
+  <p class="note">
+    A <a>WebVTT line position cue setting</a> configures the position of the cue
+    box in the direction opposite to the
+    <a title="text track cue writing direction">writing direction</a>.
+    For horizontal cues, this is the vertical position. The positioning is
+    calculated relative to the
+    <a title="text track cue line start alignment">start</a>,
+    <a title="text track cue line middle alignment">middle</a>, or
+    <a title="text track cue line end alignment">end</a>
+    of the cue box, depending on the <a>text track cue line alignment</a> value
+    - <a title="text track cue line start alignment">start</a> by default.
+    The position can be given either as a percentage of the video dimension or
+    as a line number. Line numbers are based on the size of the first line of
+    the cue. Positive line numbers count from the start of the video frame (the
+    first line is numbered 0), negative line numbers from the end of the frame
+    (the last line is numbered &#x2212;1).
+  </p>
+
+  <p>
+    A <dfn>WebVTT size cue setting</dfn> consists of the following components,
+    in the order given:
+  </p>
+
+  <ol>
+    <li>
+      <p>
+        The string "<code title="">size</code>" as the
+        <a>WebVTT cue setting name</a>.
+      </p>
+    </li>
+    <li><p>A U+003A COLON character (:).</p></li>
+    <li>
+      <p>
+        As the <a>WebVTT cue setting value</a>: a <a>WebVTT percentage</a>.
+      </p>
+    </li>
+  </ol>
+
+  <p class="note">
+    A <a>WebVTT size cue setting</a> configures the size of the
+    <a title="text track cue box">cue box</a> in the same direction as the
+    <a>WebVTT text position cue setting</a>. For horizontal cues, this is the
+    width of the <a title="text track cue box">cue box</a>. It is given as a
+    percentage of the width of the frame.
+  </p>
+
+  <p>
+    A <dfn>WebVTT text position cue setting</dfn> consists of the following
+    components, in the order given:
+  </p>
+
+  <ol>
+    <li>
+      <p>
+        The string "<code title="">position</code>" as the
+        <a>WebVTT cue setting name</a>.
+      </p>
+    </li>
+    <li><p>A U+003A COLON character (:).</p></li>
+    <li>
+      As the <a>WebVTT cue setting value</a>:
+      <ol>
+        <li>
+          <p>a position value consisting of: a <a>WebVTT percentage</a>.</p>
+        </li>
+        <li>an optional alignment value consisting of:
+          <ol>
+            <li><p>A U+002C COMMA character (,).</p></li>
+            <li>
+              <p>
+                One of the following strings: <code title="">start</code>,
+                <code title="">middle</code>, <code title="">end</code>
+              </p>
+            </li>
+          </ol>
+        </li>
+      </ol>
+    </li>
+  </ol>
+
+  <p class="note">
+    A <a>WebVTT text position cue setting</a> configures the position of the
+    <a title="text track cue box">cue box</a> in the direction orthogonal to the
+    <a>WebVTT line position cue setting</a>. For horizontal cues, this is the
+    horizontal position. The text position is given as a percentage of the video
+    frame. The positioning is calculated relative to the
+    <a title="text track cue text position start alignment">start</a>,
+    <a title="text track cue text position middle alignment">middle</a>, or
+    <a title="text track cue text position end alignment">end</a>
+    of the cue box, depending on the
+    <a>default text track cue text position alignment</a> value, which is
+    overridden by the <a>WebVTT text position cue setting</a> alignment value.
+  </p>
+
+  <p>
+    A <dfn>WebVTT alignment cue setting</dfn> consists of the following
+    components, in the order given:
+  </p>
+
+  <ol>
+    <li>
+      <p>
+        The string "<code title="">align</code>" as the
+        <a>WebVTT cue setting name</a>.
+      </p>
+    </li>
+    <li><p>A U+003A COLON character (:).</p></li>
+    <li>
+      <p>
+        One of the following strings as the <a>WebVTT cue setting value</a>:
+        "<code title="">start</code>", "<code title="">middle</code>",
+        "<code title="">end</code>", "<code title="">left</code>",
+        "<code title="">right</code>"
+      </p>
+    </li>
+  </ol>
+
+  <p class="note">
+    A <a>WebVTT alignment cue setting</a> configures the alignment of the text
+    within the cue. The keywords are relative to the text direction; for
+    left-to-right English text, "<code title="">start</code>" means
+    left-aligned.
+  </p>
+
+  <p>
+    A <dfn>WebVTT region cue setting</dfn> consists of the following components,
+    in the order given:
+  </p>
+
+  <ol>
+    <li>
+      <p>
+        The string "<code>region</code>" as the
+        <a>WebVTT cue setting name</a>.
+      </p>
+    </li>
+    <li><p>A U+003A COLON character (:).</p></li>
+    <li>
+      <p>
+        As the <a>WebVTT cue setting value</a>: an arbitrary string of one or
+        more characters other than U+0020 SPACE or U+0009 CHARACTER TABULATION
+        character. The string must not contain the substring "<code>--></code>"
+        (U+002D HYPHEN-MINUS, U+002D HYPHEN-MINUS, U+003E GREATER-THAN SIGN).
+      </p>
+    </li>
+  </ol>
+
+  <p class ="note">
+    A <a>WebVTT region cue setting</a> configures a cue to become part of a
+    region by referencing the region's identifier unless the cue has a
+    <a title="WebVTT vertical text cue setting">"vertical"</a>,
+    <a title="WebVTT line position cue setting">"line"</a> or
+    <a title="WebVTT size cue setting">"size"</a> cue setting. If a cue is part
+    of a region, its cue settings for
+    <a title="WebVTT line position cue setting">"position"</a> and
+    <a title="WebVTT alignment cue setting">"align"</a> are applied to the line
+    boxes in the cue relative to the region box.
+  </p>
+
+  </section><!-- END: WebVTT cue settings -->
+
+  </section><!-- END: WebVTT cue settings -->
 
   <section>
   <h3>Properties of cue sequences</h3>
@@ -1758,24 +2619,38 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
   <section>
   <h4>WebVTT file using only nested cues</h4>
 
-  <p>A <a>WebVTT file</a> whose cues all follow the following rules
-  is said to be a <dfn>WebVTT file using only nested cues</dfn>:</p>
+  <p>
+    A <a>WebVTT file</a> whose cues all follow the following rules is said to be
+    a <dfn>WebVTT file using only nested cues</dfn>:
+  </p>
 
-  <p>given any two cues <var title="">cue1</var> and <var title="">cue2</var> with start and end time
-  offsets <var title="">(x1, y1)</var> and <var title="">(x2, y2)</var> respectively,</p>
+  <p>
+    Given any two cues <var title="">cue1</var> and <var title="">cue2</var>
+    with start and end time offsets <var title="">(x1, y1)</var> and
+    <var title="">(x2, y2)</var> respectively,
+  </p>
 
   <ul>
-    <li>either <var title="">cue1</var> lies fully within <var title="">cue2</var>, i.e.
-    <var title="">x1 >= x2</var> and <var title="">y1 &lt;= y2</var></li>
-    <li>or <var title="">cue1</var> fully contains <var title="">cue2</var>, i.e.
-    <var title="">x1 &lt;= x2</var> and <var title="">y1 >= y2</var>.</li>
+    <li>
+      <p>
+        either <var title="">cue1</var> lies fully within
+        <var title="">cue2</var>, i.e. <var title="">x1 >= x2</var> and
+        <var title="">y1 &lt;= y2</var>
+      </p>
+    </li>
+    <li>
+      <p>
+        or <var title="">cue1</var> fully contains <var title="">cue2</var>,
+        i.e. <var title="">x1 &lt;= x2</var> and
+        <var title="">y1 >= y2</var>.
+      </p>
+    </li>
   </ul>
 
   <div class="example">
+    <p>The following example matches this definition:</p>
 
-   <p>The following example matches this definition:</p>
-
-  <pre>WEBVTT
+    <pre>WEBVTT
 
 00:00.000 --> 01:24.000
 Introduction
@@ -1795,36 +2670,40 @@ Achim's Demo
 03:00.000 --> 05:00.000
 Timeline Panel</pre>
 
-   <p>Notice how you can express the cues in this WebVTT file as a
-   tree structure:</p>
+    <p>
+      Notice how you can express the cues in this WebVTT file as a tree
+      structure:
+    </p>
 
-   <ul>
-    <li>
-     WebVTT file
-     <ul>
+    <ul>
       <li>
-       Introduction
-       <ul>
-        <li>Topics</li>
-        <li>Presenters</li>
-       </ul>
+        WebVTT file
+        <ul>
+          <li>
+            Introduction
+            <ul>
+              <li>Topics</li>
+              <li>Presenters</li>
+            </ul>
+          </li>
+          <li>
+            Scrolling Effects
+            <ul>
+              <li>Achim's Demo</li>
+              <li>Timeline Panel</li>
+            </ul>
+          </li>
+        </ul>
       </li>
-      <li>
-       Scrolling Effects
-       <ul>
-        <li>Achim's Demo</li>
-        <li>Timeline Panel</li>
-       </ul>
-      </li>
-     </ul>
-    </li>
    </ul>
 
-   <p>If the file has cues that can't be expressed in this fashion,
-   then they don't match the definition of a <a>WebVTT file using
-   only nested cues</a>. For example:</p>
+   <p>
+     If the file has cues that can't be expressed in this fashion, then they
+     don't match the definition of a <a>WebVTT file using only nested cues</a>.
+     For example:
+   </p>
 
-  <pre>WEBVTT
+   <pre>WEBVTT
 
 00:00.000 --> 01:00.000
 The First Minute
@@ -1832,69 +2711,80 @@ The First Minute
 00:30.000 --> 01:30.000
 The Final Minute</pre>
 
-   <p>In this ninety-second example, the two cues partly overlap, with
-   the first ending before the second ends and the second starting
-   before the first ends. This therefore is not a <a>WebVTT file
-   using only nested cues</a>.</p>
-
+    <p>
+      In this ninety-second example, the two cues partly overlap, with the first
+      ending before the second ends and the second starting before the first
+      ends. This therefore is not a <a>WebVTT file using only nested cues</a>.
+    </p>
   </div>
 
-  </section>
+  </section><!-- END: WebVTT files using only nested cues -->
 
-  </section><!-- end cue sequence properties -->
+  </section><!-- END: Properties of cue sequences -->
 
   <section>
   <h3>Types of WebVTT files</h3>
 
-  <p>The syntax definition of WebVTT files allows authoring of a wide
-  variety of WebVTT files with a mix of cues. However, only a small
-  subset of WebVTT file types are typically authored.</p>
+  <p>
+    The syntax definition of WebVTT files allows authoring of a wide variety of
+    WebVTT files with a mix of cues. However, only a small subset of WebVTT file
+    types are typically authored.
+  </p>
 
-  <p>Conformance checkers, when validating <a>WebVTT</a> files, may
-  offer to restrict syntax checking for validating these types.</p>
+  <p>
+    Conformance checkers, when validating <a>WebVTT</a> files, may offer to
+    restrict syntax checking for validating these types.
+  </p>
 
   <section>
   <h4>WebVTT file using metadata content</h4>
 
-  <p>A <a>WebVTT file</a> whose cues all have a <a>cue
-  payload</a> that is <a>WebVTT metadata text</a> is
-  said to be a <dfn>WebVTT file using metadata content</dfn>.</p>
-
-  </section>
+  <p>
+    A <a>WebVTT file</a> whose cues all have a <a>cue payload</a> that is
+    <a>WebVTT metadata text</a> is said to be a
+    <dfn>WebVTT file using metadata content</dfn>.
+  </p>
+  </section><!-- END: WebVTT file using metadata content -->
 
   <section>
   <h4>WebVTT file using chapter title text</h4>
 
-  <p><dfn>WebVTT chapter title text</dfn> is <a>WebVTT cue text</a>
-  that makes use only of zero or more of the following components, each optionally separated
-  from the next by a <a>WebVTT line terminator</a>:</p>
+  <p>
+    <dfn>WebVTT chapter title text</dfn> is <a>WebVTT cue text</a> that makes
+    use only of zero or more of the following components, each optionally
+    separated from the next by a <a>WebVTT line terminator</a>:
+  </p>
 
   <ul>
-   <li><a>WebVTT cue text span</a></li>
-   <li><a>WebVTT cue amp escape</a></li>
-   <li><a>WebVTT cue lt escape</a></li>
-   <li><a>WebVTT cue gt escape</a></li>
-   <li><a>WebVTT cue lrm escape</a></li>
-   <li><a>WebVTT cue rlm escape</a></li>
-   <li><a>WebVTT cue nbsp escape</a></li>
+    <li><p><a>WebVTT cue text span</a></p></li>
+    <li><p><a>WebVTT cue amp escape</a></p></li>
+    <li><p><a>WebVTT cue lt escape</a></p></li>
+    <li><p><a>WebVTT cue gt escape</a></p></li>
+    <li><p><a>WebVTT cue lrm escape</a></p></li>
+    <li><p><a>WebVTT cue rlm escape</a></p></li>
+    <li><p><a>WebVTT cue nbsp escape</a></p></li>
   </ul>
 
-  <p>A <dfn>WebVTT file using chapter title text</dfn> is a <a>WebVTT file using only nested cues</a>
-  whose cues all have a <a>cue payload</a> that is <a>WebVTT chapter title text</a>.</p>
-
-  </section>
+  <p>
+    A <dfn>WebVTT file using chapter title text</dfn> is a
+    <a>WebVTT file using only nested cues</a> whose cues all have a
+    <a>cue payload</a> that is <a>WebVTT chapter title text</a>.
+  </p>
+  </section><!-- END: WebVTT file using chapter title text -->
 
   <section>
   <h4>WebVTT file using cue text</h4>
 
-  <p>A <a>WebVTT file</a> whose cues all have a <a>cue payload</a> that is
-  <a>WebVTT cue text</a> is said to be a <dfn>WebVTT file using cue text</dfn>.</p>
+  <p>
+    A <a>WebVTT file</a> whose cues all have a <a>cue payload</a> that is
+    <a>WebVTT cue text</a> is said to be a
+    <dfn>WebVTT file using cue text</dfn>.
+  </p>
+  </section><!-- END: WebVTT file using cue text -->
 
-  </section>
+  </section><!-- END: Types of WebVTT files -->
 
-  </section><!-- end of WebVTT file types -->
-
-  </section><!-- end of syntax -->
+  </section><!-- END: The WebVTT file format: Syntax -->
 
   <section>
   <h2>WebVTT file format: Parsing</h2>
@@ -1902,948 +2792,1742 @@ The Final Minute</pre>
   <section>
   <h3>WebVTT file parsing</h3>
 
-  <p>A <dfn>WebVTT parser</dfn>, given an input byte stream and a
-  <a>text track list of cues</a> <var title="">output</var>,
-  must decode the byte stream using the <a title="UTF-8 decode">UTF-8
-  decode</a> algorithm, and then must parse the resulting string according
-  to the <a>WebVTT parser algorithm</a> below. This results in
-  <a title="text track cue">text track cues</a> being added to <var
-  title="">output</var>. <a href="#refsRFC3629">[RFC3629]</a></p>
+  <p>
+    A <dfn>WebVTT parser</dfn>, given an input byte stream and a
+    <a>text track list of cues</a> <var title="">output</var>, must decode the
+    byte stream using the <a title="UTF-8 decode">UTF-8 decode</a> algorithm,
+    and then must parse the resulting string according to the
+    <a>WebVTT parser algorithm</a> below. This results in
+    <a title="text track cue">text track cues</a> being added to
+    <var title="">output</var>. <a href="#refsRFC3629">[RFC3629]</a>
+  </p>
 
-  <p>A <a>WebVTT parser</a>, specifically its conversion and
-  parsing steps, is typically run asynchronously, with the input byte
-  stream being updated incrementally as the resource is downloaded;
-  this is called an <dfn>incremental WebVTT parser</dfn>.</p>
+  <p>
+    A <a>WebVTT parser</a>, specifically its conversion and parsing steps, is
+    typically run asynchronously, with the input byte stream being updated
+    incrementally as the resource is downloaded; this is called an
+    <dfn>incremental WebVTT parser</dfn>.
+  </p>
 
-  <p>A <a>WebVTT parser</a> verifies a file signature before
-  parsing the provided byte stream. If the stream lacks this WebVTT
-  file signature, then the parser aborts.</p>
+  <p>
+    A <a>WebVTT parser</a> verifies a file signature before parsing the provided
+    byte stream. If the stream lacks this WebVTT file signature, then the parser
+    aborts.
+  </p>
 
   <p>The <dfn>WebVTT parser algorithm</dfn> is as follows:</p>
 
   <ol>
-
-   <li>
-    <p>Let <var title="">input</var> be the string being parsed, after
-    conversion to Unicode, and with the following transformations
-    applied:</p>
-
-    <ul>
-
-     <li><p>Replace all U+0000 NULL characters by U+FFFD REPLACEMENT
-     CHARACTERs.</p></li>
-
-     <li><p>Replace each U+000D CARRIAGE RETURN U+000A LINE FEED
-     (CRLF) character pair by a single U+000A LINE FEED (LF)
-     character.</p></li>
-
-     <li><p>Replace all remaining U+000D CARRIAGE RETURN characters by
-     U+000A LINE FEED (LF) characters.</p></li>
-
-    </ul>
-
-   </li>
-
-   <li><p>Let <var title="">position</var> be a pointer into <var
-   title="">input</var>, initially pointing at the start of the
-   string. In an <a>incremental WebVTT parser</a>, when this
-   algorithm (or further algorithms that it uses) moves the <var
-   title="">position</var> pointer, the user agent must wait until
-   appropriate further characters from the byte stream have been added
-   to <var title="">input</var> before moving the pointer, so that the
-   algorithm never reads past the end of the <var title="">input</var>
-   string. Once the byte stream has ended, and all characters have
-   been added to <var title="">input</var>, then the <var
-   title="">position</var> pointer may, when so instructed by the
-   algorithms, be moved past the end of <var
-   title="">input</var>.</p></li>
-
-   <li>Let <var title="">line</var> be a string variable. Unset the
-   <var title="">already collected line</var> flag.</li>
-
-   <!-- SIGNATURE CHECK -->
-
-   <li><p><a>Collect a sequence of characters</a> that are
-   <em>not</em> U+000A LINE FEED (LF) characters. Let <var
-   title="">line</var> be those characters, if any.</p></li>
-
-   <li><p>If <var title="">line</var> is less than six characters
-   long, then abort these steps. The file does not start with the
-   correct <a>WebVTT file</a> signature and was therefore not
-   successfully processed.</p></li>
-
-   <li><p>If <var title="">line</var> is exactly six characters long
-   but does not exactly equal "<code title="">WEBVTT</code>", then
-   abort these steps. The file does not start with the correct
-   <a>WebVTT file</a> signature and was therefore not
-   successfully processed.</p></li>
-
-   <li><p>If <var title="">line</var> is more than six characters long
-   but the first six characters do not exactly equal "<code
-   title="">WEBVTT</code>", or the seventh character is neither a
-   U+0020 SPACE character nor a U+0009 CHARACTER TABULATION (tab)
-   character, then abort these steps. The file does not start with the
-   correct <a>WebVTT file</a> signature and was therefore not
-   successfully processed.</p></li>
-
-   <li><p>If <var title="">position</var> is past the end of <var
-   title="">input</var>, then abort these steps. The file was
-   successfully processed, but it contains no useful data and so no
-   <a title="text track cue">text track cues</a> where added to
-   <var title="">output</var>.</p></li>
-
-   <li><p>The character indicated by <var title="">position</var> is a
-   U+000A LINE FEED (LF) character. Advance <var
-   title="">position</var> to the next character in <var
-   title="">input</var>.</p></li>
-
-   <li><p><i title="">Header</i>: <a>Collect a sequence of
-   characters</a> that are <em>not</em> U+000A LINE FEED (LF)
-   characters. Let <var title="">line</var> be those characters, if
-   any.</p></li>
-
-   <!-- METADATA HEADER PARSING -->
-
-   <li><p>Let <var title="">regions</var> be a <a>text track list of regions</a>.</p></li>
-
-   <li>
-     <i>Metadata header loop</i>: If <var>line</var> is not the empty string, run the following substeps:
-
-     <ol>
-
-       <li><p><i>Metadata header creation</i>: Let <var>metadata</var> be a new <a>WebVTT metadata header</a>.</p></li>
-
-       <li><p>Let <a title="WebVTT metadata header name">metadata's name</a> be the empty string.</p></li>
-
-       <li><p>Let <a title="WebVTT metadata header value">metadata's value</a> be the empty string.</p></li>
-
-       <li><p>If <var>line</var> contains the character ":" (A U+003A COLON), then set <a title="WebVTT metadata header name">metadata's name</a> to the substring of <var>line</var> before the first ":" character and <a title="WebVTT metadata header value">metadata's value</a> to the substring after this character.</p></li>
-
-       <li>
-         <p>If <a title="WebVTT metadata header name">metadata's name</a> equals "Region":</p>
-
-         <ol>
-           <li><i>Region creation</i>: Let <var>region</var> be a new <a>text track region</a>.</li>
-           <li>Let <var>region</var>'s <a title="text track region identifier">identifier</a> be the empty string.</li>
-           <li>Let <var>region</var>'s <a title="text track region width">width</a> be 100.</li>
-           <li>Let <var>region</var>'s <a title="text track region lines">lines</a> be 3.</li>
-           <li>Let <var>region</var>'s <a title="text track region anchor">anchor point</a> be (0,100).</li>
-           <li>Let <var>region</var>'s <a title="text track region viewport anchor">viewport anchor point</a> be (0,100).</li>
-           <li>Let <var>region</var>'s <a title="text track region scroll">scroll value</a> be <a title="text track region scroll none">NONE</a>.</li>
-           <li><a>Collect WebVTT region settings</a> from <a title="WebVTT metadata header value">metadata's value</a> using <var>region</var> for the results.</li>
-           <li><i>Region processing</i>: Construct a <a>WebVTT Region Object</a> from <var>region</var>.</li>
-           <li>Append <var>region</var> to the <a>text track list of regions</a> <var>regions</var>.</li>
-        </ol>
-       </li>
-     </ol>
-   </li>
-
-   <!-- FIXME: right now ignores all WebVTT metadata headers that don't specify regions. -->
-
-   <li><p>If <var title="">position</var> is past the end of <var
-   title="">input</var>, then jump to the step labeled
-   <i>end</i>.</p></li>
-
-   <li><p>The character indicated by <var title="">position</var> is a
-   U+000A LINE FEED (LF) character. Advance <var
-   title="">position</var> to the next character in <var
-   title="">input</var>.</p></li>
-
-   <li><p>If <var title="">line</var> contains the three-character
-   substring "<code title="">--></code>" (U+002D HYPHEN-MINUS, U+002D
-   HYPHEN-MINUS, U+003E GREATER-THAN SIGN), then set the <var
-   title="">already collected line</var> flag and jump to the step
-   labeled <i>cue loop</i>.</p></li>
-
-   <li><p>If <var title="">line</var> is not the empty string, then
-   jump back to the step labeled <i title="">header</i>.</p></li>
-
-   <li><p><i>Cue loop</i>: If the <var title="">already collected
-   line</var> flag is set, then jump to the step labeled <var
-   title="">cue creation</var>.</p></li>
-
-   <li><p><a>Collect a sequence of characters</a> that are
-   U+000A LINE FEED (LF) characters.</p></li>
-
-   <li><p><a>Collect a sequence of characters</a> that are
-   <em>not</em> U+000A LINE FEED (LF) characters. Let <var
-   title="">line</var> be those characters, if any.</p></li>
-
-   <li><p>If <var title="">line</var> is the empty string, then jump
-   to the step labeled <i>end</i>. (In such a case, <var
-   title="">position</var> is also forcibly past the end of <var
-   title="">input</var><!-- since we've just collected newlines, so we
-   have none of those, and we've failed to collect anything that's not
-   a newline, so we have none of that either, meaning we have nothing.
-   -->.)</p></li>
-
-   <li>
-    <p><i>Cue creation</i>: Let <var title="">cue</var> be a new
-    <a>text track cue</a> and initialize it with the following
-    attribute values:</p>
-
-    <ol>
-     <li><p>Let <var title="">cue</var>'s <a>text track cue identifier</a> be the empty string.</p></li>
-
-     <li><p>Let <var title="">cue</var>'s <a>text track cue pause-on-exit flag</a> be false.</p></li>
-
-     <li><p>Let <var title="">cue</var>'s <a>text track cue region</a> be null.</p></li>
-
-     <li><p>Let <var title="">cue</var>'s <a>text track cue writing direction</a> be
-     <a title="text track cue horizontal writing direction">horizontal</a>.</p></li>
-
-     <li><p>Let <var title="">cue</var>'s <a>text track cue snap-to-lines flag</a> be true.</p></li>
-
-     <li><p>Let <var title="">cue</var>'s <a>text track cue line position</a> be
-     <a title="text track cue automatic line position">auto</a>.</p></li>
-
-     <li><p>Let <var title="">cue</var>'s <a>text track cue line alignment</a> be
-     <a title="text track cue line start alignment">start alignment</a>.</p></li>
-
-     <li><p>Let <var title="">cue</var>'s <a>text track cue text position</a> be 50.</p></li>
-
-     <li><p>Let <var title="">cue</var>'s <a title="">text track cue text position alignment</a> be
-     <a title="text track cue text position alignment">middle alignment</a>.</p></li>
-
-     <li><p>Let <var title="">cue</var>'s <a>text track cue size</a> be 100.</p></li>
-
-     <li><p>Let <var title="">cue</var>'s <a>text track cue text alignment</a> be
-     <a title="text track cue middle alignment">middle alignment</a>.</p></li>
-
-     <li><p>Let <var title="">cue</var>'s <a>text track cue text</a> be the empty string.</p></li>
-    </ol>
-
-   </li>
-
-   <li><p>If <var title="">line</var> contains the three-character
-   substring "<code title="">--></code>" (U+002D HYPHEN-MINUS, U+002D
-   HYPHEN-MINUS, U+003E GREATER-THAN SIGN), then jump to the step
-   labeled <i>timings</i> below.</p></li>
-
-   <li><p>Let <var title="">cue</var>'s <a>text track cue
-   identifier</a> be <var title="">line</var>.</p></li>
-
-   <li><p>If <var title="">position</var> is past the end of <var
-   title="">input</var>, then discard <var title="">cue</var> and jump
-   to the step labeled <i>end</i>.</p></li>
-
-   <li><p>If the character indicated by <var title="">position</var>
-   is a U+000A LINE FEED (LF) character, advance <var
-   title="">position</var> to the next character in <var
-   title="">input</var>.</p></li>
-
-   <li><p><a>Collect a sequence of characters</a> that are
-   <em>not</em> U+000A LINE FEED (LF) characters. Let <var
-   title="">line</var> be those characters, if any.</p></li>
-
-   <li><p>If <var title="">line</var> is the empty string, then
-   discard <var title="">cue</var> and jump to the step labeled <i>cue
-   loop</i>.</p></li>
-
-   <li><p><i>Timings</i>: Unset the <var title="">already collected
-   line</var> flag.</p></li>
-
-   <li><p><a>Collect WebVTT cue timings and settings</a> from
-   <var title="">line</var> using <var title="">regions</var>
-   for <var title="">cue</var>. If that fails, jump to the step
-   labeled <i>bad cue</i>.</p></li>
-
-   <li><p>Let <var title="">cue text</var> be the empty
-   string.</p></li>
-
-   <li><p><i>Cue text loop</i>: If <var title="">position</var> is
-   past the end of <var title="">input</var>, then jump to the step
-   labeled <i>cue text processing</i>.</p></li>
-
-   <li><p>If the character indicated by <var title="">position</var>
-   is a U+000A LINE FEED (LF) character, advance <var
-   title="">position</var> to the next character in <var
-   title="">input</var>.</p></li>
-
-   <li><p><a>Collect a sequence of characters</a> that are
-   <em>not</em> U+000A LINE FEED (LF) characters. Let <var
-   title="">line</var> be those characters, if any.</p></li>
-
-   <li><p>If <var title="">line</var> is the empty string, then jump
-   to the step labeled <i>cue text processing</i>.</p></li>
-
-   <li><p>If <var title="">line</var> contains the three-character
-   substring "<code title="">--></code>" (U+002D HYPHEN-MINUS, U+002D
-   HYPHEN-MINUS, U+003E GREATER-THAN SIGN), then set the <var
-   title="">already collected line</var> flag and jump to the step
-   labeled <i>cue text processing</i>.</p></li>
-
-   <li><p>If <var title="">cue text</var> is not empty, append a
-   U+000A LINE FEED (LF) character to <var title="">cue
-   text</var>.</p></li>
-
-   <li><p>Let <var title="">cue text</var> be the concatenation of
-   <var title="">cue text</var> and <var title="">line</var>.</p></li>
-
-   <li><p>Return to the step labeled <i>cue text loop</i>.</p></li>
-
-   <li><p><i>Cue text processing</i>: Let the <a>text track cue text</a> of <var
-   title="">cue</var> be <var title="">cue text</var>, and let the <a>rules for rendering the cue
-   in isolation</a> be the <a>rules for interpreting WebVTT cue text</a>.</p></li>
-
-   <li><p>Add <var title="">cue</var> to the <a>text track list of
-   cues</a> <var title="">output</var>.</p></li>
-
-   <li><p>Jump to the step labeled <i>cue loop</i>.</p></li>
-
-   <li><p><i>Bad cue</i>: Discard <var title="">cue</var>.</p></li>
-
-   <li><p><i>Bad cue loop</i>: If <var title="">position</var> is
-   past the end of <var title="">input</var>, then jump to the step
-   labeled <i>end</i>.</p></li>
-
-   <li><p>If the character indicated by <var title="">position</var>
-   is a U+000A LINE FEED (LF) character, advance <var
-   title="">position</var> to the next character in <var
-   title="">input</var>.</p></li>
-
-   <li><p><a>Collect a sequence of characters</a> that are
-   <em>not</em> U+000A LINE FEED (LF) characters. Let <var
-   title="">line</var> be those characters, if any.</p></li>
-
-   <li><p>If <var title="">line</var> contains the three-character
-   substring "<code title="">--></code>" (U+002D HYPHEN-MINUS, U+002D
-   HYPHEN-MINUS, U+003E GREATER-THAN SIGN), then set the <var
-   title="">already collected line</var> flag and jump to the step
-   labeled <i>cue loop</i>.</p></li>
-
-   <li><p>If <var title="">line</var> is the empty string, then jump
-   to the step labeled <i>cue loop</i>.</p></li>
-
-   <li><p>Otherwise, jump to the step labeled <i>bad cue
-   loop</i>.</p></li>
-
-   <li><p><i>End</i>: The file has ended. Abort these steps. The
-   <a>WebVTT parser</a> has finished. The file was successfully
-   processed.</p></li>
-
+    <li>
+      <p>
+        Let <var title="">input</var> be the string being parsed, after
+        conversion to Unicode, and with the following transformations
+        applied:
+      </p>
+
+      <ul>
+        <li>
+          <p>
+            Replace all U+0000 NULL characters by U+FFFD REPLACEMENT
+            CHARACTERs.
+          </p>
+        </li>
+
+        <li>
+          <p>
+            Replace each U+000D CARRIAGE RETURN U+000A LINE FEED (CRLF)
+            character pair by a single U+000A LINE FEED (LF) character.
+          </p>
+        </li>
+
+        <li>
+          <p>
+            Replace all remaining U+000D CARRIAGE RETURN characters by
+            U+000A LINE FEED (LF) characters.
+          </p>
+        </li>
+      </ul>
+
+    </li>
+
+    <li>
+      <p>
+        Let <var title="">position</var> be a pointer into
+        <var title="">input</var>, initially pointing at the start of the
+        string. In an <a>incremental WebVTT parser</a>, when this algorithm (or
+        further algorithms that it uses) moves the <var title="">position</var>
+        pointer, the user agent must wait until appropriate further characters
+        from the byte stream have been added to <var title="">input</var> before
+        moving the pointer, so that the algorithm never reads past the end of
+        the <var title="">input</var> string. Once the byte stream has ended,
+        and all characters have been added to <var title="">input</var>, then
+        the <var title="">position</var> pointer may, when so instructed by the
+        algorithms, be moved past the end of <var title="">input</var>.
+      </p>
+    </li>
+
+    <li>
+      <p>
+        Let <var title="">line</var> be a string variable. Unset the
+        <var title="">already collected line</var> flag.
+      </p>
+    </li>
+
+    <!-- SIGNATURE CHECK -->
+
+    <li>
+      <p>
+        <a>Collect a sequence of characters</a> that are <em>not</em> U+000A
+        LINE FEED (LF) characters. Let <var title="">line</var> be those
+        characters, if any.
+      </p>
+    </li>
+
+    <li>
+      <p>
+        If <var title="">line</var> is less than six characters long, then abort
+        these steps. The file does not start with the correct <a>WebVTT file</a>
+        signature and was therefore not successfully processed.
+      </p>
+    </li>
+
+    <li>
+      <p>
+        If <var title="">line</var> is exactly six characters long but does not
+        exactly equal "<code title="">WEBVTT</code>", then abort these steps.
+        The file does not start with the correct <a>WebVTT file</a> signature
+        and was therefore not successfully processed.
+      </p>
+    </li>
+
+    <li>
+      <p>
+        If <var title="">line</var> is more than six characters long but the
+        first six characters do not exactly equal
+        "<code title="">WEBVTT</code>", or the seventh character is neither a
+        U+0020 SPACE character nor a U+0009 CHARACTER TABULATION (tab)
+        character, then abort these steps. The file does not start with the
+        correct <a>WebVTT file</a> signature and was therefore not successfully
+        processed.
+      </p>
+    </li>
+
+    <li>
+      <p>
+        If <var title="">position</var> is past the end of
+        <var title="">input</var>, then abort these steps. The file was
+        successfully processed, but it contains no useful data and so no
+        <a title="text track cue">text track cues</a> where added to
+        <var title="">output</var>.
+      </p>
+    </li>
+
+    <li>
+      <p>
+        The character indicated by <var title="">position</var> is a U+000A LINE
+        FEED (LF) character. Advance <var title="">position</var> to the next
+        character in <var title="">input</var>.
+      </p>
+    </li>
+
+    <li>
+      <p>
+        <i title="">Header</i>: <a>Collect a sequence of characters</a> that are
+        <em>not</em> U+000A LINE FEED (LF) characters. Let
+        <var title="">line</var> be those characters, if any.
+      </p>
+    </li>
+
+    <!-- METADATA HEADER PARSING -->
+
+    <li>
+      <p>
+        Let <var title="">regions</var> be a
+        <a>text track list of regions</a>.
+      </p>
+    </li>
+
+    <li>
+      <i>Metadata header loop</i>: If <var>line</var> is not the empty string,
+      run the following substeps:
+
+      <ol>
+        <li>
+          <p>
+            <i>Metadata header creation</i>: Let <var>metadata</var> be a new
+            <a>WebVTT metadata header</a>.
+          </p>
+        </li>
+
+        <li>
+          <p>
+            Let <a title="WebVTT metadata header name">metadata's name</a> be
+            the empty string.
+          </p>
+        </li>
+
+        <li>
+          <p>
+            Let <a title="WebVTT metadata header value">metadata's value</a>
+            be the empty string.
+          </p>
+        </li>
+
+        <li>
+          <p>
+            If <var>line</var> contains the character ":" (A U+003A COLON),
+            then set
+            <a title="WebVTT metadata header name">metadata's name</a> to the
+            substring of <var>line</var> before the first ":" character and
+            <a title="WebVTT metadata header value">metadata's value</a> to
+            the substring after this character.
+          </p>
+        </li>
+
+        <li>
+          If <a title="WebVTT metadata header name">metadata's name</a> equals
+          "Region":
+
+          <ol>
+            <li>
+              <p>
+                <i>Region creation</i>: Let <var>region</var> be a new
+                <a>text track region</a>.
+              </p>
+            </li>
+            <li>
+              <p>
+                Let <var>region</var>'s
+                <a title="text track region identifier">identifier</a> be the
+                empty string.
+              </p>
+            </li>
+            <li>
+              <p>
+                Let <var>region</var>'s
+                <a title="text track region width">width</a> be 100.
+              </p>
+            </li>
+            <li>
+              <p>
+                Let <var>region</var>'s
+                <a title="text track region lines">lines</a> be 3.
+              </p>
+            </li>
+            <li>
+              <p>
+                Let <var>region</var>'s
+                <a title="text track region anchor">anchor point</a> be
+                (0,100).
+              </p>
+            </li>
+            <li>
+              <p>
+                Let <var>region</var>'s
+                <a title="text track region viewport anchor">viewport anchor point</a>
+                be (0,100).
+              </p>
+            </li>
+            <li>
+              <p>
+                Let <var>region</var>'s
+                <a title="text track region scroll">scroll value</a> be
+                <a title="text track region scroll none">NONE</a>.
+              </p>
+            </li>
+            <li>
+              <p>
+                <a>Collect WebVTT region settings</a> from
+                <a title="WebVTT metadata header value">metadata's value</a>
+                using <var>region</var> for the results.
+              </p>
+            </li>
+            <li>
+              <p>
+                <i>Region processing</i>: Construct a
+                <a>WebVTT Region Object</a> from <var>region</var>.
+              </p>
+            </li>
+            <li>
+              <p>
+                Append <var>region</var> to the
+                <a>text track list of regions</a> <var>regions</var>.
+              </p>
+            </li>
+          </ol>
+        </li>
+      </ol>
+    </li>
+
+    <!-- FIXME: right now ignores all WebVTT metadata headers that don't specify regions. -->
+
+    <li>
+      <p>
+        If <var title="">position</var> is past the end of
+        <var title="">input</var>, then jump to the step labeled
+        <i>end</i>.
+      </p>
+    </li>
+
+    <li>
+      <p>
+        The character indicated by <var title="">position</var> is a U+000A
+        LINE FEED (LF) character. Advance <var title="">position</var> to the
+        next character in <var title="">input</var>.
+      </p>
+    </li>
+
+    <li>
+      <p>
+        If <var title="">line</var> contains the three-character substring
+        "<code title="">--></code>" (U+002D HYPHEN-MINUS, U+002D HYPHEN-MINUS,
+        U+003E GREATER-THAN SIGN), then set the
+        <var title="">already collected line</var> flag and jump to the step
+        labeled <i>cue loop</i>.
+      </p>
+    </li>
+
+    <li>
+      <p>
+        If <var title="">line</var> is not the empty string, then jump back to
+        the step labeled <i title="">header</i>.
+      </p>
+    </li>
+
+    <!-- Cue loop -->
+
+    <li>
+      <p>
+        <i>Cue loop</i>: If the <var title="">already collected line</var>
+        flag is set, then jump to the step labeled
+        <var title="">cue creation</var>.
+      </p>
+    </li>
+
+    <li>
+      <p>
+        <a>Collect a sequence of characters</a> that are U+000A LINE FEED (LF)
+        characters.
+      </p>
+    </li>
+
+    <li>
+      <p>
+        <a>Collect a sequence of characters</a> that are <em>not</em> U+000A
+        LINE FEED (LF) characters. Let <var title="">line</var> be those
+        characters, if any.
+      </p>
+    </li>
+
+    <li>
+      <p>
+        If <var title="">line</var> is the empty string, then jump to the step
+        labeled <i>end</i>. (In such a case, <var title="">position</var> is
+        also forcibly past the end of <var title="">input</var><!-- since
+        we've just collected newlines, so we have none of those, and we've
+        failed to collect anything that's not a newline, so we have none of
+        that either, meaning we have nothing. -->.)
+      </p>
+    </li>
+
+    <li>
+      <i>Cue creation</i>: Let <var title="">cue</var> be a new
+      <a>text track cue</a> and initialize it with the following attribute
+      values:
+
+      <ol>
+        <li>
+          <p>
+            Let <var title="">cue</var>'s <a>text track cue identifier</a> be
+            the empty string.
+          </p>
+        </li>
+
+        <li>
+          <p>
+            Let <var title="">cue</var>'s
+            <a>text track cue pause-on-exit flag</a> be false.
+          </p>
+        </li>
+
+        <li>
+          <p>
+            Let <var title="">cue</var>'s <a>text track cue region</a> be
+            null.
+          </p>
+        </li>
+
+        <li>
+          <p>
+            Let <var title="">cue</var>'s
+            <a>text track cue writing direction</a> be
+            <a title="text track cue horizontal writing direction">horizontal</a>.
+          </p>
+        </li>
+
+        <li>
+          <p>
+            Let <var title="">cue</var>'s
+            <a>text track cue snap-to-lines flag</a> be true.
+          </p>
+        </li>
+
+        <li>
+          <p>
+            Let <var title="">cue</var>'s <a>text track cue line position</a>
+            be <a title="text track cue automatic line position">auto</a>.
+          </p>
+        </li>
+
+        <li>
+          <p>
+            Let <var title="">cue</var>'s <a>text track cue line alignment</a>
+            be
+            <a title="text track cue line start alignment">start alignment</a>.
+          </p>
+        </li>
+
+        <li>
+          <p>
+            Let <var title="">cue</var>'s <a>text track cue text position</a>
+            be 50.
+          </p>
+        </li>
+
+        <li>
+          <p>
+            Let <var title="">cue</var>'s
+            <a title="">text track cue text position alignment</a> be
+            <a title="text track cue text position alignment">middle alignment</a>.
+          </p>
+        </li>
+
+        <li>
+          <p>
+            Let <var title="">cue</var>'s <a>text track cue size</a> be
+            100.
+          </p>
+        </li>
+
+        <li>
+          <p>
+            Let <var title="">cue</var>'s <a>text track cue text alignment</a>
+            be
+            <a title="text track cue middle alignment">middle alignment</a>.
+          </p>
+        </li>
+
+        <li>
+          <p>
+            Let <var title="">cue</var>'s <a>text track cue text</a> be the
+            empty string.
+          </p>
+        </li>
+      </ol>
+    </li>
+
+    <li>
+      <p>
+        If <var title="">line</var> contains the three-character substring
+        "<code title="">--></code>" (U+002D HYPHEN-MINUS, U+002D HYPHEN-MINUS,
+        U+003E GREATER-THAN SIGN), then jump to the step labeled
+        <i>timings</i> below.
+      </p>
+    </li>
+
+    <li>
+      <p>
+        Let <var title="">cue</var>'s <a>text track cue identifier</a> be
+        <var title="">line</var>.
+      </p>
+    </li>
+
+    <li>
+      <p>
+        If <var title="">position</var> is past the end of
+        <var title="">input</var>, then discard <var title="">cue</var> and
+        jump to the step labeled <i>end</i>.
+      </p>
+    </li>
+
+    <li>
+      <p>
+        If the character indicated by <var title="">position</var> is a U+000A
+        LINE FEED (LF) character, advance <var title="">position</var> to the
+        next character in <var title="">input</var>.
+      </p>
+    </li>
+
+    <li>
+      <p>
+        <a>Collect a sequence of characters</a> that are <em>not</em> U+000A
+        LINE FEED (LF) characters. Let <var title="">line</var> be those
+        characters, if any.
+      </p>
+    </li>
+
+    <li>
+      <p>
+        If <var title="">line</var> is the empty string, then discard
+        <var title="">cue</var> and jump to the step labeled
+        <i>cue loop</i>.
+      </p>
+    </li>
+
+    <li>
+      <p>
+        <i>Timings</i>: Unset the <var title="">already collected line</var>
+        flag.
+      </p>
+    </li>
+
+    <li>
+      <p>
+        <a>Collect WebVTT cue timings and settings</a> from
+        <var title="">line</var> using <var title="">regions</var>
+        for <var title="">cue</var>. If that fails, jump to the step
+        labeled <i>bad cue</i>.
+      </p>
+    </li>
+
+    <li>
+      <p>Let <var title="">cue text</var> be the empty string.</p>
+    </li>
+
+    <li>
+      <p>
+        <i>Cue text loop</i>: If <var title="">position</var> is past the end
+        of <var title="">input</var>, then jump to the step labeled
+        <i>cue text processing</i>.
+      </p>
+    </li>
+
+    <li>
+      <p>
+        If the character indicated by <var title="">position</var> is a U+000A
+        LINE FEED (LF) character, advance <var title="">position</var> to the
+        next character in <var title="">input</var>.
+      </p>
+    </li>
+
+    <li>
+      <p>
+        <a>Collect a sequence of characters</a> that are <em>not</em> U+000A
+        LINE FEED (LF) characters. Let <var title="">line</var> be those
+        characters, if any.
+      </p>
+    </li>
+
+    <li>
+      <p>
+        If <var title="">line</var> is the empty string, then jump to the step
+        labeled <i>cue text processing</i>.
+      </p>
+    </li>
+
+    <li>
+      <p>
+        If <var title="">line</var> contains the three-character substring
+        "<code title="">--></code>" (U+002D HYPHEN-MINUS, U+002D HYPHEN-MINUS,
+        U+003E GREATER-THAN SIGN), then set the
+        <var title="">already collected line</var> flag and jump to the step
+        labeled <i>cue text processing</i>.
+      </p>
+    </li>
+
+    <li>
+      <p>
+        If <var title="">cue text</var> is not empty, append a U+000A LINE
+        FEED (LF) character to <var title="">cue text</var>.
+      </p>
+    </li>
+
+    <li>
+      <p>
+        Let <var title="">cue text</var> be the concatenation of
+        <var title="">cue text</var> and <var title="">line</var>.
+      </p>
+    </li>
+
+    <li><p>Return to the step labeled <i>cue text loop</i>.</p></li>
+
+    <li>
+      <p>
+        <i>Cue text processing</i>: Let the <a>text track cue text</a> of
+        <var title="">cue</var> be <var title="">cue text</var>, and let the
+        <a>rules for rendering the cue in isolation</a> be the
+        <a>rules for interpreting WebVTT cue text</a>.
+      </p>
+    </li>
+
+    <li>
+      <p>
+        Add <var title="">cue</var> to the <a>text track list of cues</a>
+        <var title="">output</var>.
+      </p>
+    </li>
+
+    <li><p>Jump to the step labeled <i>cue loop</i>.</p></li>
+
+    <li><p><i>Bad cue</i>: Discard <var title="">cue</var>.</p></li>
+
+    <li>
+      <p>
+        <i>Bad cue loop</i>: If <var title="">position</var> is past the end
+        of <var title="">input</var>, then jump to the step labeled <i>end</i>.
+      </p>
+    </li>
+
+    <li>
+      <p>
+        If the character indicated by <var title="">position</var> is a U+000A
+        LINE FEED (LF) character, advance <var title="">position</var> to the
+        next character in <var title="">input</var>.
+      </p>
+    </li>
+
+    <li>
+      <p>
+        <a>Collect a sequence of characters</a> that are <em>not</em> U+000A
+        LINE FEED (LF) characters. Let <var title="">line</var> be those
+        characters, if any.
+      </p>
+    </li>
+
+    <li>
+      <p>
+        If <var title="">line</var> contains the three-character substring
+        "<code title="">--></code>" (U+002D HYPHEN-MINUS, U+002D HYPHEN-MINUS,
+        U+003E GREATER-THAN SIGN), then set the
+        <var title="">already collected line</var> flag and jump to the step
+        labeled <i>cue loop</i>.
+      </p>
+    </li>
+
+    <li>
+      <p>
+        If <var title="">line</var> is the empty string, then jump to the step
+        labeled <i>cue loop</i>.
+      </p>
+    </li>
+
+    <li><p>Otherwise, jump to the step labeled <i>bad cue loop</i>.</p></li>
+
+    <li>
+      <p>
+        <i>End</i>: The file has ended. Abort these steps. The
+        <a>WebVTT parser</a> has finished. The file was successfully
+        processed.
+      </p>
+    </li>
   </ol>
 
-  </section>
+  </section><!-- END: WebVTT file parsing -->
 
   <section>
   <h3>WebVTT region settings parsing</h3>
 
-  <p>When the <a>WebVTT parser</a> requires that the user agent <dfn>collect WebVTT region settings</dfn> from a string <var>input</var> for a <a>text track</a>, the user agent must run the following algorithm.</p>
+  <p>
+    When the <a>WebVTT parser</a> requires that the user agent
+    <dfn>collect WebVTT region settings</dfn> from a string <var>input</var>
+    for a <a>text track</a>, the user agent must run the following algorithm.
+  </p>
 
-  <p>A <dfn>WebVTT region object</dfn> is a conceptual construct to represent a <a>WebVTT region</a> that is used as a root node for <a title="List of WebVTT node objects">lists of WebVTT node objects</a>. This algorithm returns a list of <a title="WebVTT region object">WebVTT Region Objects</a>.</p>
+  <p>
+    A <dfn>WebVTT region object</dfn> is a conceptual construct to represent a
+    <a>WebVTT region</a> that is used as a root node for
+    <a title="List of WebVTT node objects">lists of WebVTT node objects</a>.
+    This algorithm returns a list of
+    <a title="WebVTT region object">WebVTT Region Objects</a>.
+  </p>
 
   <ol>
-    <li><p>Let <var>settings</var> be the result of <a title="split a string on spaces">splitting <var>input</var> on spaces</a>.</p></li>
+    <li>
+      <p>
+        Let <var>settings</var> be the result of
+        <a title="split a string on spaces">splitting <var>input</var> on spaces</a>.
+      </p>
+    </li>
 
     <li>
-      For each token <var>setting</var> in the list <var>settings</var>, run the following substeps:
+      For each token <var>setting</var> in the list <var>settings</var>, run the
+      following substeps:
 
       <ol>
-        <li><p>If <var>setting</var> does not contain a U+003D EQUALS SIGN character (=), or if the first U+003D EQUALS SIGN character (=) in <var>setting</var> is either the first or last character of <var>setting</var>, then jump to the step labeled <i>next setting</i>.</p></li>
-
-        <li><p>Let <var>name</var> be the leading substring of <var>setting</var> up to and excluding the first U+003D EQUALS SIGN character (=) in that string.</p></li>
-
-        <li><p>Let <var>value</var> be the trailing substring of <var>setting</var> starting from the character immediately after the first U+003D EQUALS SIGN character (=) in that string.</p></li>
-
         <li>
-        <p>Run the appropriate substeps that apply for the value of <var>name</var>, as follows:</p>
-
-        <dl>
-          <dt><p>If <var>name</var> is a <a>case-sensitive</a> match for "<code>id</code>"</p></dt>
-          <dd><p>Let <var>region</var>'s <a title="text track region identifier">identifier</a> be <var>value</var>.</p>
-          </dd>
-
-          <dt><p>Otherwise if <var>name</var> is a <a>case-sensitive</a> match for "<code>width</code>"</p></dt>
-          <dd><p>If <a>parse a percentage string</a> from <var>value</var> returns a <var>percentage</var>, let <var>region</var>'s <a>text track region width</a> be <var>percentage</var>.</p>
-          </dd>
-
-          <dt>Otherwise if <var>name</var> is a <a>case-sensitive</a> match for "<code>lines</code>"</dt>
-          <dd>
-            <ol>
-              <li><p>If <var>value</var> contains any characters other than <a>ASCII digits</a>, then jump to the step labeled <i>next setting</i>.</p></li>
-
-              <li><p>Interpret <var>value</var> as an integer, and let <var>number</var> be that number.</p></li>
-
-              <li><p>Let <var>region</var>'s <a>text track region lines</a> be <var>number</var>.</p></li>
-            </ol>
-          </dd>
-
-          <dt>Otherwise if <var>name</var> is a <a>case-sensitive</a> match for "<code>regionanchor</code>"</dt>
-          <dd>
-            <ol>
-              <li><p>If <var>value</var> does not contain a U+002C COMMA character (,), then jump to the step labeled <i>next setting</i>.</p></li>
-
-              <li><p>Let <var>anchorX</var> be the leading substring of <var>value</var> up to and excluding the first U+002C COMMA character (,) in that string.</p></li>
-
-              <li><p>Let <var>anchorY</var> be the trailing substring of <var>value</var> starting from the character immediately after the first U+002C COMMA character (,) in that string.</p></li>
-
-              <li><p>If <a>parse a percentage string</a> from <var>anchorX</var> or <a>parse a percentage string</a> from <var>anchorY</var> don't return a <var>percentage</var>, then jump to the step labeled <i>next setting</i>.</p></li>
-
-              <li><p>Let <var>region</var>'s <a title="text track region anchor">text track region anchor point</a> be the tuple of the <var>percentage</var> values calculated from <var>anchorX</var> and <var>anchorY</var>.</p></li>
-            </ol>
-          </dd>
-
-          <dt>Otherwise if <var>name</var> is a <a>case-sensitive</a> match for "<code>viewportanchor</code>"</dt>
-          <dd>
-            <ol>
-              <li><p>If <var>value</var> does not contain a U+002C COMMA character (,), then jump to the step labeled <i>next setting</i>.</p></li>
-
-              <li><p>Let <var>viewportanchorX</var> be the leading substring of <var>value</var> up to and excluding the first U+002C COMMA character (,) in that string.</p></li>
-
-              <li><p>Let <var>viewportanchorY</var> be the trailing substring of <var>value</var> starting from the character immediately after the first U+002C COMMA character (,) in that string.</p></li>
-
-              <li><p>If <a>parse a percentage string</a> from <var>viewportanchorX</var> or <a>parse a percentage string</a> from <var>viewportanchorY</var> don't return a <var>percentage</var>, then jump to the step labeled <i>next setting</i>.</p></li>
-
-              <li><p>Let <var>region</var>'s <a title="text track region viewport anchor">text track region viewport anchor point</a> be the tuple of the <var>percentage</var> values calculated from <var>viewportanchorX</var> and <var>viewportanchorY</var>.</p></li>
-            </ol>
-          </dd>
-
-          <dt>Otherwise if <var>name</var> is a <a>case-sensitive</a> match for "<code>scroll</code>"</dt>
-          <dd>
-            <ol>
-              <li><p>If <var>value</var> is a <a>case-sensitive</a> match for the string "<code>up</code>", then let <var>region</var>'s <a title="text track region scroll">scroll value</a> be "<a title="text track region scroll up">scroll up</a>".</p></li>
-           </ol>
-          </dd>
-        </dl>
+          <p>
+            If <var>setting</var> does not contain a U+003D EQUALS SIGN
+            character (=), or if the first U+003D EQUALS SIGN character (=) in
+            <var>setting</var> is either the first or last character of
+            <var>setting</var>, then jump to the step labeled
+            <i>next setting</i>.
+          </p>
         </li>
 
-        <li><i>Next setting</i>: Continue to the next setting, if any.</li>
+        <li>
+          <p>
+            Let <var>name</var> be the leading substring of <var>setting</var>
+            up to and excluding the first U+003D EQUALS SIGN character (=) in
+            that string.
+          </p>
+        </li>
+
+        <li>
+          <p>
+            Let <var>value</var> be the trailing substring of <var>setting</var>
+            starting from the character immediately after the first U+003D
+            EQUALS SIGN character (=) in that string.
+          </p>
+        </li>
+
+        <li>
+          Run the appropriate substeps that apply for the value of
+          <var>name</var>, as follows:
+
+          <dl>
+            <dt>
+              If <var>name</var> is a <a>case-sensitive</a> match for
+              "<code>id</code>"
+            </dt>
+            <dd>
+              <p>
+                Let <var>region</var>'s
+                <a title="text track region identifier">identifier</a> be
+                <var>value</var>.
+              </p>
+            </dd>
+
+            <dt>
+              Otherwise if <var>name</var> is a <a>case-sensitive</a> match
+              for "<code>width</code>"
+            </dt>
+            <dd>
+              <p>
+                If <a>parse a percentage string</a> from <var>value</var>
+                returns a <var>percentage</var>, let <var>region</var>'s
+                <a>text track region width</a> be <var>percentage</var>.
+              </p>
+            </dd>
+
+            <dt>
+              Otherwise if <var>name</var> is a <a>case-sensitive</a> match for
+              "<code>lines</code>"
+            </dt>
+            <dd>
+              <ol>
+                <li>
+                  <p>
+                    If <var>value</var> contains any characters other than
+                    <a>ASCII digits</a>, then jump to the step labeled
+                    <i>next setting</i>.
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    Interpret <var>value</var> as an integer, and let
+                    <var>number</var> be that number.
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    Let <var>region</var>'s <a>text track region lines</a> be
+                    <var>number</var>.
+                  </p>
+                </li>
+              </ol>
+            </dd>
+
+            <dt>
+              Otherwise if <var>name</var> is a <a>case-sensitive</a> match for
+              "<code>regionanchor</code>"
+            </dt>
+            <dd>
+              <ol>
+                <li>
+                  <p>
+                    If <var>value</var> does not contain a U+002C COMMA
+                    character (,), then jump to the step labeled
+                    <i>next setting</i>.
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    Let <var>anchorX</var> be the leading substring of
+                    <var>value</var> up to and excluding the first U+002C COMMA
+                    character (,) in that string.
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    Let <var>anchorY</var> be the trailing substring of
+                    <var>value</var> starting from the character immediately
+                    after the first U+002C COMMA character (,) in that
+                    string.
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    If <a>parse a percentage string</a> from <var>anchorX</var>
+                    or <a>parse a percentage string</a> from <var>anchorY</var>
+                    don't return a <var>percentage</var>, then jump to the step
+                    labeled <i>next setting</i>.
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    Let <var>region</var>'s
+                    <a title="text track region anchor">text track region anchor point</a>
+                    be the tuple of the <var>percentage</var> values calculated
+                    from <var>anchorX</var> and <var>anchorY</var>.
+                  </p>
+                </li>
+              </ol>
+            </dd>
+
+            <dt>
+              Otherwise if <var>name</var> is a <a>case-sensitive</a> match for
+              "<code>viewportanchor</code>"
+            </dt>
+            <dd>
+              <ol>
+                <li>
+                  <p>
+                    If <var>value</var> does not contain a U+002C COMMA
+                    character (,), then jump to the step labeled
+                    <i>next setting</i>.
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    Let <var>viewportanchorX</var> be the leading substring of
+                    <var>value</var> up to and excluding the first U+002C COMMA
+                    character (,) in that string.
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    Let <var>viewportanchorY</var> be the trailing substring of
+                    <var>value</var> starting from the character immediately
+                    after the first U+002C COMMA character (,) in that
+                    string.
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    If <a>parse a percentage string</a> from
+                    <var>viewportanchorX</var> or
+                    <a>parse a percentage string</a> from
+                    <var>viewportanchorY</var> don't return a
+                    <var>percentage</var>, then jump to the step labeled
+                    <i>next setting</i>.
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    Let <var>region</var>'s
+                    <a title="text track region viewport anchor">text track region viewport anchor point</a>
+                    be the tuple of the <var>percentage</var> values calculated
+                    from <var>viewportanchorX</var> and
+                    <var>viewportanchorY</var>.
+                  </p>
+                </li>
+              </ol>
+            </dd>
+
+            <dt>
+              Otherwise if <var>name</var> is a <a>case-sensitive</a> match for
+              "<code>scroll</code>"
+            </dt>
+            <dd>
+              <ol>
+                <li>
+                  <p>
+                    If <var>value</var> is a <a>case-sensitive</a> match for the
+                    string "<code>up</code>", then let <var>region</var>'s
+                    <a title="text track region scroll">scroll value</a> be
+                    "<a title="text track region scroll up">scroll up</a>".
+                  </p>
+                </li>
+              </ol>
+            </dd>
+          </dl>
+        </li>
+
+        <li>
+          <p><i>Next setting</i>: Continue to the next setting, if any.</p>
+        </li>
       </ol>
     </li>
   </ol>
 
-  <p>The rules to <dfn>parse a percentage string</dfn> are as follows. This will return either a
-  number in the range 0..100, or nothing. If at any point the algorithm says that it "fails", this
-  means that it is aborted at that point and returns nothing.</p>
+  <p>
+    The rules to <dfn>parse a percentage string</dfn> are as follows. This will
+    return either a number in the range 0..100, or nothing. If at any point the
+    algorithm says that it "fails", this means that it is aborted at that point
+    and returns nothing.
+  </p>
 
   <ol>
-   <li><p>Let <var>input</var> be the string being parsed.</p></li>
+    <li><p>Let <var>input</var> be the string being parsed.</p></li>
 
-   <li><p>If <var>input</var> contains any characters other than U+0025 PERCENT SIGN characters (%), U+002E DOT characters (.) and <a>ASCII digits</a>, then fail.</p></li>
+    <li>
+      <p>
+        If <var>input</var> contains any characters other than U+0025 PERCENT
+        SIGN characters (%), U+002E DOT characters (.) and <a>ASCII digits</a>,
+        then fail.
+      </p>
+    </li>
 
-   <li><p>If <var>input</var> does not contain at least one <a title="ASCII digits">ASCII digit</a>, then fail.</p></li>
+    <li>
+      <p>
+        If <var>input</var> does not contain at least one
+        <a title="ASCII digits">ASCII digit</a>, then fail.
+      </p>
+    </li>
 
-   <li><p>If <var>input</var> contains more than one U+002E DOT character (.), then fail.</p></li>
+    <li>
+      <p>
+        If <var>input</var> contains more than one U+002E DOT character (.),
+        then fail.
+      </p>
+    </li>
 
-   <li><p>If any character in <var>input</var> other than the last character is a U+0025 PERCENT SIGN character (%), then fail.</p></li>
+    <li>
+      <p>
+        If any character in <var>input</var> other than the last character is a
+        U+0025 PERCENT SIGN character (%), then fail.
+      </p>
+    </li>
 
-   <li><p>If the last character in <var>input</var> is not a U+0025 PERCENT SIGN character (%), then fail.</p></li>
+    <li>
+      <p>
+        If the last character in <var>input</var> is not a U+0025 PERCENT SIGN
+        character (%), then fail.
+      </p>
+    </li>
 
-   <li><p>Ignoring the trailing percent sign, interpret <var>input</var> as a real number. Let that number be the <var>percentage</var>.</p></li>
+    <li>
+      <p>
+        Ignoring the trailing percent sign, interpret <var>input</var> as a real
+        number. Let that number be the <var>percentage</var>.
+      </p>
+    </li>
 
-   <li><p>If <var>percentage</var> is outside the range 0..100, then fail.</p></li>
+    <li>
+      <p>If <var>percentage</var> is outside the range 0..100, then fail.</p>
+    </li>
 
-   <li><p>Return <var>percentage</var>.</p></li>
+    <li><p>Return <var>percentage</var>.</p></li>
   </ol>
 
-  </section>
+  </section><!-- END: WebVTT region settings parsing -->
 
   <section>
   <h3>WebVTT cue timings and settings parsing</h3>
 
-  <p>When the algorithm above requires that the user agent
-  <dfn>Collect WebVTT cue timings and settings</dfn> from a string
-  <var title="">input</var> using a <a>text track list of
-  regions</a> <var title="">regions</var> for a <a>text track
-  cue</a> <var title="">cue</var>, the user agent must run the
-  following algorithm.</p>
+  <p>
+    When the algorithm above requires that the user agent
+    <dfn>Collect WebVTT cue timings and settings</dfn> from a string
+    <var title="">input</var> using a <a>text track list of regions</a>
+    <var title="">regions</var> for a <a>text track cue</a>
+    <var title="">cue</var>, the user agent must run the following
+    algorithm.
+  </p>
 
   <ol>
+    <li>
+      <p>Let <var title="">input</var> be the string being parsed.</p>
+    </li>
 
-   <li><p>Let <var title="">input</var> be the string being
-   parsed.</p></li>
+    <li>
+      <p>
+        Let <var title="">position</var> be a pointer into
+        <var title="">input</var>, initially pointing at the start of the
+        string.
+      </p>
+    </li>
 
-   <li><p>Let <var title="">position</var> be a pointer into <var
-   title="">input</var>, initially pointing at the start of the
-   string.</p></li>
+    <li><p><a>Skip whitespace</a>.</p></li>
 
-   <li><p><a>Skip whitespace</a>.</p></li>
+    <li>
+      <p>
+        <a>Collect a WebVTT timestamp</a>. If that algorithm fails, then abort
+        these steps and return failure. Otherwise, let <var title="">cue</var>'s
+        <a>text track cue start time</a> be the collected time.
+      </p>
+    </li>
 
-   <li><p><a>Collect a WebVTT timestamp</a>. If that algorithm
-   fails, then abort these steps and return failure. Otherwise, let
-   <var title="">cue</var>'s <a>text track cue start time</a>
-   be the collected time.</p></li>
+    <li><p><a>Skip whitespace</a>.</p></li>
 
-   <li><p><a>Skip whitespace</a>.</p></li>
+    <!-- we can't be beyond the end of the string until we've seen the
+    arrow, since we know the arrow is in the string and nothing we've
+    done so far would move us past the first "-". -->
 
-   <!-- we can't be beyond the end of the string until we've seen the
-   arrow, since we know the arrow is in the string and nothing we've
-   done so far would move us past the first "-". -->
+    <li>
+      <p>
+        If the character at <var title="">position</var> is not a U+002D
+        HYPHEN-MINUS character (-) then abort these steps and return failure.
+        Otherwise, move <var title="">position</var> forwards one
+        character.
+      </p>
+    </li>
 
-   <li><p>If <!--<var title="">position</var> is beyond the end of
-   <var title="">input</var> or if--> the character at <var
-   title="">position</var> is not a U+002D HYPHEN-MINUS character (-)
-   then abort these steps and return failure. Otherwise, move <var
-   title="">position</var> forwards one character.</p></li>
+    <li>
+      <p>
+        If the character at <var title="">position</var> is not a U+002D
+        HYPHEN-MINUS character (-) then abort these steps and return failure.
+        Otherwise, move <var title="">position</var> forwards one
+        character.
+      </p>
+    </li>
 
-   <li><p>If <!--<var title="">position</var> is beyond the end of
-   <var title="">input</var> or if--> the character at <var
-   title="">position</var> is not a U+002D HYPHEN-MINUS character (-)
-   then abort these steps and return failure. Otherwise, move <var
-   title="">position</var> forwards one character.</p></li>
+    <li>
+      <p>
+        If the character at <var title="">position</var> is not a U+003E
+        GREATER-THAN SIGN character (>) then abort these steps and return
+        failure. Otherwise, move <var title="">position</var> forwards one
+        character.
+      </p>
+    </li>
 
-   <li><p>If <!--<var title="">position</var> is beyond the end of
-   <var title="">input</var> or if--> the character at <var
-   title="">position</var> is not a U+003E GREATER-THAN SIGN character
-   (>) then abort these steps and return failure. Otherwise, move <var
-   title="">position</var> forwards one character.</p></li>
+    <li><p><a>Skip whitespace</a>.</p></li>
 
-   <li><p><a>Skip whitespace</a>.</p></li>
+    <li>
+      <p>
+        <a>Collect a WebVTT timestamp</a>. If that algorithm fails, then abort
+        these steps and return failure. Otherwise, let <var title="">cue</var>'s
+        <a>text track cue end time</a> be the collected time.
+      </p>
+    </li>
 
-   <li><p><a>Collect a WebVTT timestamp</a>. If that algorithm
-   fails, then abort these steps and return failure. Otherwise, let
-   <var title="">cue</var>'s <a>text track cue end time</a>
-   be the collected time.</p></li>
+    <li>
+      <p>
+        Let <var title="">remainder</var> be the trailing substring of
+        <var title="">input</var> starting at <var title="">position</var>.
+      </p>
+    </li>
 
-   <li><p>Let <var title="">remainder</var> be the trailing substring
-   of <var title="">input</var> starting at <var
-   title="">position</var>.</p></li>
-
-   <li><p><a>Parse the WebVTT cue settings</a> from
-   <var title="">remainder</var> using <var title="">regions</var> for
-   <var title="">cue</var>.</p></li>
-
+    <li>
+      <p>
+        <a>Parse the WebVTT cue settings</a> from <var title="">remainder</var>
+        using <var title="">regions</var> for <var title="">cue</var>.
+      </p>
+    </li>
   </ol>
 
-  <p>When the user agent is to <dfn>Parse the WebVTT cue settings</dfn>
-  from a string <var title="">input</var> using a <a>text track list of
-  regions</a> <var title="">regions</var> for a <a>text track cue</a>
-  <var title="">cue</var>, the user agent must run the following
-  steps:</p>
+  <p>
+    When the user agent is to <dfn>Parse the WebVTT cue settings</dfn>
+    from a string <var title="">input</var> using a
+    <a>text track list of regions</a> <var title="">regions</var> for a
+    <a>text track cue</a> <var title="">cue</var>, the user agent must run the
+    following steps:
+  </p>
 
   <ol>
+    <li>
+      <p>
+        Let <var title="">settings</var> be the result of
+        <a title="split a string on spaces">splitting <var title="">input</var>
+        on spaces</a>.
+      </p>
+    </li>
 
-   <li><p>Let <var title="">settings</var> be the result of <a
-   title="split a string on spaces">splitting <var
-   title="">input</var> on spaces</a>.</p></li>
+    <li>
+      For each token <var title="">setting</var> in the list
+      <var title="">settings</var>, run the following substeps:
 
-   <li>
+      <ol>
+        <li>
+          <p>
+            If <var title="">setting</var> does not contain a U+003A COLON
+            character (:), or if the first U+003A COLON character (:) in
+            <var title="">setting</var> is either the first or last character of
+            <var title="">setting</var>, then jump to the step labeled
+            <i>next setting</i>.
+          </p>
+        </li>
 
-    <p>For each token <var title="">setting</var> in the list <var
-    title="">settings</var>, run the following substeps:</p>
+        <li>
+          <p>
+            Let <var title="">name</var> be the leading substring of
+            <var title="">setting</var> up to and excluding the first U+003A
+            COLON character (:) in that string.
+          </p>
+        </li>
 
-    <ol>
+        <li>
+          <p>
+            Let <var title="">value</var> be the trailing substring of
+            <var title="">setting</var> starting from the character immediately
+            after the first U+003A COLON character (:) in that string.
+          </p>
+        </li>
 
-     <li><p>If <var title="">setting</var> does not contain a U+003A
-     COLON character (:), or if the first U+003A COLON character (:)
-     in <var title="">setting</var> is either the first or last
-     character of <var title="">setting</var>, then jump to the step
-     labeled <i>next setting</i>.</p></li>
+        <li>
+          <p>
+            Let <var title="">positionSet</var> and
+            <var title="">positionAlignSet</var> be false. (These are required
+            to determine if the position settings need to be adjusted for
+            non-middle aligned cue text.)
+          </p>
+        </li>
 
-     <li><p>Let <var title="">name</var> be the leading substring of
-     <var title="">setting</var> up to and excluding the first U+003A
-     COLON character (:) in that string.</p></li>
+        <li>
+          Run the appropriate substeps that apply for the value of
+          <var title="">name</var>, as follows:
 
-     <li><p>Let <var title="">value</var> be the trailing substring of
-     <var title="">setting</var> starting from the character
-     immediately after the first U+003A COLON character (:) in that
-     string.</p></li>
+          <dl>
+            <dt>
+              If <var title="">name</var> is a <a>case-sensitive</a> match for
+              "<code>region</code>"
+            </dt>
+            <dd>
+              <ol>
+                <li>
+                  <p>
+                    Let <var>cue</var>'s <a>text track cue region</a> be the
+                    last <a>text track region</a> in <var title="">regions</var>
+                    whose <a>text track region identifier</a> is
+                    <var>value</var>, if any, or null otherwise.
+                  </p>
+                </li>
+              </ol>
+            </dd>
 
-     <li><p>Let <var title="">positionSet</var> and <var title="">positionAlignSet</var>
-     be false. (These are required to determine if the position settings need to be adjusted
-     for non-middle aligned cue text.)</p></li>
+            <dt>
+              If <var title="">name</var> is a <a>case-sensitive</a> match for
+              "<code title="">vertical</code>"
+            </dt>
+            <dd>
+              <ol>
+                <li>
+                  <p>
+                    If <var title="">value</var> is a <a>case-sensitive</a>
+                    match for the string "<code title="">rl</code>", then let
+                    <var title="">cue</var>'s
+                    <a>text track cue writing direction</a> be
+                    <a title="text track cue vertical growing left writing direction">vertical growing left</a>.
+                  </p>
+                </li>
 
-     <li>
+                <li>
+                  <p>
+                    Otherwise, if <var title="">value</var> is a
+                    <a>case-sensitive</a> match for the string
+                    "<code title="">lr</code>", then let
+                    <var title="">cue</var>'s
+                    <a>text track cue writing direction</a> be
+                    <a title="text track cue vertical growing right writing direction">vertical growing right</a>.
+                  </p>
+                </li>
+              </ol>
+            </dd>
 
-      <p>Run the appropriate substeps that apply for the value of <var
-      title="">name</var>, as follows:</p>
+            <dt>
+              If <var title="">name</var> is a <a>case-sensitive</a> match for
+              "<code title="">line</code>"
+            </dt>
+            <dd>
+              <ol>
+                <li>
+                  <p>
+                    If <var title="">value</var> contains a U+002C COMMA
+                    character (,), then let <var title="">linepos</var> be the
+                    leading substring of <var title="">value</var> up to and
+                    excluding the first U+002C COMMA character (,) in that
+                    string and let <var title="">linealign</var> be the trailing
+                    substring of <var title="">value</var> starting from the
+                    character immediately after the first U+002C COMMA character
+                    (,) in that string.
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    Otherwise let <var title="">linepos</var> be the full
+                    <var title="">value</var> string and
+                    <var title="">linealign</var> be the empty string.
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    If <var title="">linepos</var> does not contain at least one
+                    <a title="ASCII digits">ASCII digit</a>, then jump to the
+                    step labeled <i>next setting</i>.
+                  </p>
+                </li>
+
+                <li>
+                  <dl>
+                    <dt>
+                      If the last character in <var title="">linepos</var> is
+                      a U+0025 PERCENT SIGN character (%)
+                    </dt>
+                    <dd>
+                      <p>
+                        If <a>parse a percentage string</a> from
+                        <var title="">linepos</var> doesn't fail, let
+                        <var title="">number</var> be the returned
+                        <var>percentage</var>, otherwise jump to the step
+                        labeled <i>next setting</i>.
+                      </p>
+                    </dd>
+
+                    <dt><p>Otherwise</p></dt>
+                    <dd>
+                      <ol>
+                        <li>
+                          <p>
+                            If <var title="">linepos</var> contains any
+                            characters other than U+002D HYPHEN-MINUS characters
+                            (-) and <a>ASCII digits</a>, then jump to the step
+                            labeled <i>next setting</i>.
+                          </p>
+                        </li>
+
+                        <li>
+                          <p>
+                            If any character in <var title="">linepos</var>
+                            other than the first character is a U+002D
+                            HYPHEN-MINUS character (-), then jump to the step
+                            labeled <i>next setting</i>.
+                          </p>
+                        </li>
+
+                        <li>
+                          <p>
+                            Interpret <var title="">linepos</var> as a
+                            (potentially signed) integer, and let
+                            <var title="">number</var> be that number.
+                          </p>
+                        </li>
+                      </ol>
+                    </dd>
+                  </dl>
+                </li>
+
+                <li>
+                  <p>
+                    Let <var title="">cue</var>'s
+                    <a>text track cue line position</a> be
+                    <var title="">number</var>.
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    If the last character in <var title="">linepos</var> is a
+                    U+0025 PERCENT SIGN character (%), then let
+                    <var title="">cue</var>'s
+                    <a>text track cue snap-to-lines flag</a> be false.
+                    Otherwise, let it be true.
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    If <var title="">linealign</var> is a <a>case-sensitive</a>
+                    match for the string "<code title="">start</code>", then let
+                    <var title="">cue</var>'s
+                    <a>text track cue line alignment</a> be
+                    <a title="text track cue line start alignment">start alignment</a>.
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    If <var title="">linealign</var> is a <a>case-sensitive</a>
+                    match for the string "<code title="">middle</code>", then
+                    let <var title="">cue</var>'s
+                    <a>text track cue line alignment</a> be
+                    <a title="text track cue line middle alignment">middle alignment</a>.
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    If <var title="">linealign</var> is a <a>case-sensitive</a>
+                    match for the string "<code title="">end</code>", then let
+                    <var title="">cue</var>'s
+                    <a>text track cue line alignment</a> be
+                    <a title="text track cue line end alignment">end alignment</a>.
+                  </p>
+                </li>
+              </ol>
+            </dd>
+
+            <dt>
+              If <var title="">name</var> is a <a>case-sensitive</a> match for
+              "<code title="">size</code>"
+            </dt>
+            <dd>
+              <ol>
+                <li>
+                  <p>
+                    If <a>parse a percentage string</a> from
+                    <var title="">value</var> doesn't fail, let
+                    <var title="">number</var> be the returned
+                    <var>percentage</var>, otherwise jump to the step labeled
+                    <i>next setting</i>.
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    Let <var title="">cue</var>'s <a>text track cue size</a> be
+                    <var title="">number</var>.
+                  </p>
+                </li>
+              </ol>
+            </dd>
+
+            <dt>
+              If <var title="">name</var> is a <a>case-sensitive</a> match for
+              "<code title="">position</code>"
+            </dt>
+            <dd>
+              <ol>
+                <li>
+                  <p>
+                    If <var title="">value</var> contains a U+002C COMMA
+                    character (,), then let <var title="">colpos</var> be the
+                    leading substring of <var title="">value</var> up to and
+                    excluding the first U+002C COMMA character (,) in that
+                    string and let <var title="">colalign</var> be the trailing
+                    substring of <var title="">value</var> starting from the
+                    character immediately after the first U+002C COMMA character
+                    (,) in that string.
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    Otherwise let <var title="">colpos</var> be the full
+                    <var title="">value</var> string and
+                    <var title="">colalign</var> be the empty string.
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    If <a>parse a percentage string</a> from
+                    <var title="">colpos</var> doesn't fail, let
+                    <var title="">number</var> be the returned
+                    <var>percentage</var>, otherwise jump to
+                    the step labeled <i>next setting</i>.
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    Let <var title="">cue</var>'s
+                    <a>text track cue text position</a> be
+                    <var title="">number</var> and let
+                    <var title="">positionSet</var> be true.
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    If <var title="">colalign</var> is a <a>case-sensitive</a>
+                    match for the string "<code title="">start</code>", then let
+                    <var title="">cue</var>'s
+                    <a>text track cue text position alignment</a> be
+                    <a title="text track cue text position start alignment">start alignment</a>
+                    and let <var title="">positionAlignSet</var> be true.
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    If <var title="">colalign</var> is a <a>case-sensitive</a>
+                    match for the string "<code title="">middle</code>", then
+                    let <var title="">cue</var>'s
+                    <a>text track cue text position alignment</a> be
+                    <a title="text track cue text position middle alignment">middle alignment</a>
+                    and let <var title="">positionAlignSet</var> be true.
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    If <var title="">colalign</var> is a <a>case-sensitive</a>
+                    match for the string "<code title="">end</code>", then let
+                    <var title="">cue</var>'s
+                    <a>text track cue text position alignment</a> be
+                    <a title="text track cue text position end alignment">end alignment</a>
+                    and let <var title="">positionAlignSet</var> be true.
+                  </p>
+                </li>
+              </ol>
+            </dd>
+
+            <dt>
+              If <var title="">name</var> is a <a>case-sensitive</a> match for
+              "<code title="">align</code>"
+            </dt>
+            <dd>
+              <ol>
+                <li>
+                  <p>
+                    If <var title="">value</var> is a <a>case-sensitive</a>
+                    match for the string "<code title="">start</code>", then let
+                    <var title="">cue</var>'s
+                    <a>text track cue text alignment</a> be
+                    <a title="text track cue start alignment">start alignment</a>.
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    If <var title="">value</var> is a <a>case-sensitive</a>
+                    match for the string "<code title="">middle</code>", then
+                    let <var title="">cue</var>'s
+                    <a>text track cue text alignment</a> be
+                    <a title="text track cue middle alignment">middle alignment</a>.
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    If <var title="">value</var> is a <a>case-sensitive</a>
+                    match for the string "<code title="">end</code>", then let
+                    <var title="">cue</var>'s
+                    <a>text track cue text alignment</a> be
+                    <a title="text track cue end alignment">end alignment</a>.
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    If <var title="">value</var> is a <a>case-sensitive</a>
+                    match for the string "<code title="">left</code>", then let
+                    <var title="">cue</var>'s
+                    <a>text track cue text alignment</a> be
+                    <a title="text track cue left alignment">left alignment</a>.
+                  </p>
+                </li>
+
+                <li>
+                  <p>
+                    If <var title="">value</var> is a <a>case-sensitive</a>
+                    match for the string "<code title="">right</code>", then let
+                    <var title="">cue</var>'s
+                    <a>text track cue text alignment</a> be
+                    <a title="text track cue right alignment">right alignment</a>.
+                  </p>
+                </li>
+              </ol>
+            </dd>
+          </dl>
+        </li>
+
+        <li>
+          <p>
+            <i>Next setting</i>: Continue to the next token, if
+            any.
+          </p><!-- this step is just here to give the algorithms
+            above a clean way to 'break' -->
+        </li>
+      </ol>
+    </li>
+
+    <li>
+      If <var title="">positionSet</var> is false (i.e. the cue box has not
+      been explicitly positioned with a position setting), and
+      <a>text track cue text alignment</a> is not
+      <a title="text track cue middle alignment">middle alignment</a>,
+      then adjust the <a>text track cue text position</a> as follows:
 
       <dl>
+        <dt>
+          If <a>text track cue text alignment</a> is
+          <a title="text track cue left alignment">left</a> or
+          <a title="text track cue start alignment">start</a>
+        </dt>
+        <dd><p>Let <a>text track cue text position</a> be 0%.</p></dd>
 
-        <dt>If <var title="">name</var> is a <a>case-sensitive</a> match for "<code>region</code>"</dt>
+        <dt>
+          If <a>text track cue text alignment</a> is
+          <a title="text track cue right alignment">right</a> or
+          <a title="text track cue end alignment">end</a>
+        </dt>
+        <dd><p>Let <a>text track cue text position</a> be 100%.</p></dd>
+      </dl>
+    </li>
 
+    <li>
+      If <var title="">positionAlignSet</var> is false (i.e. the cue box has
+      not been explicitly position aligned with a position alignment setting),
+      and <a>text track cue text alignment</a> is not
+      <a title="text track cue middle alignment">middle alignment</a>, then
+      adjust the <a>text track cue text position alignment</a> as follows:
+
+      <dl>
+        <dt>
+          If <a>text track cue text alignment</a> is
+          <a title="text track cue left alignment">left</a> or
+          <a title="text track cue start alignment">start</a>
+        </dt>
         <dd>
-          <ol>
-            <li><p>Let <var>cue</var>'s <a>text track cue region</a> be the last <a>text
-            track region</a> in <var title="">regions</var> whose <a>text track region
-            identifier</a> is <var>value</var>, if any, or null otherwise.</p></li>
-          </ol>
+          <p>
+            Let <a>text track cue text position alignment</a> be
+            <a title="text track cue text position start alignment">start alignment</a>.
+          </p>
         </dd>
 
-       <dt>If <var title="">name</var> is a <a>case-sensitive</a> match for "<code title="">vertical</code>"</dt>
-
-       <dd>
-
-        <ol>
-
-         <li><p>If <var title="">value</var> is a
-         <a>case-sensitive</a> match for the string "<code
-         title="">rl</code>", then let <var title="">cue</var>'s
-         <a>text track cue writing direction</a> be <a
-         title="text track cue vertical growing left writing
-         direction">vertical growing left</a>.</p></li>
-
-         <li><p>Otherwise, if <var title="">value</var> is a
-         <a>case-sensitive</a> match for the string "<code
-         title="">lr</code>", then let <var title="">cue</var>'s
-         <a>text track cue writing direction</a> be <a
-         title="text track cue vertical growing right writing
-         direction">vertical growing right</a>.</p></li>
-
-        </ol>
-
-       </dd>
-
-       <dt>If <var title="">name</var> is a <a>case-sensitive</a> match for "<code title="">line</code>"</dt>
-
-       <dd>
-
-        <ol>
-
-         <li><p>If <var title="">value</var> contains a U+002C COMMA character (,), then let
-         <var title="">linepos</var> be the leading substring of <var title="">value</var> up to and
-         excluding the first U+002C COMMA character (,) in that string and let <var title="">linealign</var>
-         be the trailing substring of <var title="">value</var> starting from the character immediately
-         after the first U+002C COMMA character (,) in that string.</p></li>
-
-         <li><p>Otherwise let <var title="">linepos</var> be the full <var title="">value</var> string
-         and <var title="">linealign</var> be the empty string.</p></li>
-
-         <li><p>If <var title="">linepos</var> does not contain at least one <a title="ASCII
-         digits">ASCII digit</a>, then jump to the step labeled <i>next setting</i>.</p></li>
-
-         <li>
-           <dl>
-            <dt><p>If the last character in <var title="">linepos</var> is
-            a U+0025 PERCENT SIGN character (%)</p></dt>
-
-            <dd><p>If <a>parse a percentage string</a> from
-            <var title="">linepos</var> doesn't fail, let <var title="">number</var>
-            be the returned <var>percentage</var>, otherwise jump to the
-            step labeled <i>next setting</i>.</p>
-            </dd>
-
-            <dt><p>Otherwise</p></dt>
-
-            <dd>
-             <ol>
-              <li><p>If <var title="">linepos</var> contains any characters other than
-              U+002D HYPHEN-MINUS characters (-) and <a>ASCII digits</a>, then
-              jump to the step labeled <i>next setting</i>.</p></li>
-
-              <li><p>If any character in <var title="">linepos</var> other
-              than the first character is a U+002D HYPHEN-MINUS character
-              (-), then jump to the step labeled <i>next setting</i>.</p></li>
-
-              <li><p>Interpret <var title="">linepos</var> as a (potentially signed)
-              integer, and let <var title="">number</var> be that number.</p></li>
-             </ol>
-            </dd>
-           </dl>
-         </li>
-
-         <li><p>Let <var title="">cue</var>'s <a>text track cue line position</a>
-         be <var title="">number</var>.</p></li>
-
-         <li><p>If the last character in <var title="">linepos</var> is
-         a U+0025 PERCENT SIGN character (%), then let <var title="">cue</var>'s
-         <a>text track cue snap-to-lines flag</a> be false. Otherwise, let it be true.</p></li>
-
-         <li><p>If <var title="">linealign</var> is a <a>case-sensitive</a> match for the string
-         "<code title="">start</code>", then let <var title="">cue</var>'s
-         <a>text track cue line alignment</a> be
-         <a title="text track cue line start alignment">start alignment</a>.</p></li>
-
-         <li><p>If <var title="">linealign</var> is a <a>case-sensitive</a> match for the string
-         "<code title="">middle</code>", then let <var title="">cue</var>'s
-         <a>text track cue line alignment</a> be
-         <a title="text track cue line middle alignment">middle alignment</a>.</p></li>
-
-         <li><p>If <var title="">linealign</var> is a <a>case-sensitive</a> match for the string
-         "<code title="">end</code>", then let <var title="">cue</var>'s
-         <a>text track cue line alignment</a> be
-         <a title="text track cue line end alignment">end alignment</a>.</p></li>
-
-        </ol>
-
-       </dd>
-
-       <dt>If <var title="">name</var> is a <a>case-sensitive</a> match for "<code title="">size</code>"</dt>
-
-       <dd>
-
-        <ol>
-
-         <li><p>If <a>parse a percentage string</a> from <var title="">value</var> doesn't fail,
-         let <var title="">number</var> be the returned <var>percentage</var>, otherwise jump to
-         the step labeled <i>next setting</i>.</p></li>
-
-         <li><p>Let <var title="">cue</var>'s <a>text track cue
-         size</a> be <var title="">number</var>.</p></li>
-
-        </ol>
-
-       </dd>
-
-       <dt>If <var title="">name</var> is a <a>case-sensitive</a> match for "<code title="">position</code>"</dt>
-
-       <dd>
-
-        <ol>
-
-          <li><p>If <var title="">value</var> contains a U+002C COMMA character (,), then let
-          <var title="">colpos</var> be the leading substring of <var title="">value</var> up to and
-          excluding the first U+002C COMMA character (,) in that string and let <var title="">colalign</var>
-          be the trailing substring of <var title="">value</var> starting from the character immediately
-          after the first U+002C COMMA character (,) in that string.</p></li>
-
-          <li><p>Otherwise let <var title="">colpos</var> be the full <var title="">value</var> string
-          and <var title="">colalign</var> be the empty string.</p></li>
-
-         <li><p>If <a>parse a percentage string</a> from <var title="">colpos</var> doesn't fail,
-         let <var title="">number</var> be the returned <var>percentage</var>, otherwise jump to
-         the step labeled <i>next setting</i>.</p></li>
-
-         <li><p>Let <var title="">cue</var>'s <a>text track cue text position</a> be
-         <var title="">number</var> and let <var title="">positionSet</var> be true.</p></li>
-
-         <li><p>If <var title="">colalign</var> is a <a>case-sensitive</a> match for the string
-         "<code title="">start</code>", then let <var title="">cue</var>'s
-         <a>text track cue text position alignment</a> be
-         <a title="text track cue text position start alignment">start alignment</a>
-         and let <var title="">positionAlignSet</var> be true.</p></li>
-
-         <li><p>If <var title="">colalign</var> is a <a>case-sensitive</a> match for the string
-         "<code title="">middle</code>", then let <var title="">cue</var>'s
-         <a>text track cue text position alignment</a> be
-         <a title="text track cue text position middle alignment">middle alignment</a>
-         and let <var title="">positionAlignSet</var> be true.</p></li>
-
-         <li><p>If <var title="">colalign</var> is a <a>case-sensitive</a> match for the string
-         "<code title="">end</code>", then let <var title="">cue</var>'s
-         <a>text track cue text position alignment</a> be
-         <a title="text track cue text position end alignment">end alignment</a>
-         and let <var title="">positionAlignSet</var> be true.</p></li>
-
-        </ol>
-
-       </dd>
-
-       <dt>If <var title="">name</var> is a <a>case-sensitive</a> match for "<code title="">align</code>"</dt>
-
-       <dd>
-
-        <ol>
-
-         <li><p>If <var title="">value</var> is a
-         <a>case-sensitive</a> match for the string "<code
-         title="">start</code>", then let <var title="">cue</var>'s
-         <a>text track cue text alignment</a> be <a title="text
-         track cue start alignment">start alignment</a>.</p></li>
-
-         <li><p>If <var title="">value</var> is a
-         <a>case-sensitive</a> match for the string "<code
-         title="">middle</code>", then let <var title="">cue</var>'s
-         <a>text track cue text alignment</a> be <a title="text
-         track cue middle alignment">middle alignment</a>.</p></li>
-
-         <li><p>If <var title="">value</var> is a
-         <a>case-sensitive</a> match for the string "<code
-         title="">end</code>", then let <var title="">cue</var>'s
-         <a>text track cue text alignment</a> be <a title="text
-         track cue end alignment">end alignment</a>.</p></li>
-
-         <li><p>If <var title="">value</var> is a
-         <a>case-sensitive</a> match for the string "<code
-         title="">left</code>", then let <var title="">cue</var>'s
-         <a>text track cue text alignment</a> be <a title="text
-         track cue left alignment">left alignment</a>.</p></li>
-
-         <li><p>If <var title="">value</var> is a
-         <a>case-sensitive</a> match for the string "<code
-         title="">right</code>", then let <var title="">cue</var>'s
-         <a>text track cue text alignment</a> be <a title="text
-         track cue right alignment">right alignment</a>.</p></li>
-
-        </ol>
-
-       </dd>
-
+        <dt>
+          If <a>text track cue text alignment</a> is
+          <a title="text track cue right alignment">right</a> or
+          <a title="text track cue end alignment">end</a>
+        </dt>
+        <dd>
+          <p>
+            Let <a>text track cue text position alignment</a> be
+            <a title="text track cue text position end alignment">end alignment</a>.
+          </p>
+        </dd>
       </dl>
+    </li>
 
-     </li>
-
-     <li><p><i>Next setting</i>: Continue to the next token, if
-     any.</p></li> <!-- this step is just here to give the algorithms
-     above a clean way to 'break' -->
-
-    </ol>
-
-   </li>
-
-   <li>
-   <p>If <var title="">positionSet</var> is false (i.e. the cue box has not been explicitly
-   positioned with a position setting), and <a>text track cue text alignment</a>
-   is not <a title="text track cue middle alignment">middle alignment</a>, then adjust the
-   <a>text track cue text position</a> as follows:</p>
-
-   <dl>
-     <dt>If <a>text track cue text alignment</a> is <a title="text track cue left alignment">left</a> or
-     <a title="text track cue start alignment">start</a></dt>
-     <dd>Let <a>text track cue text position</a> be 0%.</dd>
-
-     <dt>If <a>text track cue text alignment</a> is <a title="text track cue right alignment">right</a> or
-     <a title="text track cue end alignment">end</a></dt>
-     <dd>Let <a>text track cue text position</a> be 100%.</dd>
-   </dl>
-   </li>
-
-   <li>
-   <p>If <var title="">positionAlignSet</var> is false (i.e. the cue box has not been explicitly
-   position aligned with a position alignment setting), and <a>text track cue text alignment</a>
-   is not <a title="text track cue middle alignment">middle alignment</a>, then adjust the
-   <a>text track cue text position alignment</a> as follows:</p>
-
-   <dl>
-     <dt>If <a>text track cue text alignment</a> is <a title="text track cue left alignment">left</a> or
-     <a title="text track cue start alignment">start</a></dt>
-     <dd>Let <a>text track cue text position alignment</a> be
-     <a title="text track cue text position start alignment">start alignment</a>.</dd>
-
-     <dt>If <a>text track cue text alignment</a> is <a title="text track cue right alignment">right</a> or
-     <a title="text track cue end alignment">end</a></dt>
-     <dd>Let <a>text track cue text position alignment</a> be
-     <a title="text track cue text position end alignment">end alignment</a>.</dd>
-   </dl>
-   </li>
-
-   <li><p>If <var>cue</var>'s <a>text track cue line position</a> is not <a>text track cue automatic line position</a>
-   or <var>cue</var>'s <a>text track cue size</a> is not 100 or <var>cue</var>'s <a>text track cue writing direction</a>
-   is not <a title="text track cue horizontal writing direction">horizontal</a>, let <var>cue</var>'s <a>text track cue
-   region</a> be null.</p></li>
-
+    <li>
+      <p>
+        If <var>cue</var>'s <a>text track cue line position</a> is not
+        <a>text track cue automatic line position</a> or <var>cue</var>'s
+        <a>text track cue size</a> is not 100 or <var>cue</var>'s
+        <a>text track cue writing direction</a> is not
+        <a title="text track cue horizontal writing direction">horizontal</a>,
+        let <var>cue</var>'s <a>text track cue region</a> be null.
+      </p>
+    </li>
   </ol>
 
-  <p class="note">Step 5 makes sure that no matter in which order the cue settings are provided, if the cue has a <a>text track cue line position</a> or a <a>text track cue size</a> setting or is <a title="text track cue vertical growing left writing direction">text track cue vertical growing left</a> or <a title="text track cue vertical growing right writing direction">growing right writing direction</a>, the <a>text track cue region</a> will be ignored.</p>
+  <p class="note">
+    Step 5 makes sure that no matter in which order the cue settings are
+    provided, if the cue has a <a>text track cue line position</a> or a
+    <a>text track cue size</a> setting or is
+    <a title="text track cue vertical growing left writing direction">text track cue vertical growing left</a>
+    or <a title="text track cue vertical growing right writing direction">growing right writing direction</a>,
+    the <a>text track cue region</a> will be ignored.
+  </p>
 
-  <p>When this specification says that a user agent is to
-  <dfn>Collect a WebVTT timestamp</dfn>, the user agent must run the
-  following steps:</p>
+  <p>
+    When this specification says that a user agent is to
+    <dfn>Collect a WebVTT timestamp</dfn>, the user agent must run the following
+    steps:
+  </p>
 
   <ol>
+    <li>
+      <p>
+        Let <var title="">input</var> and <var title="">position</var> be the
+        same variables as those of the same name in the algorithm that invoked
+        these steps.
+      </p>
+    </li>
 
-   <li><p>Let <var title="">input</var> and <var
-   title="">position</var> be the same variables as those of the same
-   name in the algorithm that invoked these steps.</p></li>
+    <li>
+      <p>
+        Let <var title="">most significant units</var> be
+        <i title="">minutes</i>.
+      </p>
+    </li>
 
-   <li><p>Let <var title="">most significant units</var> be <i
-   title="">minutes</i>.</p></li>
+    <li>
+      <p>
+        If <var title="">position</var> is past the end of
+        <var title="">input</var>, return an error and abort these steps.
+      </p>
+    </li>
 
-   <li><p>If <var title="">position</var> is past the end of <var
-   title="">input</var>, return an error and abort these
-   steps.</p></li>
+    <li>
+      <p>
+        If the character indicated by <var title="">position</var> is not an
+        <a title="ASCII digits">ASCII digit</a>, then return an error and abort
+        these steps.
+      </p>
+    </li>
 
-   <li><p>If the character indicated by <var title="">position</var>
-   is not an <a title="ASCII digits">ASCII digit</a>, then
-   return an error and abort these steps.</p></li>
+    <li>
+      <p>
+        <a>Collect a sequence of characters</a> that are <a>ASCII digits</a>,
+        and let <var title="">string</var> be the collected substring.
+      </p>
+    </li>
 
-   <li><p><a>Collect a sequence of characters</a> that are <a>ASCII digits</a>, and let
-   <var title="">string</var> be the collected substring.</p></li>
+    <li>
+      <p>
+        Interpret <var title="">string</var> as a base-ten integer. Let
+        <var title="">value<sub>1</sub></var> be that integer.
+      </p>
+    </li>
 
-   <li><p>Interpret <var title="">string</var> as a base-ten
-   integer. Let <var title="">value<sub>1</sub></var> be that
-   integer.</p></li>
+    <li>
+      <p>
+        If <var title="">string</var> is not exactly two characters in length,
+        or if <var title="">value<sub>1</sub></var> is greater than 59, let
+        <var title="">most significant units</var> be <i title="">hours</i>.
+      </p>
+    </li>
 
-   <li><p>If <var title="">string</var> is not exactly two characters
-   in length, or if <var title="">value<sub>1</sub></var> is greater
-   than 59, let <var title="">most significant units</var> be <i
-   title="">hours</i>.</p></li>
+    <li>
+      <p>
+        If <var title="">position</var> is beyond the end of
+        <var title="">input</var> or if the character at
+        <var title="">position</var> is not a U+003A COLON character (:), then
+        return an error and abort these steps. Otherwise, move
+        <var title="">position</var> forwards one character.
+      </p>
+    </li>
 
-   <li><p>If <var title="">position</var> is beyond the end of <var
-   title="">input</var> or if the character at <var
-   title="">position</var> is not a U+003A COLON character (:), then
-   return an error and abort these steps. Otherwise, move <var
-   title="">position</var> forwards one character.</p></li>
+    <li>
+      <p>
+        <a>Collect a sequence of characters</a> that are <a>ASCII digits</a>,
+        and let <var title="">string</var> be the collected substring.
+      </p>
+    </li>
 
-   <li><p><a>Collect a sequence of characters</a> that are <a>ASCII digits</a>, and let
-   <var title="">string</var> be the collected substring.</p></li>
+    <li>
+      <p>
+        If <var title="">string</var> is not exactly two characters in length,
+        return an error and abort these steps.
+      </p>
+    </li>
 
-   <li><p>If <var title="">string</var> is not exactly two characters
-   in length, return an error and abort these steps.</p></li>
+    <li>
+      <p>
+        Interpret <var title="">string</var> as a base-ten integer. Let
+        <var title="">value<sub>2</sub></var> be that integer.
+      </p>
+    </li>
 
-   <li><p>Interpret <var title="">string</var> as a base-ten
-   integer. Let <var title="">value<sub>2</sub></var> be that
-   integer.</p></li>
+    <li>
+      <p>
+        If <var title="">most significant units</var> is <i title="">hours</i>,
+        or if <var title="">position</var> is not beyond the end of
+        <var title="">input</var> and the character at
+        <var title="">position</var> is a U+003A COLON character (:), run these
+        substeps:
+      </p>
 
-   <li>
+      <ol>
+        <li>
+          <p>
+            If <var title="">position</var> is beyond the end of
+            <var title="">input</var> or if the character at
+            <var title="">position</var> is not a U+003A COLON character (:),
+            then return an error and abort these steps. Otherwise, move
+            <var title="">position</var> forwards one character.
+          </p>
+        </li>
 
-    <p>If <var title="">most significant units</var> is <i
-    title="">hours</i>, or if <var title="">position</var> is not
-    beyond the end of <var title="">input</var> and the character at
-    <var title="">position</var> is a U+003A COLON character (:), run
-    these substeps:</p>
+        <li>
+          <p>
+            <a>Collect a sequence of characters</a> that are
+            <a>ASCII digits</a>, and let <var title="">string</var> be the
+            collected substring.
+          </p>
+        </li>
 
-    <ol>
+        <li>
+          <p>
+            If <var title="">string</var> is not exactly two characters in
+            length, return an error and abort these steps.
+          </p>
+        </li>
 
-     <li><p>If <var title="">position</var> is beyond the end of <var
-     title="">input</var> or if the character at <var
-     title="">position</var> is not a U+003A COLON character (:), then
-     return an error and abort these steps. Otherwise, move <var
-     title="">position</var> forwards one character.</p></li>
+        <li>
+          <p>
+            Interpret <var title="">string</var> as a base-ten integer. Let
+            <var title="">value<sub>3</sub></var> be that integer.
+          </p>
+        </li>
+      </ol>
 
-     <li><p><a>Collect a sequence of characters</a> that are <a>ASCII digits</a>, and
-     let <var title="">string</var> be the collected substring.</p></li>
+      <p>
+        Otherwise (if <var title="">most significant units</var> is not
+        <i title="">hours</i>, and either <var title="">position</var> is beyond
+        the end of <var title="">input</var>, or the character at
+        <var title="">position</var> is not a U+003A COLON character (:)), let
+        <var title="">value<sub>3</sub></var> have the value of
+        <var title="">value<sub>2</sub></var>, then
+        <var title="">value<sub>2</sub></var> have the value of
+        <var title="">value<sub>1</sub></var>, then let
+        <var title="">value<sub>1</sub></var> equal zero.
+      </p>
+    </li>
 
-     <li><p>If <var title="">string</var> is not exactly two
-     characters in length, return an error and abort these
-     steps.</p></li>
+    <li>
+      <p>
+        If <var title="">position</var> is beyond the end of
+        <var title="">input</var> or if the character at
+        <var title="">position</var> is not a U+002E FULL STOP character (.),
+        then return an error and abort these steps. Otherwise, move
+        <var title="">position</var> forwards one character.
+      </p>
+    </li>
 
-     <li><p>Interpret <var title="">string</var> as a base-ten
-     integer. Let <var title="">value<sub>3</sub></var> be that
-     integer.</p></li>
+    <li>
+      <p>
+        <a>Collect a sequence of characters</a> that are <a>ASCII digits</a>,
+        and let <var title="">string</var> be the collected substring.
+      </p>
+    </li>
 
-    </ol>
+    <li>
+      <p>
+        If <var title="">string</var> is not exactly three characters in length,
+        return an error and abort these steps.
+      </p>
+    </li>
 
-    <p>Otherwise (if <var title="">most significant units</var> is not
-    <i title="">hours</i>, and either <var title="">position</var> is
-    beyond the end of <var title="">input</var>, or the character at
-    <var title="">position</var> is not a U+003A COLON character (:)),
-    let <var title="">value<sub>3</sub></var> have the value of <var
-    title="">value<sub>2</sub></var>, then <var
-    title="">value<sub>2</sub></var> have the value of <var
-    title="">value<sub>1</sub></var>, then let <var
-    title="">value<sub>1</sub></var> equal zero.</p>
+    <li>
+      <p>
+        Interpret <var title="">string</var> as a base-ten integer. Let
+        <var title="">value<sub>4</sub></var> be that integer.
+      </p>
+    </li>
 
-   </li>
+    <li>
+      <p>
+        If <var title="">value<sub>2</sub></var> is greater than 59 or if
+        <var title="">value<sub>3</sub></var> is greater than 59, return an
+        error and abort these steps.
+      </p>
+    </li>
 
-   <li><p>If <var title="">position</var> is beyond the end of <var
-   title="">input</var> or if the character at <var
-   title="">position</var> is not a U+002E FULL STOP character (.),
-   then return an error and abort these steps. Otherwise, move <var
-   title="">position</var> forwards one character.</p></li>
+    <!-- no need to check if <var title="">value<sub>4</sub></var> is
+    greater than 999, since we know it had exactly three characters in
+    the range 0-9, so we know it's a number in the range 0-999 -->
 
-   <li><p><a>Collect a sequence of characters</a> that are <a>ASCII digits</a>, and let
-   <var title="">string</var> be the collected substring.</p></li>
+    <li>
+      <p>
+        Let <var title="">result</var> be
+        <var title="">value<sub>1</sub></var>&times;60&times;60 +
+        <var title="">value<sub>2</sub></var>&times;60 +
+        <var title="">value<sub>3</sub></var> +
+        <var title="">value<sub>4</sub></var>&#x2215;1000.
+      <!-- &#x00f7; is the division sign if people prefer that to the slash -->
+      </p>
+    </li>
 
-   <li><p>If <var title="">string</var> is not exactly three
-   characters in length, return an error and abort these
-   steps.</p></li>
-
-   <li><p>Interpret <var title="">string</var> as a base-ten
-   integer. Let <var title="">value<sub>4</sub></var> be that
-   integer.</p></li>
-
-   <li><p>If <var title="">value<sub>2</sub></var> is greater than 59
-   or if <var title="">value<sub>3</sub></var> is greater than 59,
-   return an error and abort these steps.</p></li>
-
-   <!-- no need to check if <var title="">value<sub>4</sub></var> is
-   greater than 999, since we know it had exactly three characters in
-   the range 0-9, so we know it's a number in the range 0-999 -->
-
-   <li><p>Let <var title="">result</var> be <var
-   title="">value<sub>1</sub></var>&times;60&times;60 + <var
-   title="">value<sub>2</sub></var>&times;60 + <var
-   title="">value<sub>3</sub></var> + <var
-   title="">value<sub>4</sub></var>&#x2215;1000. <!-- &#x00f7;
-   is the division sign if people prefer that to the slash
-   --></p></li>
-
-   <li><p>Return <var title="">result</var>.</p></li>
-
+    <li><p>Return <var title="">result</var>.</p></li>
   </ol>
-  </section>
+
+  </section><!-- END: WebVTT cue timings and settings parsing -->
+
+  <!-- TODO: reformat below here -->
 
   <section>
   <h3><dfn>WebVTT cue text parsing rules</dfn></h3>
@@ -3676,7 +5360,7 @@ The Final Minute</pre>
    <li><p>Jump to the step labeled <i>loop</i>.</p></li>
 
   </ol>
-  </section>
+  </section><!-- END: WebVTT cue text parsing rules -->
 
   <section>
   <h3><dfn>WebVTT cue text DOM construction rules</dfn></h3>
@@ -3762,9 +5446,9 @@ The Final Minute</pre>
   or dependent on characteristics defined above must be left at their
   initial values.</p>
 
-  </section>
+  </section><!-- END: WebVTT cue text DOM construction rules -->
 
-  </section>
+  </section><!-- END: WebVTT file format: Parsing -->
 
   <section>
   <h2>Rendering</h2>
@@ -3784,7 +5468,7 @@ The Final Minute</pre>
    <li><p class="todo">...</p></li> <!-- flatten nodes and return a single string somehow -->
 
   </ol>
-  </section>
+  </section><!-- END: Cues in isolation -->
 
   <section>
   <h3>Cues with video</h3>
@@ -4574,7 +6258,7 @@ Unicode paragraph of the cue. <a href="#refsBIDI">[BIDI]</a></p>
 
   </ol>
 
-  </section>
+  </section><!-- END: Processing model -->
 
   <section>
   <h4>Applying CSS properties to <a title="WebVTT Node Object">WebVTT Node Objects</a></h4>
@@ -4752,7 +6436,7 @@ Unicode paragraph of the cue. <a href="#refsBIDI">[BIDI]</a></p>
   element</a> or other playback mechanism, then they must be
   interpreted as defined in the next section.</p>
 
-  </section>
+  </section><!-- END: Applying CSS properties to WebVTT Node Objects -->
 
   <section>
   <h4>CSS extensions</h4>
@@ -4979,7 +6663,7 @@ Unicode paragraph of the cue. <a href="#refsBIDI">[BIDI]</a></p>
   <a>list of WebVTT Node Objects</a>, must instead be applied to
   the <a>WebVTT cue background box</a>.</p>
 
-  </section>
+  </section><!-- END: CSS extensions -->
 
   <section>
   <h5>The ':past' and ':future' pseudo-classes</h5>
@@ -5014,7 +6698,7 @@ Unicode paragraph of the cue. <a href="#refsBIDI">[BIDI]</a></p>
   position</a> of the <a>media element</a> that is the
   <i>matched element</i>, entirely before the <a>WebVTT Node
   Object</a> <var title="">c</var>.</p>
-  </section>
+  </section><!-- END: The ':past' and ':future' pseudo-classes -->
 
   <section>
   <h3>The '::cue-region' pseudo-element</h3>
@@ -5031,13 +6715,13 @@ Unicode paragraph of the cue. <a href="#refsBIDI">[BIDI]</a></p>
 
   <p>A CSS user agent that implements the text tracks model must implement the '::cue-region' pseudo-element.</p>
 
-    </section>
+    </section><!-- END: The '::cue-region' pseudo-element -->
 
-  </section>
+  </section><!-- END: CSS extensions -->
 
-  </section>
+  </section><!-- END: Cues with video -->
 
-  </section>
+  </section><!-- END: Rendering -->
 
   <section>
   <h2>WebVTT API for Browsers</h2>
@@ -5417,7 +7101,7 @@ interface <dfn>VTTCue</dfn> : <a>TextTrackCue</a> {
   text DOM construction rules</a> to the result of applying the <a>WebVTT cue text parsing
   rules</a> to the <a>text track cue text</a>.</p>
 
-  </section>
+  </section><!-- END: VTTCue interface -->
 
   <section>
   <h3>VTTRegion interface</h3>
@@ -5546,9 +7230,9 @@ interface <dfn>VTTRegion</dfn> {
 
   <p>On setting, the <a>text track region scroll</a> must be set to the value given on the first cell of the row in the table above whose second cell is a <a>case-sensitive</a> match for the new value.</p>
 
-  </section><!-- end VTTRegion object -->
+  </section><!-- END: VTTRegion interface -->
 
-  </section><!-- WebVTT API for browsers -->
+  </section><!-- END: WebVTT API for browsers -->
 
   <section>
   <h2 id="iana">IANA considerations</h2>
@@ -5642,9 +7326,9 @@ interface <dfn>VTTRegion</dfn> {
   <p>Fragment identifiers have no meaning with
   <code>text/vtt</code> resources.</p>
 
-  </section>
+  </section><!-- END: text/vtt -->
 
-  </section>
+  </section><!-- END: IANA considerations -->
 
   <section>
   <h2 class="no-num" id="references">References</h2>
@@ -5688,7 +7372,7 @@ interface <dfn>VTTRegion</dfn> {
 
   </dl>
 
-  </section>
+  </section><!-- END: References -->
 
   <section>
   <h2 class="no-num">Acknowledgements</h2>
@@ -5721,7 +7405,7 @@ interface <dfn>VTTRegion</dfn> {
   David Singer.
   </p>
 
-  </section>
+  </section><!-- END: Acknowledgements -->
 
 </body>
 </html>


### PR DESCRIPTION
First half of cleaning up the source code:
- indent is on two white spaces
- restrict to 80 columns
- provide all closing elements (for editor ease)
- don't break markup that is indexed (e.g. &lt;a>...&lt;/a>)
- put start/end elements on new lines unless they fit within a line
  completely
- add comments to end sections to describe which section they are ending
