### PR TITLE
Add 'text-combine-upright' to the list of supported CSS properties

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -18,7 +18,7 @@ Test Suite: https://github.com/w3c/web-platform-tests/tree/master/webvtt
 Abstract: This specification defines WebVTT, the Web Video Text Tracks format. Its main use is for marking up external text track resources in connection with the HTML &lt;track> element.
 Abstract: WebVTT files provide captions or subtitles for video content, and also text video descriptions [[MAUR]], chapters for content navigation, and more generally any form of metadata that is time-aligned with audio or video content.
 Boilerplate: omit conformance, omit feedback-header
-Ignored Terms: unicode-bidi, direction, color
+Ignored Terms: unicode-bidi, direction, color, text-combine-upright
 Ignored Vars: seconds-frac, selector, fragment
 
 </pre>
@@ -4257,6 +4257,7 @@ set on the pseudo-element must be ignored:</p>
  <li>the properties corresponding to the 'outline' shorthand</li>
  <li>the properties corresponding to the 'font' shorthand, including 'line-height'</li>
  <li>'white-space'</li>
+ <li>'text-combine-upright'</li>
  <!-- add more... -->
  <!-- definitely not: display, float, position, top, left, right, bottom, width, height, margin-top,
  margin-bottom, margin-left, margin-right, clip, clear, content, cursor, direction, max-height,
@@ -4390,6 +4391,7 @@ when the selector does not contain the '':past'' and '':future'' pseudo-classes:
 <ul class="brief">
  <li>the properties corresponding to the 'font' shorthand, including 'line-height'</li>
  <li>'white-space'</li>
+ <li>'text-combine-upright'</li>
  <!-- add more... -->
  <!-- definitely not: display, float, position, top, left, right, bottom, width, height, margin-top,
  margin-bottom, margin-left, margin-right, clip, clear, content, cursor, direction, max-height,
@@ -5103,6 +5105,7 @@ originally specified. [[!HTML]]</p>
  Kyle Huey,
  Richard Ishida,
  Anne van Kesteren,
+ Dae Kim,
  Glenn Maynard,
  Ronny Mennerich,
  Ms2ger,

--- a/index.html
+++ b/index.html
@@ -4058,6 +4058,7 @@ set on the pseudo-element must be ignored:</p>
     <li>the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-ui-3/#propdef-outline">outline</a> shorthand
     <li>the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-fonts-3/#propdef-font">font</a> shorthand, including <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visudet.html#propdef-line-height">line-height</a>
     <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-3/#propdef-white-space">white-space</a>
+    <li><a class="property" data-link-type="propdesc">text-combine-upright</a>
    </ul>
    <p>The <dfn class="css" data-dfn-type="selector" data-export="" id="selectordef-cue-selector">::cue(<var>selector</var>)<a class="self-link" href="#selectordef-cue-selector"></a></dfn> pseudo-element with an argument must have an argument that
 consists of a CSS selector <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a>. It matches any <a data-link-type="dfn" href="#webvtt-internal-node-object">WebVTT Internal Node Object</a> constructed for the <i>matched element</i> that also matches the given CSS selector, with the nodes
@@ -4145,6 +4146,7 @@ when the selector does not contain the <a class="css" data-link-type="maybe" hre
    <ul class="brief">
     <li>the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-fonts-3/#propdef-font">font</a> shorthand, including <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visudet.html#propdef-line-height">line-height</a>
     <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-3/#propdef-white-space">white-space</a>
+    <li><a class="property" data-link-type="propdesc">text-combine-upright</a>
    </ul>
    <p>Properties that do not apply must be ignored.</p>
    <p>As a special exception, the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#background">background</a> shorthand, when they
@@ -4673,6 +4675,7 @@ originally specified. <a data-link-type="biblio" href="#biblio-html">[HTML]</a><
  Kyle Huey,
  Richard Ishida,
  Anne van Kesteren,
+ Dae Kim,
  Glenn Maynard,
  Ronny Mennerich,
  Ms2ger,


### PR DESCRIPTION
Fixes https://www.w3.org/Bugs/Public/show_bug.cgi?id=28184.