### PR TITLE
Preparation of introductory sections for FPWD.

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -124,13 +124,19 @@
    href="http://www.w3.org/Bugs/Public/enter_bug.cgi?product=TextTracks%20CG&amp;component=WebVTT&amp;short_desc=%5BWebVTT%5D%20">our
    public bug database</a>.</p>
 
+   <p>This specification is being developed as a Living Specification in the <a
+   href="http://www.w3.org/community/texttracks/">Web Media Text Tracks Community Group</a>. A
+   snapshot version 1.0 of this specification is also being progressed through the <a
+   href="http://www.w3.org/AudioVideo/TT/">W3C Timed Text Working Group</a> to be published as a W3C
+   Recommendation for reference purposes.</p>
+
+   <p>To email the Timed Text Working Group, add [webvtt] at the start of your email's subject.
+   Implementors that target the Living Specification should provide feedback to the Community
+   Group.</p>
+
   </section>
 
-  <section id='sotd'>
-   <p>This specification is being developed as a Living Specification. There is a plan to take a
-   snapshot and publish it as a W3C Recommendation through the <a
-   href="http://www.w3.org/AudioVideo/TT/">W3C Timed Text Working Group</a>.</p>
-  </section>
+  <section id='sotd'></section>
 
   <section>
    <h2>Introduction</h2>


### PR DESCRIPTION
Emptying sotd and moving some wording into intro.

This replaces https://github.com/w3c/webvtt/pull/126 , https://github.com/w3c/webvtt/pull/125 and https://github.com/w3c/webvtt/pull/120
