### PR TITLE
Drop 'right' from the list of CSS settings

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -4544,15 +4544,14 @@ Unicode paragraph of the cue. <a href="#refsBIDI">[BIDI]</a></p>
    <li>the 'direction' property must be set to <var>direction</var></li>
    <li>the 'writing-mode' property must be set to <var>writing-mode</var></li>
    <li>the 'top' property must be set to <var>top</var></li>
-   <li>the 'left' property must be set to <var>left</var>, if <var>left</var> has a value</li>
-   <li>the 'right' property must be set to <var>right</var>, if <var>right</var> has a value</li>
+   <li>the 'left' property must be set to <var>left</var></li>
    <li>the 'width' property must be set to <var>width</var></li>
    <li>the 'height' property must be set to <var>height</var></li>
   </ul>
 
   <p>The variables <var>direction</var>,
   <var>writing-mode</var>, <var>top</var>,
-  <var>left</var>, <var>right</var>, <var>width</var>, and
+  <var>left</var>, <var>width</var>, and
   <var>height</var> are the values with those names determined by
   the <a>rules for updating the display of WebVTT text
   tracks</a> for the <a>text track cue</a> from whose <a
@@ -4645,7 +4644,6 @@ Unicode paragraph of the cue. <a href="#refsBIDI">[BIDI]</a></p>
     <li>the 'min-height' property must be set to '0px'</li>
     <li>the 'max-height' property must be set to <var>height</var></li>
     <li>the 'left' property must be set to <var>left</var></li>
-    <li>the 'right' property must be set to <var>right</var></li>
     <li>the 'top' property must be set to <var>top</var></li>
     <li>the 'display' property must be set to 'inline-flex'</li>
     <li>the 'flex-flow' property must be set to 'column'</li>


### PR DESCRIPTION
It is unused since commit 89e29b542c36378718382c1807e2a14fdbcdf16b.
