### PR TITLE
Remove "case-sensitive" in description of "NOTE" for consistency

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -1182,7 +1182,7 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
   the given order:</p>
 
   <ol>
-   <li>The <a>case-sensitive</a> string "<code title="">NOTE</code>".</li>
+   <li>The string "<code title="">NOTE</code>".</li>
    <li>
     Optionally, the following components, in the given order:
     <ol>


### PR DESCRIPTION
No other strings (like "WEBVTT" and "width") say "case-sensitive".
