### PR TITLE
Require the boxes in boxes, not output, to be within the title area box

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -4404,7 +4404,7 @@ The Final Minute</pre>
           </li>
 
           <li><p><i>Step loop</i>: If none of the boxes in <var>boxes</var> would overlap any of the
-          boxes in <var>output</var>, and all of the boxes in <var>output</var> are entirely within
+          boxes in <var>output</var>, and all of the boxes in <var>boxes</var> are entirely within
           the <var>title area</var> box, then jump to the step labeled <i>done positioning</i>
           below.</p></li>
 
@@ -4519,14 +4519,13 @@ The Final Minute</pre>
           </li>
 
           <li><p>If none of the boxes in <var>boxes</var> would overlap any of the boxes in
-          <var>output</var>, and all the boxes in <var>output</var> are within the
-          <var>video</var>'s rendering area, then jump to the step labeled <i>done positioning</i>
-          below.</p></li>
+          <var>output</var>, and all the boxes in <var>boxes</var> are within the <var>video</var>'s
+          rendering area, then jump to the step labeled <i>done positioning</i> below.</p></li>
 
           <li><p>If there is a position to which the boxes in <var>boxes</var> can be moved while
           maintaining the relative positions of the boxes in <var>boxes</var> to each other such
           that none of the boxes in <var>boxes</var> would overlap any of the boxes in
-          <var>output</var>, and all the boxes in <var>output</var> would be within the
+          <var>output</var>, and all the boxes in <var>boxes</var> would be within the
           <var>video</var>'s rendering area, then move the boxes in <var>boxes</var> to the closest
           such position to their current position, and then jump to the step labeled <i>done
           positioning</i> below. If there are multiple such positions that are equidistant from


### PR DESCRIPTION
This is almost equivalent as the "done positioning" step removes any
line boxes that do not completely fit inside the video, but as actually
implemented in at least Presto and Blink, it's the boxes in boxes which
are checked, not all of the boxes in output. Make this explicitly so.