### PR TITLE
Don't refer to text track cue concepts as attributes

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -2068,8 +2068,7 @@ The Final Minute</pre>
 
    <li>
     <p><i>Cue creation</i>: Let <var title="">cue</var> be a new
-    <a>text track cue</a> and initialize it with the following
-    attribute values:</p>
+    <a>text track cue</a> and initialize it as follows:</p></li>
 
     <ol>
      <li><p>Let <var title="">cue</var>'s <a>text track cue identifier</a> be the empty string.</p></li>


### PR DESCRIPTION
These concepts are part of the model, not the attributes in the API.
