### PR TITLE
Remove effect of rtl / ltr on position related rendering for non-snap-to-lines.

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -4456,22 +4456,12 @@ Unicode paragraph of the cue. <a href="#refsBIDI">[BIDI]</a></p>
 
          <dl class="switch">
 
-          <dt>If the <a>text track cue writing direction</a> is <a title="text track cue horizontal writing direction">horizontal</a>,
-                 and <var>direction</var> is 'ltr'</dt>
+          <dt>If the <a>text track cue writing direction</a> is <a title="text track cue horizontal writing direction">horizontal</a></dt>
           <dd>
            <p>Let <var>x</var> be a percentage given by the
            <a>text track cue text position</a>, and let
            <var>y</var> be a percentage given by the <a>text
            track cue computed line position</a>.</p>
-          </dd>
-
-          <dt>If the <a>text track cue writing direction</a> is <a title="text track cue horizontal writing direction">horizontal</a>,
-                 and <var>direction</var> is 'rtl'</dt>
-          <dd>
-           <p>Let <var>x</var> be a percentage given by the
-           <a>text track cue text position</a> subtracted from
-           100, and let <var>y</var> be a percentage given
-           by the <a>text track cue computed line position</a>.</p>
           </dd>
 
           <dt>If the <a>text track cue writing direction</a> is <a title="text track cue vertical growing left writing direction">vertical growing left</a></dt>


### PR DESCRIPTION
It was an oversight to leave this in the rendering section - text position is
supposed to be calculated always from the left edge for horizontal cues or top
edge for vertical cues.
