### PR TITLE
Remove hidden comments for cue and region settings

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -1473,12 +1473,12 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
   <p>The <dfn>WebVTT region setting list</dfn> of a <a>WebVTT region metadata header</a> consists of zero or more of the following components, in any order, separated from each other by one or more U+0020 SPACE characters or U+0009 CHARACTER TABULATION (tab) characters. Each component must not be included more than once per <a>WebVTT region setting list</a> string.</p>
 
   <ul>
-   <li>A <a>WebVTT region identifier</a>.</li> <!-- id:fred -->
-   <li>A <a>WebVTT region width setting</a>.</li> <!-- width:80.5% -->
-   <li>A <a>WebVTT region lines setting</a>.</li> <!-- lines:3 -->
-   <li>A <a>WebVTT region anchor setting</a>.</li> <!-- regionanchor:0%,100% -->
-   <li>A <a>WebVTT region viewport anchor setting</a>.</li> <!-- viewportanchor:10.5%,90.5% -->
-   <li>A <a>WebVTT region scroll setting</a>.</li> <!-- scroll:up -->
+   <li>A <a>WebVTT region identifier</a>.</li>
+   <li>A <a>WebVTT region width setting</a>.</li>
+   <li>A <a>WebVTT region lines setting</a>.</li>
+   <li>A <a>WebVTT region anchor setting</a>.</li>
+   <li>A <a>WebVTT region viewport anchor setting</a>.</li>
+   <li>A <a>WebVTT region scroll setting</a>.</li>
   </ul>
 
   <p class="note">The <a>WebVTT region setting list</a> gives configuration
@@ -1591,15 +1591,12 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
   setting must not be included more than once per <a>WebVTT cue settings list</a>.</p>
 
   <ul class="brief">
-   <li>A <a>WebVTT vertical text cue setting</a>.</li> <!-- vertical:rl/lr [writing direction] -->
-   <li>A <a>WebVTT line position cue setting</a>.</li> <!-- line:100% line:1 line:-1
-                                                       [snap-to-lines & line position & line alignment] -->
-   <li>A <a>WebVTT size cue setting</a>.</li>          <!-- size:100% -->
-   <li>A <a>WebVTT text position cue setting</a>.</li> <!-- position:100%
-                                                       [text position & text position alignment] -->
-   <li>A <a>WebVTT alignment cue setting</a>.</li>     <!-- align:start/middle/end/left/right
-                                                       [text alignment] -->
-   <li>A <a>WebVTT region cue setting</a>.</li>        <!-- region:fred [region id] -->
+   <li>A <a>WebVTT vertical text cue setting</a>.</li>
+   <li>A <a>WebVTT line position cue setting</a>.</li>
+   <li>A <a>WebVTT size cue setting</a>.</li>
+   <li>A <a>WebVTT text position cue setting</a>.</li>
+   <li>A <a>WebVTT alignment cue setting</a>.</li>
+   <li>A <a>WebVTT region cue setting</a>.</li>
   </ul>
 
   <p class="note">A <a>WebVTT cue settings list</a> gives configuration


### PR DESCRIPTION
These aren't particularly illuminating, and the indentation would get
mangled by format.py. Fixing format.py does not seem worthwhile.
