### PR TITLE
Don't use quotes around 'true' as it is not a string

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -760,7 +760,7 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
       as requested (modulo overlap avoidance if multiple cues are in the same place).</p>
 
       <p>By default, the <a title="text track cue snap-to-lines flag">snap-to-lines flag</a> is set
-      to 'true'.</p>
+      to true.</p>
 
      </dd>
 


### PR DESCRIPTION
This is consistent with many other uses of "be true" and "be false",
as in "Let cue's text track cue snap-to-lines flag be true."