### PR TITLE
Fix #234: Use a default background for <rt>

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4500,8 +4500,8 @@ corresponding <a lt="text track cue">cue</a>'s <a>WebVTT cue text alignment</a>:
 <p>The 'color' property on the (root) <a>list of WebVTT Node Objects</a> must be set to
 'rgba(255,255,255,1)'. [[!CSS3-COLOR]]</p>
 
-<p>The 'background' shorthand property on the <a>WebVTT cue background box</a> must be set to
-'rgba(0,0,0,0.8)'. [[!CSS3-COLOR]]</p>
+<p>The 'background' shorthand property on the <a>WebVTT cue background box</a> and on <a>WebVTT Ruby
+Text Objects</a> must be set to 'rgba(0,0,0,0.8)'. [[!CSS3-COLOR]]</p>
 
 <p>The 'white-space' property on the (root) <a>list of WebVTT Node Objects</a> must be set to
 ''white-space/pre-line''. [[!CSS21]]</p>

--- a/index.html
+++ b/index.html
@@ -4463,8 +4463,8 @@ corresponding <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
 '5vh sans-serif'. <a data-link-type="biblio" href="#biblio-css3-ruby">[CSS3-RUBY]</a> <a data-link-type="biblio" href="#biblio-css-values">[CSS-VALUES]</a></p>
    <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-color-4/#propdef-color">color</a> property on the (root) <a data-link-type="dfn" href="#list-of-webvtt-node-objects">list of WebVTT Node Objects</a> must be set to
 'rgba(255,255,255,1)'. <a data-link-type="biblio" href="#biblio-css3-color">[CSS3-COLOR]</a></p>
-   <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#background">background</a> shorthand property on the <a data-link-type="dfn" href="#webvtt-cue-background-box">WebVTT cue background box</a> must be set to
-'rgba(0,0,0,0.8)'. <a data-link-type="biblio" href="#biblio-css3-color">[CSS3-COLOR]</a></p>
+   <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#background">background</a> shorthand property on the <a data-link-type="dfn" href="#webvtt-cue-background-box">WebVTT cue background box</a> and on <a data-link-type="dfn" href="#webvtt-ruby-text-object">WebVTT Ruby
+Text Objects</a> must be set to 'rgba(0,0,0,0.8)'. <a data-link-type="biblio" href="#biblio-css3-color">[CSS3-COLOR]</a></p>
    <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-3/#propdef-white-space">white-space</a> property on the (root) <a data-link-type="dfn" href="#list-of-webvtt-node-objects">list of WebVTT Node Objects</a> must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-text-3/#valdef-white-space-pre-line">pre-line</a>. <a data-link-type="biblio" href="#biblio-css21">[CSS21]</a></p>
    <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-fonts-3/#propdef-font-style">font-style</a> property on <a data-link-type="dfn" href="#webvtt-italic-object">WebVTT Italic Objects</a> must be set
 to <span class="css">italic</span>.</p>


### PR DESCRIPTION
The ruby text is rendered outside the background box, so by default,
if the video is white or very bright, the ruby text would be unreadable.