### PR TITLE
Normalize the style of "Text track ..." in table heading

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -4621,7 +4621,7 @@ Unicode paragraph of the cue. <a href="#refsBIDI">[BIDI]</a></p>
   <table>
    <thead>
     <tr>
-     <th><a>text track cue text alignment</a></th>
+     <th><a>Text track cue text alignment</a></th>
      <th>'text-align' value</th>
     </tr>
    </thead>
@@ -5254,7 +5254,7 @@ interface <dfn>VTTCue</dfn> : <a>TextTrackCue</a> {
   <table>
    <thead>
     <tr>
-     <th><a>text track cue writing direction</a></th>
+     <th><a>Text track cue writing direction</a></th>
      <th><code title="dom-VTTCue-direction">direction</code> value</th>
     </tr>
    </thead>
@@ -5301,7 +5301,7 @@ interface <dfn>VTTCue</dfn> : <a>TextTrackCue</a> {
   <table>
    <thead>
     <tr>
-     <th><a>text track cue line alignment</a></th>
+     <th><a>Text track cue line alignment</a></th>
      <th><code title="dom-VTTCue-lineAlign">lineAlign</code> value</th>
     </tr>
    </thead>
@@ -5339,7 +5339,7 @@ interface <dfn>VTTCue</dfn> : <a>TextTrackCue</a> {
   <table>
    <thead>
     <tr>
-     <th><a>text track cue text position alignment</a></th>
+     <th><a>Text track cue text position alignment</a></th>
      <th><code title="dom-VTTCue-positionAlign">positionAlign</code> value</th>
     </tr>
    </thead>
@@ -5377,7 +5377,7 @@ interface <dfn>VTTCue</dfn> : <a>TextTrackCue</a> {
   <table>
    <thead>
     <tr>
-     <th><a>text track cue text alignment</a></th>
+     <th><a>Text track cue text alignment</a></th>
      <th><code title="dom-VTTCue-align">align</code> value</th>
     </tr>
    </thead>
@@ -5531,7 +5531,7 @@ interface <dfn>VTTRegion</dfn> {
   <table>
    <thead>
     <tr>
-     <th><a>Text track region scroll</a> setting</th>
+     <th><a>Text track region scroll</a></th>
      <th><code id="dom-VTTRegion-scroll">scroll</code> value</th>
     </tr>
    </thead>


### PR DESCRIPTION
It looks like the capitalization was accidentally changed in commit
ee3d595280508aa87d74f9f36e84cfa402fec98b.
