### PR TITLE
Replace "group of selectors" with "selector".

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -4712,9 +4712,9 @@ The Final Minute</pre>
      </ul>
 
      <p>The '<dfn title="pseudo-cue-selector">::cue(<var>selector</var>)</dfn>' pseudo-element with
-     an argument must have an argument that consists of a group of selectors. It matches any
+     an argument must have an argument that consists of a CSS selector [[!SELECTORS]]. It matches any
      <a>WebVTT Internal Node Object</a> constructed for the <i>matched element</i> that also matches
-     the given group of selectors, with the nodes being treated as follows:</p>
+     the given CSS selector, with the nodes being treated as follows:</p>
 
      <ul>
 


### PR DESCRIPTION
Selectors Level 4 has a new definition for selectors:
http://www.w3.org/TR/selectors4/#syntax
Fixes https://www.w3.org/Bugs/Public/show_bug.cgi?id=28472