### PR TITLE
Remove a few unused HTML terms

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -518,8 +518,6 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
    <li><a href="http://www.w3.org/html/wg/drafts/html/master/#alphanumeric-ascii-characters"><dfn>Alphanumeric ASCII characters</dfn></a></li>
    <li><a href="http://www.w3.org/html/wg/drafts/html/master/#space-character"><dfn>Space character</dfn></a></li>
    <li><a href="http://www.w3.org/html/wg/drafts/html/master/#skip-whitespace"><dfn>Skip whitespace</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/#supported-property-indices"><dfn>Supported property indices</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/#determine-the-value-of-an-indexed-property"><dfn>Determine the value of an indexed property</dfn></a></li>
    <li><a href="http://www.w3.org/html/wg/drafts/html/master/#split-a-string-on-spaces"><dfn>Split a string on spaces</dfn></a></li>
    <li><a href="http://www.w3.org/html/wg/drafts/html/master/#html-namespace"><dfn>HTML namespace</dfn></a></li>
    <li><a href="http://www.w3.org/html/wg/drafts/html/master/#media-element"><dfn>Media element</dfn></a></li>
@@ -529,7 +527,6 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
    <li><a href="http://www.w3.org/html/wg/drafts/html/master/#text-track"><dfn>Text track</dfn></a></li>
    <li><a href="http://www.w3.org/html/wg/drafts/html/master/#text-track-kind"><dfn>Text track kind</dfn></a></li>
    <li><a href="http://www.w3.org/html/wg/drafts/html/master/#text-track-mode"><dfn>Text track mode</dfn></a></li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/#text-track-disabled"><dfn>Text track disabled</dfn></a></li>
    <li><a href="http://www.w3.org/html/wg/drafts/html/master/#text-track-showing"><dfn>Text track showing</dfn></a></li>
    <li><a href="http://www.w3.org/html/wg/drafts/html/master/#text-track-cue"><dfn>Text track cue</dfn></a></li>
    <li><a href="http://www.w3.org/html/wg/drafts/html/master/#text-track-list-of-cues"><dfn>Text track list of cues</dfn></a></li>
@@ -544,7 +541,6 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
    <li><a href="http://www.w3.org/html/wg/drafts/html/master/#rules-for-updating-the-text-track-rendering"><dfn>Rules for updating the text track rendering</dfn></a></li>
    <li><a href="http://www.w3.org/html/wg/drafts/html/master/#rules-for-rendering-the-cue-in-isolation"><dfn>Rules for rendering the cue in isolation</dfn></a></li>
    <li><a href="http://www.w3.org/html/wg/drafts/html/master/#texttrackcue"><dfn><code>TextTrackCue</code></dfn></a> interface</li>
-   <li><a href="http://www.w3.org/html/wg/drafts/html/master/#texttrack"><dfn><code>TextTrack</code></dfn></a> interface</li>
   </ul>
   </section>
   </section>


### PR DESCRIPTION
These are unused since commit 970b3a2d425d26e63fe2cd94b030f8f80289af00:
"Remove the extensions to the TextTrack interface"
