### PR TITLE
Mark the Media Accessibility User Requirements reference non-normative

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -5691,8 +5691,8 @@ interface <dfn>VTTRegion</dfn> {
     Berjon, T. Leithead, E. Doyle Navara, E. O'Connor, S. Pfeiffer. W3C.</dd>
 
     <dt id="refsMAUR">[MAUR]</dt>
-    <dd><cite><a href="http://www.w3.org/TR/media-accessibility-reqs/">Media Accessibility User
-    Requirements</a></cite>, S. McCarron, M. Cooper, M. Sadecki (eds). W3C.</dd>
+    <dd>(Non-normative) <cite><a href="http://www.w3.org/TR/media-accessibility-reqs/">Media
+    Accessibility User Requirements</a></cite>, S. McCarron, M. Cooper, M. Sadecki (eds). W3C.</dd>
 
     <dt id="refsRFC2119">[RFC2119]</dt>
     <dd><cite><a href="http://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate


### PR DESCRIPTION
The start of the references sections says:
All references are normative unless marked "Non-normative".
