### PR TITLE
Remove the region nullification from the parser

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -2707,21 +2707,6 @@ The Final Minute</pre>
    </dl>
    </li>
 
-   <li>
-
-    <p>If <var>cue</var>'s <a>text track cue line position</a> is not <a>text track cue automatic line position</a>
-    or <var>cue</var>'s <a>text track cue size</a> is not 100 or <var>cue</var>'s <a>text track cue writing direction</a>
-    is not <a title="text track cue horizontal writing direction">horizontal</a>, let <var>cue</var>'s <a>text track cue
-    region</a> be null.</p>
-
-    <p class="note">This makes sure that no matter in which order the cue settings are provided, if
-    if the cue has a <a>text track cue line position</a> or a <a>text track cue size</a> setting or
-    is <a title="text track cue vertical growing left writing direction">text track cue vertical
-    growing left</a> or <a title="text track cue vertical growing right writing direction">growing
-    right writing direction</a>, the <a>text track cue region</a> will be ignored.</p>
-
-   </li>
-
   </ol>
 
   <p>When this specification says that a user agent is to


### PR DESCRIPTION
Scripts can already get cues into the state that this tries to avoid,
and it seems harmless due to how the rendering algorithm works.

https://www.w3.org/Bugs/Public/show_bug.cgi?id=25948
