### PR TITLE
Drop 'cue' from 'A cue line position/alignment'

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -603,7 +603,7 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
 
    </dd>
 
-   <dt><dfn title="text track cue line position">A cue line position</dfn></dt>
+   <dt><dfn title="text track cue line position">A line position</dfn></dt>
    <dd>
     <p>The line position defines positioning of the <a title="text track cue box">cue box</a>.</p>
 
@@ -660,7 +660,7 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
 
    </dd>
 
-   <dt><dfn title="text track cue line alignment">A cue line alignment</dfn></dt>
+   <dt><dfn title="text track cue line alignment">A line alignment</dfn></dt>
    <dd>
      <p>An alignment for the <a title="text track cue box">cue box</a>'s <a title="text track cue line position">line position</a>,
      one of:</p>


### PR DESCRIPTION
No other terms in this section except 'A cue box' include 'cue'.
