### PR TITLE
Move the ruby anonymous box logic back to its original place

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -4225,6 +4225,12 @@ Unicode paragraph of the cue. <a href="#refsBIDI">[BIDI]</a></p>
       value 'inline'. This is the <dfn>WebVTT cue background
       box</dfn>.</li>
 
+      <li>Runs of children of <a title="WebVTT Ruby Object">WebVTT
+      Ruby Objects</a> that are not <a title="WebVTT Ruby Text
+      Object">WebVTT Ruby Text Objects</a> must be wrapped in
+      anonymous boxes whose 'display' property has the value
+      'ruby-base'. <a href="#refsCSSRUBY">[CSSRUBY]</a></li>
+
       <li>Properties on <a title="WebVTT Node Object">WebVTT Node
       Objects</a> have their values set as defined in the next
       section. (That section uses some of the variables whose values
@@ -4702,12 +4708,6 @@ Unicode paragraph of the cue. <a href="#refsBIDI">[BIDI]</a></p>
   <p>The 'display' property on <a title="WebVTT Ruby Text
   Object">WebVTT Ruby Text Objects</a> must be set to
   'ruby-text'. <a href="#refsCSSRUBY">[CSSRUBY]</a></p>
-
-  <p>Runs of children of <a title="WebVTT Ruby Object">WebVTT
-  Ruby Objects</a> that are not <a title="WebVTT Ruby Text
-  Object">WebVTT Ruby Text Objects</a> must be wrapped in
-  anonymous boxes whose 'display' property has the value
-  'ruby-base'. <a href="#refsCSSRUBY">[CSSRUBY]</a></p>
 
   <p>Every <a>WebVTT region object</a> is initialized with the following CSS settings:</p>
   <ul>


### PR DESCRIPTION
This was moved in commit 3d05e2e05c72b01404cf290bf07c7f0f367827a7
but seems to belong better in its original place since it creates
boxes and does not merely set properties.
