### PR TITLE
Remove weird properties on the WebVTT cue background box

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -4666,26 +4666,6 @@ Unicode paragraph of the cue. <a href="#refsBIDI">[BIDI]</a></p>
   Node Objects</a> must be set to 'pre-line'. <a
   href="#refsCSS">[CSS]</a></p>
 
-  <p>The 'padding-top' and 'padding-bottom' property on the <a>WebVTT cue background box</a>
-  must be set to '1.5vh' or another user-agent-defined number to define a padding at the edges of the
-  video into which cues will not be placed. In situations with overscan, this padding should be sufficient
-  to place a cue within the title-safe area. In the absence of overscan, this value should be picked for
-  aesthetics (to avoid text being aligned precisely on the top or bottom edge of the video, which can be
-  ugly).</p>
-
-  <p>The 'padding-left' and 'padding-right' property on the <a>WebVTT cue background box</a>
-  must be set to '1.5vw' or another user-agent-defined number to define a padding at the edges of the
-  video into which cues will not be placed. In situations with overscan, this padding should be sufficient
-  to place a cue within the title-safe area. In the absence of overscan, this value should be picked for
-  aesthetics (to avoid text being aligned precisely on the top or bottom edge of the video, which can be
-  ugly).</p>
-
-  <p>The 'box-sizing' property on the <a>WebVTT cue background box</a>
-  must be set to 'border-box'.</p>
-
-  <p>The 'overflow' property on the <a>WebVTT cue background box</a> must be set
-  to 'hidden'.</p>
-
   <p>The 'font-style' property on <a title="WebVTT Italic
   Object">WebVTT Italic Objects</a> must be set to 'italic'.</p>
 


### PR DESCRIPTION
These were added in commits 3d05e2e05c72b01404cf290bf07c7f0f367827a7 and
be09934775d380753873ab9667c70e1b3af43aa3 but don't make sense since the
WebVTT cue background box is a per-cue inline box.
