### PR TITLE
Conformance for authors section in wrong place.

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -471,9 +471,9 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
   <section>
    <h2>Conformance</h2>
 
-   <h3>Conformance for authors</h3>
-
    <section>
+    <h3>Conformance for authors</h3>
+
     <p>The <a href="#h2_syntax">Syntax</a> section of this specification defines what consists a
     valid WebVTT document. Authors need to follow the <a href="#h2_syntax">Syntax</a> specification
     and are encouraged to use a validator.</p>


### PR DESCRIPTION
This makes sure that the "Conformance for authors" section gets into the
Table of Contents.
