### PR TITLE
Change "earlier" to "former" as the opposite of "latter"

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -223,8 +223,7 @@
    href="http://www.w3.org/community/texttracks/">Web Media Text Tracks Community Group</a> as well
    as in the <a href="http://www.w3.org/AudioVideo/TT/">W3C Timed Text Working Group</a>. The latter
    group works towards a W3C Recommendation for reference purposes with interoperability
-   requirements, while the earlier is as a Draft Community Group Report that continues to
-   evolve.</p>
+   requirements, while the former is a Draft Community Group Report that continues to evolve.</p>
   </section>
 
   <section>


### PR DESCRIPTION
As requested by David Singer.

Also drop a superfluous "as".
