### PR TITLE
Drop punctuation trailing "If ..." in switches

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -3893,12 +3893,12 @@ Unicode paragraph of the cue. <a href="#refsBIDI">[BIDI]</a></p>
            <dd>
              <dl class="switch">
                <dt>If the <a>text track cue computed text position alignment</a> is
-               <a title="text track cue text position middle alignment">middle alignment</a>:</dt>
+               <a title="text track cue text position middle alignment">middle alignment</a></dt>
                <dd><p>Subtract half of <var>region</var>'s <a>text track region width</a> from
                <var>offset</var>.</p></dd>
 
                <dt>If the <a>text track cue computed text position alignment</a> is
-               <a title="text track cue text position end alignment">end alignment</a>:</dt>
+               <a title="text track cue text position end alignment">end alignment</a></dt>
                <dd><p>Subtract <var>region</var>'s <a>text track region width</a> from
                <var>offset</var>.</p></dd>
              </dl>
@@ -4000,20 +4000,20 @@ Unicode paragraph of the cue. <a href="#refsBIDI">[BIDI]</a></p>
      <dl class="switch">
 
        <dt>If the <a>text track cue writing direction</a> is
-       <a title="text track cue horizontal writing direction">horizontal</a>:</dt>
+       <a title="text track cue horizontal writing direction">horizontal</a></dt>
        <dd>
          <dl class="switch">
            <dt>If the <a>text track cue computed text position alignment</a> is
-           <a title="text track cue text position start alignment">start alignment</a>:</dt>
+           <a title="text track cue text position start alignment">start alignment</a></dt>
            <dd><p>Let <var>x-position</var> be the <a>text track cue computed text position</a>.</p></dd>
 
            <dt>If the <a>text track cue computed text position alignment</a> is
-           <a title="text track cue text position middle alignment">middle alignment</a>:</dt>
+           <a title="text track cue text position middle alignment">middle alignment</a></dt>
            <dd><p>Let <var>x-position</var> be the <a>text track cue computed text position</a> minus
            half of <var>size</var>.</p></dd>
 
            <dt>If the <a>text track cue computed text position alignment</a> is
-           <a title="text track cue text position end alignment">end alignment</a>:</dt>
+           <a title="text track cue text position end alignment">end alignment</a></dt>
            <dd><p>Let <var>x-position</var> be the <a>text track cue computed text position</a> minus
            <var>size</var>.</p></dd>
          </dl>
@@ -4021,20 +4021,20 @@ Unicode paragraph of the cue. <a href="#refsBIDI">[BIDI]</a></p>
 
        <dt>If the <a>text track cue writing direction</a> is
        <a title="text track cue vertical growing left writing direction">vertical growing left</a>
-       or <a title="text track cue vertical growing right writing direction">vertical growing right</a>:</dt>
+       or <a title="text track cue vertical growing right writing direction">vertical growing right</a></dt>
        <dd>
          <dl class="switch">
            <dt>If the <a>text track cue computed text position alignment</a> is
-           <a title="text track cue text position start alignment">start alignment</a>:</dt>
+           <a title="text track cue text position start alignment">start alignment</a></dt>
            <dd><p>Let <var>y-position</var> be the <a>text track cue computed text position</a>.</p></dd>
 
            <dt>If the <a>text track cue computed text position alignment</a> is
-           <a title="text track cue text position middle alignment">middle alignment</a>:</dt>
+           <a title="text track cue text position middle alignment">middle alignment</a></dt>
            <dd><p>Let <var>y-position</var> be the <a>text track cue computed text position</a> minus
            half of <var>size</var>.</p></dd>
 
            <dt>If the <a>text track cue computed text position alignment</a> is
-           <a title="text track cue text position end alignment">end alignment</a>:</dt>
+           <a title="text track cue text position end alignment">end alignment</a></dt>
            <dd><p>Let <var>y-position</var> be the <a>text track cue computed text position</a> minus
            <var>size</var>.</p></dd>
          </dl>
@@ -4051,65 +4051,65 @@ Unicode paragraph of the cue. <a href="#refsBIDI">[BIDI]</a></p>
 
       <dl class="switch">
 
-      <dt>If the <a>text track cue snap-to-lines flag</a> is not set:</dt>
+      <dt>If the <a>text track cue snap-to-lines flag</a> is not set</dt>
       <dd>
         <dl class="switch">
 
         <dt>If the <a>text track cue writing direction</a> is
-        <a title="text track cue horizontal writing direction">horizontal</a>:</dt>
+        <a title="text track cue horizontal writing direction">horizontal</a></dt>
         <dd>
           <dl class="switch">
             <dt>If the <a>text track cue line alignment</a> is
-            <a title="text track cue line start alignment">start alignment</a>:</dt>
+            <a title="text track cue line start alignment">start alignment</a></dt>
             <dd><p>Let <var>y-position</var> be the <a>text track cue computed line position</a>.</p></dd>
 
             <dt>If the <a>text track cue line alignment</a> is
-            <a title="text track cue text position middle alignment">middle alignment</a>:</dt>
+            <a title="text track cue text position middle alignment">middle alignment</a></dt>
             <dd><p>Let <var>y-position</var> be the <a>text track cue computed line position</a> minus
             half of the cue box height.</p></dd>
 
             <dt>If the <a>text track cue line alignment</a> is
-            <a title="text track cue text position end alignment">end alignment</a>:</dt>
+            <a title="text track cue text position end alignment">end alignment</a></dt>
             <dd><p>Let <var>y-position</var> be the <a>text track cue computed line position</a> minus
             the cue box height.</p></dd>
           </dl>
         </dd>
 
         <dt>If the <a>text track cue writing direction</a> is
-        <a title="text track cue vertical growing left writing direction">vertical growing left</a>:</dt>
+        <a title="text track cue vertical growing left writing direction">vertical growing left</a></dt>
         <dd>
           <dl class="switch">
             <dt>If the <a>text track cue line alignment</a> is
-            <a title="text track cue text position start alignment">start alignment</a>:</dt>
+            <a title="text track cue text position start alignment">start alignment</a></dt>
             <dd><p>Let <var>x-position</var> be 100 minus the <a>text track cue computed line position</a>
             minus the cue box width.</p></dd>
 
             <dt>If the <a>text track cue line alignment</a> is
-            <a title="text track cue text position middle alignment">middle alignment</a>:</dt>
+            <a title="text track cue text position middle alignment">middle alignment</a></dt>
             <dd><p>Let <var>x-position</var> be 100 minus the <a>text track cue computed line position</a>
             minus half of the cue box width.</p></dd>
 
             <dt>If the <a>text track cue line alignment</a> is
-            <a title="text track cue text position end alignment">end alignment</a>:</dt>
+            <a title="text track cue text position end alignment">end alignment</a></dt>
             <dd><p>Let <var>x-position</var> be 100 minus the <a>text track cue computed line position</a>.</p></dd>
           </dl>
         </dd>
 
         <dt>If the <a>text track cue writing direction</a> is
-        <a title="text track cue vertical growing right writing direction">vertical growing right</a>:</dt>
+        <a title="text track cue vertical growing right writing direction">vertical growing right</a></dt>
         <dd>
           <dl class="switch">
             <dt>If the <a>text track cue line alignment</a> is
-            <a title="text track cue text position start alignment">start alignment</a>:</dt>
+            <a title="text track cue text position start alignment">start alignment</a></dt>
             <dd><p>Let <var>x-position</var> be the <a>text track cue computed line position</a>.</p></dd>
 
             <dt>If the <a>text track cue line alignment</a> is
-            <a title="text track cue text position middle alignment">middle alignment</a>:</dt>
+            <a title="text track cue text position middle alignment">middle alignment</a></dt>
             <dd><p>Let <var>x-position</var> be the <a>text track cue computed line position</a> plus
             half of the cue box width.</p></dd>
 
             <dt>If the <a>text track cue line alignment</a> is
-            <a title="text track cue text position end alignment">end alignment</a>:</dt>
+            <a title="text track cue text position end alignment">end alignment</a></dt>
             <dd><p>Let <var>x-position</var> be the <a>text track cue computed line position</a> plus
             the cue box width.</p></dd>
           </dl>
@@ -4118,17 +4118,17 @@ Unicode paragraph of the cue. <a href="#refsBIDI">[BIDI]</a></p>
         </dl>
       </dd>
 
-      <dt>If the <a>text track cue snap-to-lines flag</a> is set:</dt>
+      <dt>If the <a>text track cue snap-to-lines flag</a> is set</dt>
       <dd>
         <dl class="switch">
 
         <dt>If the <a>text track cue writing direction</a> is
-        <a title="text track cue horizontal writing direction">horizontal</a>:</dt>
+        <a title="text track cue horizontal writing direction">horizontal</a></dt>
         <dd><p>Let <var>y-position</var> be 0.</p></dd>
 
         <dt>If the <a>text track cue writing direction</a> is
         <a title="text track cue vertical growing left writing direction">vertical growing left</a> or
-        <a title="text track cue vertical growing right writing direction">vertical growing right</a>:</dt>
+        <a title="text track cue vertical growing right writing direction">vertical growing right</a></dt>
         <dd><p>Let <var>x-position</var> be 0.</p></dd>
 
         </dl>
@@ -5412,7 +5412,7 @@ interface <dfn>VTTRegion</dfn> {
    <dd>
     <p>Returns a string representing the <a>text track region scroll</a> as follows:</p>
     <dl class="switch">
-     <dt>If it is unset.</dt>
+     <dt>If it is unset</dt>
      <dd><p>The empty string.</p></dd>
      <dt>If it is up</dt>
      <dd><p>The string "<code>up</code>".</p></dd>


### PR DESCRIPTION
The original WebVTT spec and current HTML spec does not use this style,
and no punctuation is still more common in this file.
