### PR TITLE
Use consistent linking scheme to whatwg spec.

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -671,7 +671,7 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
      href="https://html.spec.whatwg.org/#rules-for-updating-the-text-track-rendering"><dfn>Rules for
      updating the text track rendering</dfn></a></li>
      <li><a
-     href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-rules-for-extracting-the-chapter-title"><dfn>Rules
+     href="https://html.spec.whatwg.org/#text-track-rules-for-extracting-the-chapter-title"><dfn>Rules
      for extracting the chapter title</dfn></a></li>
      <li><a
      href="https://html.spec.whatwg.org/#texttrackcue"><dfn><code>TextTrackCue</code></dfn></a>


### PR DESCRIPTION
All other links got directly to the single page spec and only this one
was to the multipage version.