### PR TITLE
Rename "text track region" to "WebVTT region"

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -857,8 +857,8 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
       automatic text position">auto</dfn>, which means the position is to depend on the <a
       title="text track cue text alignment">text alignment</a> of the cue.</p>
 
-      <p>If the cue is not within a <a title="text track region">region</a>, the percentage value is
-      to be interpreted as a percentage of the video dimensions, otherwise as a percentage of the
+      <p>If the cue is not within a <a title="WebVTT region">region</a>, the percentage value is to
+      be interpreted as a percentage of the video dimensions, otherwise as a percentage of the
       region dimensions.</p>
 
       <p>A <a>WebVTT cue</a> has a <dfn>text track cue computed text position</dfn> whose value is
@@ -1009,7 +1009,7 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
 
      <dt><dfn title="text track cue region">A region</dfn></dt>
      <dd>
-      <p>An optional <a>text track region</a> to which a cue belongs.</p>
+      <p>An optional <a>WebVTT region</a> to which a cue belongs.</p>
      </dd>
 
     </dl>
@@ -1033,12 +1033,12 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
    </section>
 
    <section>
-    <h3>Text track regions</h3>
+    <h3>WebVTT regions</h3>
 
-    <p>A <dfn title="text track region">text track region</dfn> represents a subpart of the video
-    viewport and provides a rendering area for <a title="WebVTT cue">WebVTT cues</a>.</p>
+    <p>A <dfn>WebVTT region</dfn> represents a subpart of the video viewport and provides a
+    rendering area for <a title="WebVTT cue">WebVTT cues</a>.</p>
 
-    <p>Each <a title="text track region">text track region</a> consists of:</p>
+    <p>Each <a>WebVTT region</a> consists of:</p>
 
     <dl>
 
@@ -1104,7 +1104,7 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
 
      <dd>
 
-      <p>A list of zero or more <a title="text track region">text track regions</a>.</p>
+      <p>A list of zero or more <a title="WebVTT region">WebVTT regions</a>.</p>
 
      </dd>
     </dl>
@@ -1589,9 +1589,8 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
    <section>
     <h3>WebVTT region definition</h3>
 
-    <p>A <a>WebVTT cue settings list</a> may contain a reference to a <a title="text track
-    region">text track region</a>. To define a region, a <a>WebVTT region metadata header</a> is
-    specified.</p>
+    <p>A <a>WebVTT cue settings list</a> may contain a reference to a <a>WebVTT region</a>. To
+    define a region, a <a>WebVTT region metadata header</a> is specified.</p>
 
     <p>A <dfn>WebVTT region metadata header</dfn> is a special kind of <a>WebVTT metadata header</a>
     where both of the following apply:</p>
@@ -1600,9 +1599,6 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
      <li>The <a>WebVTT metadata header name</a> is the string "<code>Region</code>".</li>
      <li>The <a>WebVTT metadata header value</a> is a <a>WebVTT region setting list</a>.</li>
     </ul>
-
-    <p>A <dfn>WebVTT region</dfn> represents its <a title="WebVTT region setting list">WebVTT region
-    settings</a>.</p>
 
     <p>The <dfn>WebVTT region setting list</dfn> of a <a>WebVTT region metadata header</a> consists
     of zero or more of the following components, in any order, separated from each other by one or
@@ -2137,7 +2133,7 @@ The Final Minute</pre>
         <p>If <a title="WebVTT metadata header name">metadata's name</a> equals "Region":</p>
 
         <ol>
-         <li><i>Region creation</i>: Let <var>region</var> be a new <a>text track region</a>.</li>
+         <li><i>Region creation</i>: Let <var>region</var> be a new <a>WebVTT region</a>.</li>
          <li>Let <var>region</var>'s <a title="text track region identifier">identifier</a> be the
          empty string.</li>
          <li>Let <var>region</var>'s <a title="text track region width">width</a> be 100.</li>
@@ -2556,9 +2552,9 @@ The Final Minute</pre>
 
          <dd>
           <ol>
-           <li><p>Let <var>cue</var>'s <a>text track cue region</a> be the last <a>text track
-           region</a> in <var>regions</var> whose <a>text track region identifier</a> is
-           <var>value</var>, if any, or null otherwise.</p></li>
+           <li><p>Let <var>cue</var>'s <a>text track cue region</a> be the last <a>WebVTT region</a>
+           in <var>regions</var> whose <a>text track region identifier</a> is <var>value</var>, if
+           any, or null otherwise.</p></li>
           </ol>
          </dd>
 
@@ -3744,15 +3740,15 @@ The Final Minute</pre>
      <a title="text track cue">cues</a> from <var>track</var>'s <a title="text track list of
      cues">list of cues</a> that have their <a>text track cue active flag</a> set.</p></li>
 
-     <li><p>Let <var>regions</var> be an empty list of <a title="text track region">text track
+     <li><p>Let <var>regions</var> be an empty list of <a title="WebVTT region">WebVTT
      regions</a>.</p></li>
 
      <li><p>For each track <var>track</var> in <var>tracks</var>, append to <var>regions</var> all
-     the <a title="text track region">regions</a> from <var>track</var>'s <a title="text track list
-     of regions">list of regions</a>.</p></li>
+     the <a title="WebVTT region">regions</a> from <var>track</var>'s <a title="text track list of
+     regions">list of regions</a>.</p></li>
 
-     <li><p>If <var>reset</var> is false, then, for each <a>text track region</a> <var>region</var>
-     in <var>regions</var> let <var>regionNode</var> be a <a>WebVTT region object</a>.</p></li>
+     <li><p>If <var>reset</var> is false, then, for each <a>WebVTT region</a> <var>region</var> in
+     <var>regions</var> let <var>regionNode</var> be a <a>WebVTT region object</a>.</p></li>
 
      <li>
       <p>Apply the following steps for each <var>regionNode</var>:</p>
@@ -4630,7 +4626,7 @@ The Final Minute</pre>
     </ul>
     <p>The variables <var>width</var>, <var>height</var>, <var>top</var>, and <var>left</var> are
     the values with those names determined by the <a>rules for updating the display of WebVTT text
-    tracks</a> for the <a>text track region</a> from which the <a>WebVTT region object</a> was
+    tracks</a> for the <a>WebVTT region</a> from which the <a>WebVTT region object</a> was
     constructed.</p>
 
     <p>The children of every <a>WebVTT region object</a> are further initialized with these CSS
@@ -5398,7 +5394,7 @@ interface <dfn>VTTRegion</dfn> {
     invoked, must run the following steps:</p>
 
     <ol>
-     <li><p>Create a new <a>text track region</a>. Let <var>region</var> be that <a>text track
+     <li><p>Create a new <a>WebVTT region</a>. Let <var>region</var> be that <a>WebVTT
      region</a>.</p></li>
 
      <!-- default settings -->
@@ -5427,42 +5423,42 @@ interface <dfn>VTTRegion</dfn> {
     </ol>
 
     <p>The <dfn title="VTTRegion-width"><code>width</code></dfn> attribute, on getting, must return
-    the <a>text track region width</a> of the <a>text track region</a> that the
+    the <a>text track region width</a> of the <a>WebVTT region</a> that the
     <a><code>VTTRegion</code></a> object represents, in percent of video width. On setting, the
     <a>text track region width</a> must be set to the new value, interpreted as a percentage.</p>
 
     <p>The <dfn title="VTTRegion-lines"><code>lines</code></dfn> attribute, on getting, must return
-    the <a>text track region lines</a> of the <a>text track region</a> that the
+    the <a>text track region lines</a> of the <a>WebVTT region</a> that the
     <a><code>VTTRegion</code></a> object represents, as number of lines. On setting, the <a>text
     track region lines</a> must be set to the new value, interpreted as a number of lines.</p>
 
     <p>The <dfn title="VTTRegion-regionAnchorX"><code>regionAnchorX</code></dfn> attribute, on
-    getting, must return the <a>text track region anchor</a> X offset of the <a>text track
-    region</a> that the <a><code>VTTRegion</code></a> object represents, in percent of region width.
-    On setting, the <a>text track region anchor</a> X distance must be set to the new value,
+    getting, must return the <a>text track region anchor</a> X offset of the <a>WebVTT region</a>
+    that the <a><code>VTTRegion</code></a> object represents, in percent of region width. On
+    setting, the <a>text track region anchor</a> X distance must be set to the new value,
     interpreted as a percentage.</p>
 
     <p>The <dfn title="VTTRegion-regionAnchorY"><code>regionAnchorY</code></dfn> attribute, on
-    getting, must return the <a>text track region anchor</a> Y offset of the <a>text track
-    region</a> that the <a><code>VTTRegion</code></a> object represents, in percent of region
-    height. On setting, the <a>text track region anchor</a> Y distance must be set to the new value,
+    getting, must return the <a>text track region anchor</a> Y offset of the <a>WebVTT region</a>
+    that the <a><code>VTTRegion</code></a> object represents, in percent of region height. On
+    setting, the <a>text track region anchor</a> Y distance must be set to the new value,
     interpreted as a percentage.</p>
 
     <p>The <dfn title="VTTRegion-viewportAnchorX"><code>viewportAnchorX</code></dfn> attribute, on
-    getting, must return the <a>text track region viewport anchor</a> X offset of the <a>text track
+    getting, must return the <a>text track region viewport anchor</a> X offset of the <a>WebVTT
     region</a> that the <a><code>VTTRegion</code></a> object represents, in percent of video width.
     On setting, the <a>text track region viewport anchor</a> X distance must be set to the new
     value, interpreted as a percentage.</p>
 
     <p>The <dfn title="VTTRegion-viewportAnchorY"><code>viewportAnchorY</code></dfn> attribute, on
-    getting, must return the <a>text track region viewport anchor</a> Y offset of the <a>text track
+    getting, must return the <a>text track region viewport anchor</a> Y offset of the <a>WebVTT
     region</a> that the <a><code>VTTRegion</code></a> object represents, in percent of video height.
     On setting, the <a>text track region viewport anchor</a> Y distance must be set to the new
     value, interpreted as a percentage.</p>
 
     <p>The <dfn title="VTTRegion-scroll"><code>scroll</code></dfn> attribute, on getting, must
     return the string from the second cell of the row in the table below whose first cell is the
-    <a>text track region scroll</a> setting of the <a>text track region</a> that the
+    <a>text track region scroll</a> setting of the <a>WebVTT region</a> that the
     <a><code>VTTRegion</code></a> object represents:</p>
     <table>
      <thead>


### PR DESCRIPTION
This makes the section title consistent with cues:
https://github.com/w3c/webvtt/pull/173

However, all of the "text track region *" concepts are left intact, just
like the many WebVTT-specific "text track cue *" concepts. These all
need to be renamed as well.