### PR TITLE
Refer to DOM as a standard

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -562,7 +562,7 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
      <li><a href="https://encoding.spec.whatwg.org/#utf-8-decode"><dfn>UTF-8 decode</dfn></a></li>
     </ul>
 
-    <p>The following terms are defined in the DOM specification: [[!DOM]]</p>
+    <p>The following terms are defined in the DOM standard: [[!DOM]]</p>
 
     <ul class="brief">
      <li><a href="https://dom.spec.whatwg.org/#document"><dfn><code>Document</code></dfn></a>


### PR DESCRIPTION
For consistency with Encoding/HTML and because DOM calls itself a standard.
