### PR TITLE
Modify the parsing rule to set the cue's identifier.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2194,7 +2194,7 @@ header</i> set, the user agent must run the following steps:</p>
 
         <ol>
 
-         <li><p>Let |cue|'s <a>text track cue identifier</a> be the empty string.</p></li>
+         <li><p>Let |cue|'s <a>text track cue identifier</a> be |buffer|.</p></li>
 
          <li><p>Let |cue|'s <a>text track cue pause-on-exit flag</a> be false.</p></li>
 


### PR DESCRIPTION
According to #310, the parser doesn't set the cue identifier to anything but the empty string. 
The fix is to set the cue identifier to buffer on cue creation.

@zcorpan, could you help me review this patch?
Thanks!