### PR TITLE
Break a few lines to avoid the line merging logic in format.py

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -1090,7 +1090,8 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
 
   <ol>
 
-   <li>Optionally (required if <var title="">hour</var> is non-zero):
+   <li>
+    Optionally (required if <var title="">hour</var> is non-zero):
 
     <ol>
 
@@ -1171,7 +1172,8 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
 
   <ol>
    <li>One or more <a>ASCII digits</a>.</li>
-   <li>Optionally:
+   <li>
+     Optionally:
      <ol>
        <li>A U+002E DOT character (.).</li>
        <li>One or more <a>ASCII digits</a>.</li>
@@ -1190,9 +1192,11 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
 
   <ol>
    <li>The <a>case-sensitive</a> string "<code title="">NOTE</code>".</li>
-   <li>Optionally, the following components, in the given order:
+   <li>
+    Optionally, the following components, in the given order:
     <ol>
-     <li>Either:
+     <li>
+      Either:
       <ul>
        <li>A U+0020 SPACE character or U+0009 CHARACTER TABULATION (tab) character.</li>
        <li>A <a>WebVTT line terminator</a>.</li>
@@ -1299,7 +1303,8 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
 
   <ol>
    <li>A <a>WebVTT cue span start tag</a> "<code title="">ruby</code>" that disallows an annotation.</li>
-   <li>One or more occurrences of the following group of components, in the order given:
+   <li>
+    One or more occurrences of the following group of components, in the order given:
     <ol>
      <li><a>WebVTT cue internal text</a>, representing the ruby base.</li>
      <li>A <a>WebVTT cue span start tag</a> "<code title="">rt</code>" that disallows an annotation.</li>
@@ -1344,7 +1349,8 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
 
    <li>The <var title="">tag name</var>.</li>
 
-   <li>Zero or more occurrences of the following sequence:
+   <li>
+    Zero or more occurrences of the following sequence:
 
     <ol>
 
@@ -1617,9 +1623,11 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
   <ol>
    <li><p>The string "<code title="">line</code>" as the <a>WebVTT cue setting name</a>.</p></li>
    <li><p>A U+003A COLON character (:).</p></li>
-   <li>As the <a>WebVTT cue setting value</a>:
+   <li>
+     As the <a>WebVTT cue setting value</a>:
      <ol>
-     <li>a position value, either:
+     <li>
+      a position value, either:
       <dl>
        <dt>To represent a specific position relative to the video frame</dt>
        <dd>
@@ -1634,7 +1642,8 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
        </dd>
       </dl>
     </li>
-    <li>An optional alignment value consisting of the following components:
+    <li>
+      An optional alignment value consisting of the following components:
       <ol>
       <li>A U+002C COMMA character (,).</li>
       <li>One of the following strings: <code title="">start</code>, <code title="">middle</code>,
@@ -1680,10 +1689,12 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
   <ol>
    <li><p>The string "<code title="">position</code>" as the <a>WebVTT cue setting name</a>.</p></li>
    <li><p>A U+003A COLON character (:).</p></li>
-   <li>As the <a>WebVTT cue setting value</a>:
+   <li>
+   As the <a>WebVTT cue setting value</a>:
    <ol>
     <li>a position value consisting of: a <a>WebVTT percentage</a>.</li>
-    <li>an optional alignment value consisting of:
+    <li>
+    an optional alignment value consisting of:
     <ol>
      <li>A U+002C COMMA character (,).</li>
      <li>One of the following strings: <code title="">start</code>, <code title="">middle</code>,
@@ -1788,15 +1799,18 @@ Timeline Panel</pre>
    tree structure:</p>
 
    <ul>
-    <li>WebVTT file
+    <li>
+     WebVTT file
      <ul>
-      <li>Introduction
+      <li>
+       Introduction
        <ul>
         <li>Topics</li>
         <li>Presenters</li>
        </ul>
       </li>
-      <li>Scrolling Effects
+      <li>
+       Scrolling Effects
        <ul>
         <li>Achim's Demo</li>
         <li>Timeline Panel</li>
@@ -1992,7 +2006,8 @@ The Final Minute</pre>
 
    <li><p>Let <var title="">regions</var> be a <a>text track list of regions</a>.</p></li>
 
-   <li><i>Metadata header loop</i>: If <var>line</var> is not the empty string, run the following substeps:
+   <li>
+     <i>Metadata header loop</i>: If <var>line</var> is not the empty string, run the following substeps:
 
      <ol>
 
@@ -2004,7 +2019,8 @@ The Final Minute</pre>
 
        <li><p>If <var>line</var> contains the character ":" (A U+003A COLON), then set <a title="WebVTT metadata header name">metadata's name</a> to the substring of <var>line</var> before the first ":" character and <a title="WebVTT metadata header value">metadata's value</a> to the substring after this character.</p></li>
 
-       <li><p>If <a title="WebVTT metadata header name">metadata's name</a> equals "Region":</p>
+       <li>
+         <p>If <a title="WebVTT metadata header name">metadata's name</a> equals "Region":</p>
 
          <ol>
            <li><i>Region creation</i>: Let <var>region</var> be a new <a>text track region</a>.</li>
@@ -2061,9 +2077,10 @@ The Final Minute</pre>
    a newline, so we have none of that either, meaning we have nothing.
    -->.)</p></li>
 
-   <li><p><i>Cue creation</i>: Let <var title="">cue</var> be a new
-   <a>text track cue</a> and initialize it with the following
-   attribute values:</p>
+   <li>
+    <p><i>Cue creation</i>: Let <var title="">cue</var> be a new
+    <a>text track cue</a> and initialize it with the following
+    attribute values:</p>
 
     <ol>
      <li><p>Let <var title="">cue</var>'s <a>text track cue identifier</a> be the empty string.</p></li>
@@ -2219,7 +2236,8 @@ The Final Minute</pre>
   <ol>
     <li><p>Let <var>settings</var> be the result of <a title="split a string on spaces">splitting <var>input</var> on spaces</a>.</p></li>
 
-    <li>For each token <var>setting</var> in the list <var>settings</var>, run the following substeps:
+    <li>
+      For each token <var>setting</var> in the list <var>settings</var>, run the following substeps:
 
       <ol>
         <li><p>If <var>setting</var> does not contain a U+003D EQUALS SIGN character (=), or if the first U+003D EQUALS SIGN character (=) in <var>setting</var> is either the first or last character of <var>setting</var>, then jump to the step labeled <i>next setting</i>.</p></li>
@@ -2228,7 +2246,8 @@ The Final Minute</pre>
 
         <li><p>Let <var>value</var> be the trailing substring of <var>setting</var> starting from the character immediately after the first U+003D EQUALS SIGN character (=) in that string.</p></li>
 
-        <li><p>Run the appropriate substeps that apply for the value of <var>name</var>, as follows:</p>
+        <li>
+        <p>Run the appropriate substeps that apply for the value of <var>name</var>, as follows:</p>
 
         <dl>
           <dt><p>If <var>name</var> is a <a>case-sensitive</a> match for "<code>id</code>"</p></dt>
@@ -2653,7 +2672,8 @@ The Final Minute</pre>
 
    </li>
 
-   <li><p>If <var title="">positionSet</var> is false (i.e. the cue box has not been explicitly
+   <li>
+   <p>If <var title="">positionSet</var> is false (i.e. the cue box has not been explicitly
    positioned with a position setting), and <a>text track cue text alignment</a>
    is not <a title="text track cue middle alignment">middle alignment</a>, then adjust the
    <a>text track cue text position</a> as follows:</p>
@@ -2669,7 +2689,8 @@ The Final Minute</pre>
    </dl>
    </li>
 
-   <li><p>If <var title="">positionAlignSet</var> is false (i.e. the cue box has not been explicitly
+   <li>
+   <p>If <var title="">positionAlignSet</var> is false (i.e. the cue box has not been explicitly
    position aligned with a position alignment setting), and <a>text track cue text alignment</a>
    is not <a title="text track cue middle alignment">middle alignment</a>, then adjust the
    <a>text track cue text position alignment</a> as follows:</p>
@@ -3833,10 +3854,12 @@ The Final Minute</pre>
 
    <li><p>If <var>reset</var> is false, then, for each <a>text track region</a> <var>region</var> in <var>regions</var> let <var>regionNode</var> be a <a>WebVTT region object</a>.</p></li>
 
-   <li><p>Apply the following steps for each <var>regionNode</var>:</p>
+   <li>
+     <p>Apply the following steps for each <var>regionNode</var>:</p>
 
      <ol>
-       <li><p>Prepare some variables  for the application of CSS properties to <var>regionNode</var> as follows:</p>
+       <li>
+         <p>Prepare some variables for the application of CSS properties to <var>regionNode</var> as follows:</p>
 
          <ul>
            <li><p>Let <var>regionWidth</var> be the <a>text track region width</a>. Let <var>width</var> be '<var>regionWidth</var> vw' ('vw' is a CSS unit).<a href="#refsCSSVALUES">[CSSVALUES]</a></p></li>
@@ -3849,7 +3872,8 @@ The Final Minute</pre>
          </ul>
        </li>
 
-       <li><p>Apply the terms of the CSS specifications to <var>regionNode</var> within the following constraints, thus obtaining a CSS box <var>box</var> positioned relative to an initial containing block:</p>
+       <li>
+         <p>Apply the terms of the CSS specifications to <var>regionNode</var> within the following constraints, thus obtaining a CSS box <var>box</var> positioned relative to an initial containing block:</p>
          <ol>
            <li><p>No style sheets are associated with <var>regionNode</var>. (The regionNodes are subsequently restyled using style sheets after their boxes are generated, as described below.)</p></li>
            <li><p>Properties on <var>regionNode</var> have their values set as defined in the next section. (That section uses some of the variables whose values were calculated earlier in this algorithm.)</p></li>
@@ -3861,7 +3885,8 @@ The Final Minute</pre>
      </ol>
    </li>
 
-   <li><p>If <var>reset</var> is false, then, for each <a>text track cue</a> <var>cue</var> in <var>cues</var>: if <var>cue</var>'s <a>text track cue display state</a> has a set of CSS boxes, then:</p>
+   <li>
+     <p>If <var>reset</var> is false, then, for each <a>text track cue</a> <var>cue</var> in <var>cues</var>: if <var>cue</var>'s <a>text track cue display state</a> has a set of CSS boxes, then:</p>
 
      <ul>
        <li><p>If <var>cue</var>'s <a>text track cue region</a> is not null, add those boxes to that
@@ -3880,7 +3905,8 @@ The Final Minute</pre>
     cue order</a>, run the following substeps:</p>
 
     <ul>
-     <li><p>If <var>cue</var>'s <a>text track cue region</a> is null, run the following substeps:</p>
+     <li>
+      <p>If <var>cue</var>'s <a>text track cue region</a> is null, run the following substeps:</p>
 
       <ol>
 
@@ -3898,7 +3924,8 @@ The Final Minute</pre>
       </ol>
      </li>
 
-     <li><p>Otherwise, run the following substeps:</p>
+     <li>
+       <p>Otherwise, run the following substeps:</p>
        <ol>
          <li><p>Let <var>region</var> be <var>cue</var>'s <a>text track cue region</a>.</p></li>
 
@@ -3906,7 +3933,8 @@ The Final Minute</pre>
 
          <li><p>Let <var>nodes</var> be the <a>list of WebVTT Node Objects</a> obtained by applying the <a>WebVTT cue text parsing rules</a> to the <var>cue</var>'s <a>text track cue text</a>.</p></li>
 
-         <li><p>Apply the Unicode Bidirectional Algorithm's Paragraph Level steps to the concatenation of the values of each <a>WebVTT Text Object</a> in <var>nodes</var>, in a pre-order, depth-first traversal, excluding <a title="WebVTT Ruby Text Object">WebVTT Ruby Text Objects</a> and their descendants, to determine the <i>paragraph embedding level</i> of the first
+         <li>
+           <p>Apply the Unicode Bidirectional Algorithm's Paragraph Level steps to the concatenation of the values of each <a>WebVTT Text Object</a> in <var>nodes</var>, in a pre-order, depth-first traversal, excluding <a title="WebVTT Ruby Text Object">WebVTT Ruby Text Objects</a> and their descendants, to determine the <i>paragraph embedding level</i> of the first
 Unicode paragraph of the cue. <a href="#refsBIDI">[BIDI]</a></p>
            <p class="note">Within a cue, paragraph boundaries are only denoted by Type B characters, such as U+000A LINE FEED (LF), U+0085 NEXT LINE (NEL), and U+2029 PARAGRAPH SEPARATOR. (This means each line of the cue is reordered as if it was a separate paragraph.)</p>
          </li>
@@ -3917,12 +3945,14 @@ Unicode paragraph of the cue. <a href="#refsBIDI">[BIDI]</a></p>
          <li><p>Let <var>offset</var> be the <a>text track cue text position</a> multiplied by <var>region</var>'s <a>text track region width</a> and divided by 100 (i.e. interpret it as a percentage of the region width).</p>
          </li>
 
-         <li><p>If <var>direction</var> is 'ltr' and 'text-align' is 'start' or 'left', or if <var>direction</var> is 'rtl' and 'text-align' is 'end' or 'left', let <var>left</var> be <var>offset</var> and let <var>right</var> be 'auto'</p>
+         <li>
+           <p>If <var>direction</var> is 'ltr' and 'text-align' is 'start' or 'left', or if <var>direction</var> is 'rtl' and 'text-align' is 'end' or 'left', let <var>left</var> be <var>offset</var> and let <var>right</var> be 'auto'</p>
            <p>If <var>direction</var> is 'ltr' and 'text-align' is 'end' or 'right', or if <var>direction</var> is 'rtl' and 'text-align' is 'start' or 'right', let <var>left</var> be 'auto' and <var>right</var> be <var>offset</var>.</p>
            <p>If 'text-align' is 'middle', ignore the <var>offset</var>.</p>
          </li>
 
-         <li><p>Apply the terms of the CSS specifications to <var>nodes</var> with the same constraints that are used when they are applied to <var>nodes</var> of a <var>cue</var> that is not part of a region.</p>
+         <li>
+           <p>Apply the terms of the CSS specifications to <var>nodes</var> with the same constraints that are used when they are applied to <var>nodes</var> of a <var>cue</var> that is not part of a region.</p>
 
            <p>Let <var>boxes</var> be the boxes generated as descendants of the initial containing block, along with their positions.</p>
          </li>
@@ -4195,8 +4225,9 @@ Unicode paragraph of the cue. <a href="#refsBIDI">[BIDI]</a></p>
       section. (That section uses some of the variables whose values
       were calculated earlier in this algorithm.)</li>
 
-      <li>Text runs must be wrapped according to the CSS
-      line-wrapping rules, with the following additional constraints:
+      <li>
+       Text runs must be wrapped according to the CSS
+       line-wrapping rules, with the following additional constraints:
 
        <ul>
 
@@ -5444,7 +5475,8 @@ interface <dfn>VTTRegion</dfn> {
    </dd>
 
    <dt><var title="">region</var> . <a title="dom-VTTRegion-scroll">scroll</a></dt>
-   <dd><p>Returns a string representing the <a>text track region scroll</a> as follows:</p>
+   <dd>
+    <p>Returns a string representing the <a>text track region scroll</a> as follows:</p>
     <dl class="switch">
      <dt>If it is unset.</dt>
      <dd><p>The empty string.</p></dd>


### PR DESCRIPTION
In a few cases this looks silly, but mostly it's helpful to see the
siblings nodes at the same level of indentation.

Inconsistencies in indentation, line length and wrapping &lt;p> was
intentionally left, since those changes can be automated.
