### PR TITLE
Simplify the top-level section titles

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -934,7 +934,7 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
   </section>
 
   <section>
-  <h2>The WebVTT file format: Syntax</h2>
+  <h2>Syntax</h2>
 
   <section>
   <h3>WebVTT file structure</h3>
@@ -1886,7 +1886,7 @@ The Final Minute</pre>
   </section><!-- end of syntax -->
 
   <section>
-  <h2>WebVTT file format: Parsing</h2>
+  <h2>Parsing</h2>
 
   <section>
   <h3>WebVTT file parsing</h3>
@@ -5024,7 +5024,7 @@ Unicode paragraph of the cue. <a href="#refsBIDI">[BIDI]</a></p>
   </section>
 
   <section>
-  <h2>WebVTT API for Browsers</h2>
+  <h2>API</h2>
 
   <section>
   <h3>VTTCue interface</h3>
@@ -5532,7 +5532,7 @@ interface <dfn>VTTRegion</dfn> {
 
   </section><!-- end VTTRegion object -->
 
-  </section><!-- WebVTT API for browsers -->
+  </section><!-- API -->
 
   <section>
   <h2 id="iana">IANA considerations</h2>


### PR DESCRIPTION
Repeating "WebVTT" everywhere isn't very helpful.

These names are used in web-platform-test, where it look rather silly:
https://github.com/w3c/web-platform-tests/tree/d6b71427f5dbfa0588baf1de5634f6016baff103/webvtt
