### PR TITLE
Drop mention of media timeline origin

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -1242,8 +1242,7 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
     cue block</a>. Different cues can overlap. Cues are always listed ordered by their start
     time.</p>
 
-    <p>A <dfn>WebVTT timestamp</dfn> consists of the following components, in the given
-    order:</p>
+    <p>A <dfn>WebVTT timestamp</dfn> consists of the following components, in the given order:</p>
 
     <ol>
 
@@ -1277,8 +1276,7 @@ Region: id=bill width=40% lines=3 regionanchor=100%,100% viewportanchor=90%,90% 
     </ol>
 
     <p class="note">A <a>WebVTT timestamp</a> is always interpreted relative to the <a>current
-    playback position</a> of the media data that the WebVTT file is to be synchronized with, which
-    always starts at 0.</p>
+    playback position</a> of the media data that the WebVTT file is to be synchronized with.</p>
 
     <p>A <dfn>WebVTT cue settings list</dfn> consist of a sequence of zero or more <dfn
     title="WebVTT cue setting">WebVTT cue settings</dfn> in any order, separated from each other by


### PR DESCRIPTION
It isn't guaranteed to start at zero:
https://html.spec.whatwg.org/#media-timeline