### PR TITLE
Remove inaccurate description of writing direction

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -728,10 +728,6 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
       horizontally, with consecutive lines displayed to the right of each other<!-- used for
       mongolian -->).</p>
 
-      <p>The writing direction is a property of the text inside the <a title="text track cue
-      box">cue box</a> which influences the interpretation of the positioning settings of the <a
-      title="text track cue box">cue box</a>.</p>
-
       <p>If the <a title="text track cue writing direction">writing direction</a> is <a title="text
       track cue horizontal writing direction">horizontal</a>, then the <a title="text track cue line
       position">line position</a> percentages are relative to the height of the video, and <a


### PR DESCRIPTION
This paragraph appears to conflate the writing direction, which is a
setting on the cue, with the paragraph embedding level and direction,
which are properties determined by applying the Unicode Bidirectional
Algorithm.

Introduced in commit 86ba250eaf7d2e53f614d684755ef13d089c7652.

Noticed due to https://www.w3.org/Bugs/Public/show_bug.cgi?id=28071