### PR TITLE
Improve the wording for computed text position alignment

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -783,10 +783,9 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
 
       <ol>
 
-        <li><p>If the <a>text track cue text position alignment</a> is set, then return the value of
-        the <a>text track cue text position alignment</a> and abort these steps. (Otherwise, the <a>text
-        track cue text position alignment</a> is the special value <a title="text track cue text position
-        automatic alignment">auto</a>.)</p></li>
+        <li><p>If the <a>text track cue text position alignment</a> is not <a title="text track cue
+        text position automatic alignment">auto</a>, then return the value of the <a>text track cue
+        text position alignment</a> and abort these steps.</p></li>
 
         <li><p>If the <a>text track cue text alignment</a> is <a title="text track cue start
         alignment">start</a> or <a title="text track cue left alignment">left</a>, return <a title="text


### PR DESCRIPTION
The text position alignment is always set, and the auto value is not
special in the same sense as for line and position.
