### PR TITLE
Fix the description of automatic line position

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -638,7 +638,7 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
     interpreted as defined by the <a title="text track cue writing direction">writing direction</a>
     and <a title="text track cue snap-to-lines flag">snap-to-lines flag</a> of the cue, or the special
     value <dfn title="text track cue automatic line position">auto</dfn>, which means the position
-    is to depend on the other <a title="Text track cue active flag">active</a> cues.</p>
+    is to depend on the other showing tracks.</p>
 
     <p>A <a>text track cue</a> has a <dfn>text track cue computed line position</dfn> whose
     value is that returned by the following algorithm, which is defined in terms of the other


### PR DESCRIPTION
The algorithm that follows uses showing tracks, not active cues.
