### PR TITLE
Editorial: remove unused variable 'current position score'

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4319,10 +4319,6 @@ following algorithm.</p>
      |output|, and all of the boxes in |boxes| are entirely within the |title area| box, then jump
      to the step labeled <i>done positioning</i> below.</p></li>
 
-     <li><p>Let |current position score| be the percentage of the area of the bounding box of the
-     boxes in |boxes| that <!--overlaps the boxes in |output| (if any) or that--> is outside the
-     |title area| box.</p></li>
-
      <li>
 
       <p><strong>Horizontal</strong>: If |step| is negative and the top of the first line box in

--- a/index.html
+++ b/index.html
@@ -1357,7 +1357,7 @@ Possible extra rowspan handling
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">WebVTT: The Web Video Text Tracks Format</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2016-05-27">27 May 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2016-05-30">30 May 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -4440,9 +4440,6 @@ Red or green?
         <li>
          <p><i>Step loop</i>: If none of the boxes in <var>boxes</var> would overlap any of the boxes in <var>output</var>, and all of the boxes in <var>boxes</var> are entirely within the <var>title area</var> box, then jump
      to the step labeled <i>done positioning</i> below.</p>
-        <li>
-         <p>Let <var>current position score</var> be the percentage of the area of the bounding box of the
-     boxes in <var>boxes</var> that  is outside the <var>title area</var> box.</p>
         <li>
          <p><strong>Horizontal</strong>: If <var>step</var> is negative and the top of the first line box in <var>boxes</var> is now above the top of the <var>title area</var>, or if <var>step</var> is positive and the bottom of
       the first line box in <var>boxes</var> is now below the bottom of the <var>title area</var>, jump to the step


### PR DESCRIPTION
This appears to be fallout from
c08ed4197e59163104e779fd86f1af074245ee80.

Fixes https://github.com/w3c/webvtt/issues/226.

cc @alastor0325 @foolip