### PR TITLE
Restore size clamping in rendering

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -3987,25 +3987,23 @@ Unicode paragraph of the cue. <a href="#refsBIDI">[BIDI]</a></p>
 
      <dl class="switch">
 
-      <dt>If the <a>text track cue text alignment</a> is <a title="text track cue start alignment">start</a>
-             or <a title="text track cue left alignment">left</a></dt>
+      <dt>If the <a>text track cue computed text position alignment</a> is <a title="text track cue text position start alignment">start</a></dt>
       <dd>
        <p>Let <var>maximum size</var> be the <a>text track cue computed text position</a> subtracted from 100.</p>
       </dd>
 
-      <dt>If the <a>text track cue text alignment</a> is <a title="text track cue end alignment">end</a>
-             or <a title="text track cue right alignment">right</a></dt>
+      <dt>If the <a>text track cue computed text position alignment</a> is <a title="text track cue text position end alignment">end</a></dt>
       <dd>
        <p>Let <var>maximum size</var> be the <a>text track cue computed text position</a>.</p>
       </dd>
 
-      <dt>If the <a>text track cue text alignment</a> is <a title="text track cue middle alignment">middle</a>,
+      <dt>If the <a>text track cue computed text position alignment</a> is <a title="text track cue text position middle alignment">middle</a>,
              and the <a>text track cue computed text position</a> is less than or equal to 50</dt>
       <dd>
        <p>Let <var>maximum size</var> be the <a>text track cue computed text position</a> multiplied by two.</p>
       </dd>
 
-      <dt>If the <a>text track cue text alignment</a> is <a title="text track cue middle alignment">middle</a>,
+      <dt>If the <a>text track cue computed text position alignment</a> is <a title="text track cue text position middle alignment">middle</a>,
              and the <a>text track cue computed text position</a> is greater than <!-- or equal to --> 50</dt>
       <dd>
        <p>Let <var>maximum size</var> be the result of subtracting <a>text track cue computed text position</a> from 100 and then multiplying the result by two.</p>


### PR DESCRIPTION
https://www.w3.org/Bugs/Public/show_bug.cgi?id=25660

This was removed in commit 3d05e2e05c72b01404cf290bf07c7f0f367827a7.
Text direction (LRT/RTL) now has no effect on position, so the restored
text is somewhat simpler than the original.
