### PR TITLE
The word "contribution" has legal implications.

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -5574,8 +5574,8 @@ interface <dfn>VTTRegion</dfn> {
    the SubRip software program whose SRT file format was used as the basis for the WebVTT text track
    file format.</p>
 
-   <p>Thanks to the many contributors to the HTML standard, where WebVTT was originally specified.
-   [[!HTML]]</p>
+   <p>Thanks to Ian Hickson and many others for their work on the HTML standard, where WebVTT was
+   originally specified. [[!HTML]]</p>
 
    <p>
     Further thanks to:

--- a/webvtt.html
+++ b/webvtt.html
@@ -5578,7 +5578,7 @@ interface <dfn>VTTRegion</dfn> {
    [[!HTML]]</p>
 
    <p>
-    Thanks to the following active contributors to this spec:
+    Further thanks to:
     Glenn Adams,
     Victor C&#259;rbune,
     Eric Carlson,


### PR DESCRIPTION
The legal implications of "contribution" on IPR are far more involved
than what the actual contributions of the listed people were, in
particular with respect to patents. Avoid the word.

As requested in an email thread with Thierry, Philippe and David.