### PR TITLE
Fix the capitalization of a few definitions

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -2330,7 +2330,7 @@ The Final Minute</pre>
   <h3>WebVTT cue timings and settings parsing</h3>
 
   <p>When the algorithm above requires that the user agent
-  <dfn>Collect WebVTT cue timings and settings</dfn> from a string
+  <dfn>collect WebVTT cue timings and settings</dfn> from a string
   <var title="">input</var> using a <a>text track list of
   regions</a> <var title="">regions</var> for a <a>text track
   cue</a> <var title="">cue</var>, the user agent must run the
@@ -2393,7 +2393,7 @@ The Final Minute</pre>
 
   </ol>
 
-  <p>When the user agent is to <dfn>Parse the WebVTT cue settings</dfn>
+  <p>When the user agent is to <dfn>parse the WebVTT cue settings</dfn>
   from a string <var title="">input</var> using a <a>text track list of
   regions</a> <var title="">regions</var> for a <a>text track cue</a>
   <var title="">cue</var>, the user agent must run the following
@@ -2704,7 +2704,7 @@ The Final Minute</pre>
   <p class="note">Step 5 makes sure that no matter in which order the cue settings are provided, if the cue has a <a>text track cue line position</a> or a <a>text track cue size</a> setting or is <a title="text track cue vertical growing left writing direction">text track cue vertical growing left</a> or <a title="text track cue vertical growing right writing direction">growing right writing direction</a>, the <a>text track cue region</a> will be ignored.</p>
 
   <p>When this specification says that a user agent is to
-  <dfn>Collect a WebVTT timestamp</dfn>, the user agent must run the
+  <dfn>collect a WebVTT timestamp</dfn>, the user agent must run the
   following steps:</p>
 
   <ol>


### PR DESCRIPTION
These were changed in "Fixing up the links the broke when moving to
respec" but not reverted with the rest in "Reverting the weird
capitalization since respec clone supports cneutral apitalization".
