### PR TITLE
proposed fix for Bug 28267- remove work-wrap leaving only overflow-wrap

### DIFF
--- a/webvtt.html
+++ b/webvtt.html
@@ -4610,7 +4610,6 @@ The Final Minute</pre>
      <li>the 'position' property must be set to 'absolute'</li>
      <li>the 'writing-mode' property must be set to 'horizontal-tb'</li>
      <li>the 'background' shorthand property must be set to 'rgba(0,0,0,0.8)'</li>
-     <li>the 'word-wrap' property must be set to 'break-word'</li>
      <li>the 'overflow-wrap' property must be set to 'break-word'</li>
      <li>the 'font' shorthand property must be set to 'calc(5.33vh/1.3) sans-serif'</li>
      <li>the 'line-height' shorthand property must be set to '5.33vh'</li>


### PR DESCRIPTION
Based on the comments in https://www.w3.org/Bugs/Public/show_bug.cgi?id=28267, I think that this issue can be resolved with the patch included here.  

In the section of the document that describes the CSS settings that every WebVTT region is initialized with, the word-wrap property line can be removed . The overflow-wrap line is already included.