### PR TITLE
Drop the WebVTT prefix from cue computed definitions

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -1821,9 +1821,9 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
     given as a percentage of the video frame. The positioning is calculated relative to the <a
     title="WebVTT cue text position start alignment">start</a>, <a title="WebVTT cue text position
     middle alignment">middle</a>, or <a title="WebVTT cue text position end alignment">end</a> of
-    the cue box, depending on the <a title="cue computed text position alignment">computed text
-    position alignment</a> value, which is overridden by the <a>WebVTT text position cue setting</a>
-    alignment value.</p>
+    the cue box, depending on the cue's <a title="cue computed text position alignment">computed
+    text position alignment</a>, which is overridden by the <a>WebVTT text position cue
+    setting</a>.</p>
 
     <p>A <dfn>WebVTT size cue setting</dfn> consists of the following components, in the order
     given:</p>
@@ -3854,12 +3854,13 @@ The Final Minute</pre>
          <i>paragraph direction</i> is left-to-right), let <var>direction</var> be 'ltr', otherwise,
          let it be 'rtl'.</p></li>
 
-         <li><p>Let <var>offset</var> be the <a title="cue computed text position">computed text
-         position</a> multiplied by <var>region</var>'s <a>WebVTT region width</a> and divided by
-         100 (i.e. interpret it as a percentage of the region width).</p></li>
+         <li><p>Let <var>offset</var> be <var>cue</var>'s <a title="cue computed text
+         position">computed text position</a> multiplied by <var>region</var>'s <a>WebVTT region
+         width</a> and divided by 100 (i.e. interpret it as a percentage of the region
+         width).</p></li>
 
          <li>
-          <p>Adjust <var>offset</var> using the <a title="cue computed text position
+          <p>Adjust <var>offset</var> using <var>cue</var>'s <a title="cue computed text position
           alignment">computed text position alignment</a> as follows:</p>
           <dl class="switch">
            <dt>If the <a title="cue computed text position alignment">computed text position
@@ -4325,8 +4326,8 @@ The Final Minute</pre>
          <li><p>If <var>step</var> is zero, then jump to the step labeled <i>done positioning</i>
          below.</p></li>
 
-         <li><p>Let <var>line position</var> be the <a title="cue computed line position">computed
-         line position</a>.</p></li>
+         <li><p>Let <var>line position</var> be <var>cue</var>'s <a title="cue computed line
+         position">computed line position</a>.</p></li>
 
          <li><p>Round <var>line position</var> to an integer by adding 0.5 and then flooring
          it.</p></li>

--- a/webvtt.html
+++ b/webvtt.html
@@ -769,9 +769,9 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
       value <dfn title="WebVTT cue automatic line position">auto</dfn>, which means the position is
       to depend on the other showing tracks.</p>
 
-      <p>A <a>WebVTT cue</a> has a <dfn>WebVTT cue computed line position</dfn> whose value is that
-      returned by the following algorithm, which is defined in terms of the other aspects of the
-      cue:</p>
+      <p>A <a>WebVTT cue</a> has a <dfn title="cue computed line position">computed line
+      position</dfn> whose value is that returned by the following algorithm, which is defined in
+      terms of the other aspects of the cue:</p>
 
       <ol>
 
@@ -857,9 +857,9 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
       be interpreted as a percentage of the video dimensions, otherwise as a percentage of the
       region dimensions.</p>
 
-      <p>A <a>WebVTT cue</a> has a <dfn>WebVTT cue computed text position</dfn> whose value is that
-      returned by the following algorithm, which is defined in terms of the other aspects of the
-      cue:</p>
+      <p>A <a>WebVTT cue</a> has a <dfn title="cue computed text position">computed text
+      position</dfn> whose value is that returned by the following algorithm, which is defined in
+      terms of the other aspects of the cue:</p>
 
       <ol>
 
@@ -925,9 +925,9 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
 
       </dl>
 
-      <p>A <a>WebVTT cue</a> has a <dfn>WebVTT cue computed text position alignment</dfn> whose
-      value is that returned by the following algorithm, which is defined in terms of other aspects
-      of the cue:</p>
+      <p>A <a>WebVTT cue</a> has a <dfn title="cue computed text position alignment">computed text
+      position alignment</dfn> whose value is that returned by the following algorithm, which is
+      defined in terms of other aspects of the cue:</p>
 
       <ol>
 
@@ -1821,8 +1821,9 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
     given as a percentage of the video frame. The positioning is calculated relative to the <a
     title="WebVTT cue text position start alignment">start</a>, <a title="WebVTT cue text position
     middle alignment">middle</a>, or <a title="WebVTT cue text position end alignment">end</a> of
-    the cue box, depending on the <a>WebVTT cue computed text position alignment</a> value, which is
-    overridden by the <a>WebVTT text position cue setting</a> alignment value.</p>
+    the cue box, depending on the <a title="cue computed text position alignment">computed text
+    position alignment</a> value, which is overridden by the <a>WebVTT text position cue setting</a>
+    alignment value.</p>
 
     <p>A <dfn>WebVTT size cue setting</dfn> consists of the following components, in the order
     given:</p>
@@ -3853,21 +3854,22 @@ The Final Minute</pre>
          <i>paragraph direction</i> is left-to-right), let <var>direction</var> be 'ltr', otherwise,
          let it be 'rtl'.</p></li>
 
-         <li><p>Let <var>offset</var> be the <a>WebVTT cue computed text position</a> multiplied by
-         <var>region</var>'s <a>WebVTT region width</a> and divided by 100 (i.e. interpret it as a
-         percentage of the region width).</p></li>
+         <li><p>Let <var>offset</var> be the <a title="cue computed text position">computed text
+         position</a> multiplied by <var>region</var>'s <a>WebVTT region width</a> and divided by
+         100 (i.e. interpret it as a percentage of the region width).</p></li>
 
          <li>
-          <p>Adjust <var>offset</var> using the <a>WebVTT cue computed text position alignment</a>
-          as follows:</p>
+          <p>Adjust <var>offset</var> using the <a title="cue computed text position
+          alignment">computed text position alignment</a> as follows:</p>
           <dl class="switch">
-           <dt>If the <a>WebVTT cue computed text position alignment</a> is <a title="WebVTT cue
-           text position middle alignment">middle alignment</a></dt>
+           <dt>If the <a title="cue computed text position alignment">computed text position
+           alignment</a> is <a title="WebVTT cue text position middle alignment">middle
+           alignment</a></dt>
            <dd><p>Subtract half of <var>region</var>'s <a>WebVTT region width</a> from
            <var>offset</var>.</p></dd>
 
-           <dt>If the <a>WebVTT cue computed text position alignment</a> is <a title="WebVTT cue
-           text position end alignment">end alignment</a></dt>
+           <dt>If the <a title="cue computed text position alignment">computed text position
+           alignment</a> is <a title="WebVTT cue text position end alignment">end alignment</a></dt>
            <dd><p>Subtract <var>region</var>'s <a>WebVTT region width</a> from
            <var>offset</var>.</p></dd>
           </dl>
@@ -3954,33 +3956,36 @@ The Final Minute</pre>
 
       <dl class="switch">
 
-       <dt>If the <a>WebVTT cue computed text position alignment</a> is <a title="WebVTT cue text
-       position start alignment">start</a></dt>
+       <dt>If the <a title="cue computed text position alignment">computed text position
+       alignment</a> is <a title="WebVTT cue text position start alignment">start</a></dt>
        <dd>
-        <p>Let <var>maximum size</var> be the <a>WebVTT cue computed text position</a> subtracted
-        from 100.</p>
+        <p>Let <var>maximum size</var> be the <a title="cue computed text position">computed text
+        position</a> subtracted from 100.</p>
        </dd>
 
-       <dt>If the <a>WebVTT cue computed text position alignment</a> is <a title="WebVTT cue text
-       position end alignment">end</a></dt>
+       <dt>If the <a title="cue computed text position alignment">computed text position
+       alignment</a> is <a title="WebVTT cue text position end alignment">end</a></dt>
        <dd>
-        <p>Let <var>maximum size</var> be the <a>WebVTT cue computed text position</a>.</p>
+        <p>Let <var>maximum size</var> be the <a title="cue computed text position">computed text
+        position</a>.</p>
        </dd>
 
-       <dt>If the <a>WebVTT cue computed text position alignment</a> is <a title="WebVTT cue text
-       position middle alignment">middle</a>, and the <a>WebVTT cue computed text position</a> is
-       less than or equal to 50</dt>
+       <dt>If the <a title="cue computed text position alignment">computed text position
+       alignment</a> is <a title="WebVTT cue text position middle alignment">middle</a>, and the <a
+       title="cue computed text position">computed text position</a> is less than or equal to
+       50</dt>
        <dd>
-        <p>Let <var>maximum size</var> be the <a>WebVTT cue computed text position</a> multiplied by
-        two.</p>
+        <p>Let <var>maximum size</var> be the <a title="cue computed text position">computed text
+        position</a> multiplied by two.</p>
        </dd>
 
-       <dt>If the <a>WebVTT cue computed text position alignment</a> is <a title="WebVTT cue text
-       position middle alignment">middle</a>, and the <a>WebVTT cue computed text position</a> is
-       greater than <!-- or equal to --> 50</dt>
+       <dt>If the <a title="cue computed text position alignment">computed text position
+       alignment</a> is <a title="WebVTT cue text position middle alignment">middle</a>, and the <a
+       title="cue computed text position">computed text position</a> is greater than <!-- or equal
+       to --> 50</dt>
        <dd>
-        <p>Let <var>maximum size</var> be the result of subtracting <a>WebVTT cue computed text
-        position</a> from 100 and then multiplying the result by two.</p>
+        <p>Let <var>maximum size</var> be the result of subtracting <a title="cue computed text
+        position">computed text position</a> from 100 and then multiplying the result by two.</p>
        </dd>
 
       </dl>
@@ -4008,19 +4013,22 @@ The Final Minute</pre>
        direction">horizontal</a></dt>
        <dd>
         <dl class="switch">
-         <dt>If the <a>WebVTT cue computed text position alignment</a> is <a title="WebVTT cue text
-         position start alignment">start alignment</a></dt>
-         <dd><p>Let <var>x-position</var> be the <a>WebVTT cue computed text position</a>.</p></dd>
+         <dt>If the <a title="cue computed text position alignment">computed text position
+         alignment</a> is <a title="WebVTT cue text position start alignment">start
+         alignment</a></dt>
+         <dd><p>Let <var>x-position</var> be the <a title="cue computed text position">computed text
+         position</a>.</p></dd>
 
-         <dt>If the <a>WebVTT cue computed text position alignment</a> is <a title="WebVTT cue text
-         position middle alignment">middle alignment</a></dt>
-         <dd><p>Let <var>x-position</var> be the <a>WebVTT cue computed text position</a> minus half
-         of <var>size</var>.</p></dd>
+         <dt>If the <a title="cue computed text position alignment">computed text position
+         alignment</a> is <a title="WebVTT cue text position middle alignment">middle
+         alignment</a></dt>
+         <dd><p>Let <var>x-position</var> be the <a title="cue computed text position">computed text
+         position</a> minus half of <var>size</var>.</p></dd>
 
-         <dt>If the <a>WebVTT cue computed text position alignment</a> is <a title="WebVTT cue text
-         position end alignment">end alignment</a></dt>
-         <dd><p>Let <var>x-position</var> be the <a>WebVTT cue computed text position</a> minus
-         <var>size</var>.</p></dd>
+         <dt>If the <a title="cue computed text position alignment">computed text position
+         alignment</a> is <a title="WebVTT cue text position end alignment">end alignment</a></dt>
+         <dd><p>Let <var>x-position</var> be the <a title="cue computed text position">computed text
+         position</a> minus <var>size</var>.</p></dd>
         </dl>
        </dd>
 
@@ -4029,19 +4037,22 @@ The Final Minute</pre>
        writing direction">vertical growing right</a></dt>
        <dd>
         <dl class="switch">
-         <dt>If the <a>WebVTT cue computed text position alignment</a> is <a title="WebVTT cue text
-         position start alignment">start alignment</a></dt>
-         <dd><p>Let <var>y-position</var> be the <a>WebVTT cue computed text position</a>.</p></dd>
+         <dt>If the <a title="cue computed text position alignment">computed text position
+         alignment</a> is <a title="WebVTT cue text position start alignment">start
+         alignment</a></dt>
+         <dd><p>Let <var>y-position</var> be the <a title="cue computed text position">computed text
+         position</a>.</p></dd>
 
-         <dt>If the <a>WebVTT cue computed text position alignment</a> is <a title="WebVTT cue text
-         position middle alignment">middle alignment</a></dt>
-         <dd><p>Let <var>y-position</var> be the <a>WebVTT cue computed text position</a> minus half
-         of <var>size</var>.</p></dd>
+         <dt>If the <a title="cue computed text position alignment">computed text position
+         alignment</a> is <a title="WebVTT cue text position middle alignment">middle
+         alignment</a></dt>
+         <dd><p>Let <var>y-position</var> be the <a title="cue computed text position">computed text
+         position</a> minus half of <var>size</var>.</p></dd>
 
-         <dt>If the <a>WebVTT cue computed text position alignment</a> is <a title="WebVTT cue text
-         position end alignment">end alignment</a></dt>
-         <dd><p>Let <var>y-position</var> be the <a>WebVTT cue computed text position</a> minus
-         <var>size</var>.</p></dd>
+         <dt>If the <a title="cue computed text position alignment">computed text position
+         alignment</a> is <a title="WebVTT cue text position end alignment">end alignment</a></dt>
+         <dd><p>Let <var>y-position</var> be the <a title="cue computed text position">computed text
+         position</a> minus <var>size</var>.</p></dd>
         </dl>
        </dd>
 
@@ -4062,12 +4073,14 @@ The Final Minute</pre>
 
          <dt>If the <a>WebVTT cue writing direction</a> is <a title="WebVTT cue horizontal writing
          direction">horizontal</a></dt>
-         <dd><p>Let <var>y-position</var> be the <a>WebVTT cue computed line position</a>.</p></dd>
+         <dd><p>Let <var>y-position</var> be the <a title="cue computed line position">computed line
+         position</a>.</p></dd>
 
          <dt>If the <a>WebVTT cue writing direction</a> is <a title="WebVTT cue vertical growing
          left writing direction">vertical growing left</a> or <a title="WebVTT cue vertical growing
          right writing direction">vertical growing right</a></dt>
-         <dd><p>Let <var>x-position</var> be the <a>WebVTT cue computed line position</a>.</p></dd>
+         <dd><p>Let <var>x-position</var> be the <a title="cue computed line position">computed line
+         position</a>.</p></dd>
 
         </dl>
        </dd>
@@ -4312,8 +4325,8 @@ The Final Minute</pre>
          <li><p>If <var>step</var> is zero, then jump to the step labeled <i>done positioning</i>
          below.</p></li>
 
-         <li><p>Let <var>line position</var> be the <a>WebVTT cue computed line
-         position</a>.</p></li>
+         <li><p>Let <var>line position</var> be the <a title="cue computed line position">computed
+         line position</a>.</p></li>
 
          <li><p>Round <var>line position</var> to an integer by adding 0.5 and then flooring
          it.</p></li>


### PR DESCRIPTION
It's very repetetive in cases like "A WebVTT cue has a WebVTT cue
computed line position" and isn't needed to disambiguate.

This is the first commit of several indented to separate the
defintitions as follows:

 * "cue x" for the text track cue and WebVTT model
 * "WebVTT cue x" for the syntax
 * "vttcue-x" for the VTTCue API