### PR TITLE
Don't automatically add *.png to CVS

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -58,5 +58,4 @@ if [ -z "$FORCE" ]; then
 fi
 COMMIT="$(git rev-parse HEAD)"
 cd html5/webvtt
-cvs add *.png
 cvs commit -m "Sync WebVTT with Git commit $COMMIT"


### PR DESCRIPTION
cvs add fails if the file is already added, so add new images manually
when needed, which will be rarely.