### PR TITLE
Revert "Ask for feedback to public-texttracks to keep discussion in one ...

### DIFF
--- a/config-wg.js
+++ b/config-wg.js
@@ -30,7 +30,7 @@ var respecConfig = {
     wgURI: "http://www.w3.org/AudioVideo/TT/",
 
     // name (without the @w3c.org) of the public mailing to which comments are due
-    wgPublicList: "public-texttracks",
+    wgPublicList: "public-tt",
     wgPatentURI:  "http://www.w3.org/2004/01/pp-impl/34314/status#disclosures",
     processVersion: 2014,
 


### PR DESCRIPTION
Reverts w3c/webvtt#138

The pointer to the WG mailing list needs to remain the one to the TT-WG.
