### PR TITLE
Moving the respec menu underneath the bug filing.

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -146,6 +146,10 @@
       opacity: 0.8;
       text-align: right;
     }
+    /* move respec button out of the way of the bug button */
+    #respec-ui{
+        top: 100px !important;
+    }
     </style>
   </head>
   <body>


### PR DESCRIPTION
This avoids overlap of these two boxes during spec development.
