### PR TITLE
Disallow WebVTT metadata and cue settings zero length. 

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -1168,7 +1168,7 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
     </ol>
 
     <p>A <dfn>WebVTT metadata header name</dfn> and a <dfn>WebVTT metadata header value</dfn> each
-    consist of any sequence of zero or more characters other than U+000A LINE FEED (LF) characters
+    consist of any sequence of one or more characters other than U+000A LINE FEED (LF) characters
     and U+000D CARRIAGE RETURN (CR) characters except that the entire resulting string must not
     contain the substring "<code>--></code>" (U+002D HYPHEN-MINUS, U+002D HYPHEN-MINUS, U+003E
     GREATER-THAN SIGN).</p>
@@ -1313,7 +1313,7 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
     </ol>
 
     <p>A <dfn>WebVTT cue setting name</dfn> and a <dfn>WebVTT cue setting value</dfn> each consist
-    of any sequence of zero or more characters other than U+000A LINE FEED (LF) characters and
+    of any sequence of one or more characters other than U+000A LINE FEED (LF) characters and -
     U+000D CARRIAGE RETURN (CR) characters except that the entire resulting string must not contain
     the substring "<code>--></code>" (U+002D HYPHEN-MINUS, U+002D HYPHEN-MINUS, U+003E GREATER-THAN
     SIGN).</p>


### PR DESCRIPTION
Closes https://www.w3.org/Bugs/Public/show_bug.cgi?id=28259