### PR TITLE
Make the URL work again for CG version of spec.

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -9,8 +9,9 @@
    // Include the spec URL in bug reports.
    var specUrl = respecConfig.edDraftURI;
    if (respecConfig.shortName == "webvtt1") {
-     var specUrl = "http://www.w3.org/TR/webvtt1/";
+     specUrl = "http://www.w3.org/TR/webvtt1/";
    }
+
    respecConfig.bugTracker.new += "&amp;bug_file_loc=" + encodeURIComponent(specUrl);
   </script>
   <script>


### PR DESCRIPTION
This is likely a typo that led to double declaration of specUrl and
broke the URL for CG bugs.
