### PR TITLE
Rename the section on WebVTT cues

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -695,7 +695,7 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
    <!-- Describe metadata, caption/subtitle, chapter & description cues -->
 
    <section>
-    <h3>Text track cues</h3>
+    <h3>WebVTT cues</h3>
 
     <p>WebVTT cues are HTML <a title="text track cue">text track cues</a> that additionally consist
     of the following: [[!HTML]]</p>
@@ -5627,7 +5627,8 @@ interface <dfn>VTTRegion</dfn> {
     Giuseppe Pascale,
     Simon Pieters,
     Caitlin Potter,
-    David Singer.
+    David Singer,
+    Andreas Tai.
    </p>
 
   </section>


### PR DESCRIPTION
https://www.w3.org/Bugs/Public/show_bug.cgi?id=28070

This leaves the "Text track regions" section looking out of place:
https://www.w3.org/Bugs/Public/show_bug.cgi?id=28098