### PR TITLE
Add a section that explains the CSS extensions to authors.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3687,9 +3687,9 @@ follows:</p>
 <h2 id=rendering>Rendering</h2>
 
 <p class="note">This section describes in some detail how to visually render WebVTT cues in a user
-agent. It also specifies extra CSS functionality made available to manipulate the visual rendering.
-The processing model is quite tightly linked to media elements in HTML. When supporting WebVTT in
-media players that don't support CSS, equivalent visual rendering will need to be implemented.</p>
+agent. The processing model is quite tightly linked to media elements in HTML. When supporting
+WebVTT in media players that don't support CSS, equivalent visual rendering will need to be
+implemented.</p>
 
 
 <h3 id=processing-model algorithm>Processing model</h3>
@@ -4598,7 +4598,265 @@ object">WebVTT region objects</a> must take their initial values.</p>
 then they must be interpreted as defined in the next section.</p>
 
 
-<h4 id=css-extensions>CSS extensions</h4>
+<h2 id=css-extensions>CSS extensions</h2>
+
+<p class="note">This section specifies some CSS pseudo-elements and pseudo-classes and how they
+apply to WebVTT. This section does not apply to user agents that don't support CSS.</p>
+
+
+<h3 id=css-extensions-introduction>Introduction</h3>
+
+<p><i>This section is non-normative.</i></p>
+
+<p>The ''::cue'' pseudo-element represents a cue.</p>
+
+<p>The ''::cue(|selector|)'' pseudo-element represents a cue or element inside a cue that match the
+given selector.</p>
+
+<p>The ''::cue-region'' pseudo-element represents a region.</p>
+
+<p class="note">Similarly to all other pseudo-elements, these pseudo-elements are not directly
+present in the <{video}> element's document tree.</p>
+
+<p>The '':past'' and '':future'' pseudo-classes can be used in ''::cue(|selector|)'' to match <a>WebVTT Internal Node Objects</a> based on the <a>current playback position</a>.</p>
+
+<div class="example" id="example-cue-selector">
+ <p>The following table shows examples of what can be selected with a given selector, together with
+ WebVTT syntax to produce the relevant objects.</p>
+
+ <table class="data">
+  <thead>
+   <tr>
+    <th>Selector (CSS syntax example)
+    <th>Matches (WebVTT syntax example)
+  <tbody>
+   <tr>
+    <td class=long>
+     <p>''::cue''</p>
+
+     <pre>
+     video::cue {
+       color: yellow;
+     }</pre>
+    <td class=long>
+     <p>Any <a>list of WebVTT Node Objects</a>.</p>
+
+     <pre>
+     WEBVTT
+
+     00:00:00.000 --> 00:00:08.000
+     Yellow!
+
+     00:00:08.000 --> 00:00:16.000
+     Also yellow!
+     </pre>
+   <tr>
+    <td class=long>
+     <p><a>ID selector</a> in ''::cue()''</p>
+
+     <pre>
+     video::cue(#cue1) {
+       color: yellow;
+     }</pre>
+    <td class=long>
+     <p>Any <a>list of WebVTT Node Objects</a> with the cue's <a>text track cue identifier</a>
+     matching the given ID.</p>
+
+     <pre>
+     WEBVTT
+
+     cue1
+     00:00:00.000 --> 00:00:08.000
+     Yellow!
+     </pre>
+   <tr>
+    <td class=long>
+     <p><a>Type selector</a> in ''::cue()''</p>
+
+     <pre>
+     video::cue(c),
+     video::cue(i),
+     video::cue(b),
+     video::cue(u),
+     video::cue(ruby),
+     video::cue(rt),
+     video::cue(v),
+     video::cue(lang) {
+       color: yellow;
+     }
+     </pre>
+    <td class=long>
+     <p><a>WebVTT Internal Node Objects</a> (except the root <a>list of WebVTT Node Objects</a>)
+     with the given name.</p>
+
+     <pre>
+     WEBVTT
+
+     00:00:00.000 --> 00:00:08.000
+     &lt;c>Yellow!&lt;/c>
+     &lt;i>Yellow!&lt;/i>
+     &lt;u>Yellow!&lt;/u>
+     &lt;b>Yellow!&lt;/b>
+     &lt;u>Yellow!&lt;/u>
+     &lt;ruby>Yellow! &lt;rt>Yellow!&lt;/rt>&lt;/ruby>
+     &lt;v Kathryn>Yellow!&lt;/v>
+     &lt;lang en>Yellow!&lt;/lang>
+     </pre>
+   <tr>
+    <td class=long>
+     <p><a>Class selector</a> in ''::cue()''</p>
+
+     <pre>
+     video::cue(.loud) {
+       color: yellow;
+     }</pre>
+    <td class=long>
+     <p><a>WebVTT Internal Node Objects</a> (except the root <a>list of WebVTT Node Objects</a>)
+     with the given <a lt="WebVTT Node Object's applicable classes">applicable classes.</p>
+
+     <pre>
+     WEBVTT
+
+     00:00:00.000 --> 00:00:08.000
+     &lt;c.loud>Yellow!&lt;/c>
+     &lt;i.loud>Yellow!&lt;/i>
+     &lt;u.loud>Yellow!&lt;/u>
+     &lt;b.loud>Yellow!&lt;/b>
+     &lt;u.loud>Yellow!&lt;/u>
+     &lt;ruby.loud>Yellow! &lt;rt.loud>Yellow!&lt;/rt>&lt;/ruby>
+     &lt;v.loud Kathryn>Yellow!&lt;/v>
+     &lt;lang.loud en>Yellow!&lt;/lang>
+     </pre>
+   <tr>
+    <td class=long>
+     <p><a>Attribute selector</a> in ''::cue()''</p>
+
+     <pre>
+     video::cue([lang="en-US"]) {
+       color: yellow;
+     }
+     video::cue(lang[lang="en-GB"]) {
+       color: cyan;
+     }
+     video::cue(v[voice="Kathryn"] {
+       color: lime;
+     }
+     </pre>
+    <td class=long>
+     <p>For "lang", the root <a>list of WebVTT Node Objects</a> or <a>WebVTT Language Object</a>
+     with the given <a lt="WebVTT Node Object's applicable language">applicable language</a>; for
+     "voice", the <a>WebVTT Voice Object</a> with the given voice.</p>
+
+     <pre>
+     WEBVTT
+
+     00:00:00.000 --> 00:00:08.000
+     Yellow!
+
+     00:00:08.000 --> 00:00:16.000
+     &lt;lang en-GB>Cyan!&lt;/lang>
+
+     00:00:16.000 --> 00:00:24.000
+     &lt;v Kathryn>I like lime.&lt;/v>
+     </pre>
+
+     <p>The <a lt="WebVTT Node Object's applicable language">applicable language</a> for the <a>list
+     of WebVTT Node Objects</a> can be set by the <{track/srclang}> attribute in HTML.</p>
+
+     <pre>
+     &lt;video ...>
+      &lt;track src="example-attr.vtt"
+             <mark>srclang="en-US"</mark> default>
+     &lt;/video>
+     </pre>
+   <tr>
+    <td class=long>
+     <p>'':lang()'' pseudo-class in ''::cue()''</p>
+     <pre>
+     video::cue(:lang(en)) {
+       color: yellow;
+     }
+     video::cue(:lang(en-GB)) {
+       color: cyan;
+     }
+     </pre>
+    <td class=long>
+     <p><a>WebVTT Internal Node Objects</a> with an <a lt="WebVTT Node Object's applicable
+     language">applicable language</a> matching the given language range.</p>
+     <pre>
+     WEBVTT
+
+     00:00:00.000 --> 00:00:08.000
+     Yellow!
+
+     00:00:08.000 --> 00:00:16.000
+     &lt;lang en-GB>Cyan!&lt;/lang>
+     </pre>
+
+     <p>As above, the <a lt="WebVTT Node Object's applicable language">applicable language</a> for
+     the <a>list of WebVTT Node Objects</a> can be set by the <{track/srclang}> attribute in
+     HTML.</p>
+   <tr>
+    <td class=long>
+     <p>'':past'' and '':future'' pseudo-classes in ''::cue()''</p>
+
+     <pre>
+     video::cue(:past) {
+       color: yellow;
+     }
+     video::cue(:future) {
+       color: cyan;
+     }
+     </pre>
+    <td class=long>
+     <p>In cues that have <a>WebVTT Timestamp Objects</a>, <a>WebVTT Internal Node Objects</a>,
+     depending on the <a>current playback position</a>.</p>
+
+     <pre>
+     WEBVTT
+
+     00:00:00.000 --> 00:00:08.000
+     &lt;c>No match (no timestamps)&lt;/c>
+
+     00:00:08.000 --> 00:00:16.000
+     No match &lt;00:00:12.000> (no elements)
+
+     00:00:16.000 --> 00:00:24.000
+     &lt;00:00:16.000> &lt;c>This&lt;/c>
+     &lt;00:00:18.000> &lt;c>can&lt;/c>
+     &lt;00:00:20.000> &lt;c>match&lt;/c>
+     &lt;00:00:22.000> &lt;c>:past/:future&lt;/c>
+     &lt;00:00:24.000>
+     </pre>
+   <tr>
+    <td class=long>
+     <p>''::cue-region''</p>
+
+     <pre>
+     video::cue-region {
+       color: yellow;
+     }</pre>
+    <td class=long>
+     <p>Any region (list of <a>WebVTT region objects</a>).</p>
+
+     <pre>
+     WEBVTT
+
+     REGION
+     id:editor-comments
+     regionanchor:0%,0%
+     viewportanchor:0%,0%
+
+     00:00:00.000 --> 00:00:08.000
+     No match (normal cue)
+
+     00:00:08.000 --> 00:00:16.000 region:editor-comments
+     Yellow!
+     </pre>
+ </table>
+</div>
+
+<h3 id="css-extensions-processing-model">Processing model</h3>
 
 <p>When a user agent is rendering one or more <a lt="WebVTT cue">WebVTT cues</a> according to the
 <a>rules for updating the display of WebVTT text tracks</a>, <a lt="WebVTT Node Object">WebVTT Node
@@ -4626,7 +4884,7 @@ pseudo-elements defined below won't have any effect according to this specificat
 pseudo-classes.</p>
 
 
-<h5 id=the-cue-pseudo-element>The ''::cue'' pseudo-element</h5>
+<h4 id=the-cue-pseudo-element>The ''::cue'' pseudo-element</h4>
 
 <p>The <dfn>::cue</dfn> pseudo-element (with no argument) matches any <a>list of WebVTT Node
 Objects</a> constructed for the <i>matched element</i>, with the exception that the properties
@@ -4801,7 +5059,7 @@ would have been applied to the <a>list of WebVTT Node Objects</a>, must instead 
 <a>WebVTT cue background box</a>.</p>
 
 
-<h5 id=the-past-and-future-pseudo-classes>The '':past'' and '':future'' pseudo-classes</h5>
+<h4 id=the-past-and-future-pseudo-classes>The '':past'' and '':future'' pseudo-classes</h4>
 
 <p>The '':past'' and '':future'' pseudo-classes sometimes match <a lt="WebVTT Node Object">WebVTT
 Node Objects</a>. [[!SELECTORS4]]</p>
@@ -4825,7 +5083,7 @@ position</a> of the <a>media element</a> that is the <i>matched element</i>, ent
 <a>WebVTT Node Object</a> |c|.</p>
 
 
-<h5 id=the-cue-region-pseudo-element>The ''::cue-region'' pseudo-element</h5>
+<h4 id=the-cue-region-pseudo-element>The ''::cue-region'' pseudo-element</h4>
 
 <p>Pseudo-elements apply to elements that are matched by selectors. For the purpose of this section,
 that element is the matched element. The pseudo-element defined below affects the styling of text

--- a/index.html
+++ b/index.html
@@ -969,6 +969,8 @@ Possible extra rowspan handling
 		/* Reverse color scheme */
 		color: black;
 		border-color: #3980B5;
+		border-bottom-width: 3px !important;
+		margin-bottom: 0px !important;
 	}
 	.toc a:visited {
 		border-color: #054572;
@@ -1184,7 +1186,7 @@ Possible extra rowspan handling
       background-repeat: no-repeat;
     }
   </style>
-  <meta content="Bikeshed 1.0.0" name="generator">
+  <meta content="Bikeshed version 190a4fcba8ed9462253188b3415e5074949e11bd" name="generator">
 <style>
  samp {
    font-family: inherit;
@@ -1440,7 +1442,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">WebVTT: The Web Video Text Tracks Format</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2016-10-18">18 October 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-01-23">23 January 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1464,7 +1466,7 @@ pre.idl.highlight { color: #708090; }
    </div>
    <div data-fill-with="warning"></div>
    <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> ©
-    2011-2016
+    2011-2017
     the Contributors to the WebVTT: The Web Video Text Tracks Format Specification, published by the <a href="http://www.w3.org/community/texttracks/">Web Media Text Tracks Community Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.
       A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available.</p>
    <hr title="Separator for header">
@@ -1558,25 +1560,30 @@ title</span></a>
        <a href="#processing-model"><span class="secno">6.1</span> <span class="content">Processing model</span></a>
        <ol class="toc">
         <li><a href="#applying-css-properties"><span class="secno">6.1.1</span> <span class="content">Applying CSS properties to <span>WebVTT Node Objects</span></span></a>
-        <li>
-         <a href="#css-extensions"><span class="secno">6.1.2</span> <span class="content">CSS extensions</span></a>
-         <ol class="toc">
-          <li><a href="#the-cue-pseudo-element"><span class="secno">6.1.2.1</span> <span class="content">The <span class="css">::cue</span> pseudo-element</span></a>
-          <li><a href="#the-past-and-future-pseudo-classes"><span class="secno">6.1.2.2</span> <span class="content">The <span class="css">:past</span> and <span class="css">:future</span> pseudo-classes</span></a>
-          <li><a href="#the-cue-region-pseudo-element"><span class="secno">6.1.2.3</span> <span class="content">The <span class="css">::cue-region</span> pseudo-element</span></a>
-         </ol>
        </ol>
      </ol>
     <li>
-     <a href="#api"><span class="secno">7</span> <span class="content">API</span></a>
+     <a href="#css-extensions"><span class="secno">7</span> <span class="content">CSS extensions</span></a>
      <ol class="toc">
-      <li><a href="#the-vttcue-interface"><span class="secno">7.1</span> <span class="content">The <code class="idl"><span>VTTCue</span></code> interface</span></a>
-      <li><a href="#the-vttregion-interface"><span class="secno">7.2</span> <span class="content">The <code class="idl"><span>VTTRegion</span></code> interface</span></a>
+      <li><a href="#css-extensions-introduction"><span class="secno">7.1</span> <span class="content">Introduction</span></a>
+      <li>
+       <a href="#css-extensions-processing-model"><span class="secno">7.2</span> <span class="content">Processing model</span></a>
+       <ol class="toc">
+        <li><a href="#the-cue-pseudo-element"><span class="secno">7.2.1</span> <span class="content">The <span class="css">::cue</span> pseudo-element</span></a>
+        <li><a href="#the-past-and-future-pseudo-classes"><span class="secno">7.2.2</span> <span class="content">The <span class="css">:past</span> and <span class="css">:future</span> pseudo-classes</span></a>
+        <li><a href="#the-cue-region-pseudo-element"><span class="secno">7.2.3</span> <span class="content">The <span class="css">::cue-region</span> pseudo-element</span></a>
+       </ol>
      </ol>
     <li>
-     <a href="#iana"><span class="secno">8</span> <span class="content">IANA considerations</span></a>
+     <a href="#api"><span class="secno">8</span> <span class="content">API</span></a>
      <ol class="toc">
-      <li><a href="#iana-text-vtt"><span class="secno">8.1</span> <span class="content"><span><code>text/vtt</code></span></span></a>
+      <li><a href="#the-vttcue-interface"><span class="secno">8.1</span> <span class="content">The <code class="idl"><span>VTTCue</span></code> interface</span></a>
+      <li><a href="#the-vttregion-interface"><span class="secno">8.2</span> <span class="content">The <code class="idl"><span>VTTRegion</span></code> interface</span></a>
+     </ol>
+    <li>
+     <a href="#iana"><span class="secno">9</span> <span class="content">IANA considerations</span></a>
+     <ol class="toc">
+      <li><a href="#iana-text-vtt"><span class="secno">9.1</span> <span class="content"><span><code>text/vtt</code></span></span></a>
      </ol>
     <li><a href="#acknowledgements"><span class="secno"></span> <span class="content">Acknowledgements</span></a>
     <li>
@@ -1747,7 +1754,7 @@ NOTE end of file
    <h3 class="heading settled" data-level="1.3" id="styling"><span class="secno">1.3. </span><span class="content">Styling</span><a class="self-link" href="#styling"></a></h3>
    <p><i>This section is non-normative.</i></p>
    <p>CSS stylesheets that apply to an HTML page that contains a <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#video">video</a> element
-can target WebVTT cues and regions in the video using the <a class="css" data-link-type="maybe" href="#selectordef-cue" id="ref-for-selectordef-cue-1">::cue</a>, <a class="css" data-link-type="maybe" href="#selectordef-cue-selector" id="ref-for-selectordef-cue-selector-1">::cue()</a> and <a class="css" data-link-type="maybe" href="#selectordef-cue-region" id="ref-for-selectordef-cue-region-1">::cue-region</a> pseudo-elements.</p>
+can target WebVTT cues and regions in the video using the <span class="css">::cue</span>, <span class="css">::cue()</span> and <span class="css">::cue-region</span> pseudo-elements.</p>
    <div class="example" id="example-81aa0582">
     <a class="self-link" href="#example-81aa0582"></a> 
     <p>In this example, an HTML page has a CSS stylesheet in a <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element">style</a> element
@@ -1994,7 +2001,7 @@ requirements.</p>
  specification. <a data-link-type="biblio" href="#biblio-webidl">[WEBIDL]</a></p>
     <dt>User agents with no scripting support
     <dd>
-     <p>All processing requirements in this specification apply, except those in <a href="#api">§7 API</a>.</p>
+     <p>All processing requirements in this specification apply, except those in <a href="#api">§8 API</a>.</p>
     <dt>Conformance checkers
     <dd>
      <p>Conformance checkers must verify that a <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file-4">WebVTT file</a> conforms to the applicable
@@ -4074,7 +4081,7 @@ Node Objects</a> to DOM nodes:</p>
    included, with one leading zero if the <var>hours</var> component is less than ten, and with no leading
    zeros otherwise.
    </table>
-   <p>HTML elements created as part of the mapping described above must have their <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-node-namespaceuri">namespaceURI</a></code> set to the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#html-namespace">HTML namespace</a>, use the appropriate IDL interface as defined
+   <p>HTML elements created as part of the mapping described above must have their <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-node-namespaceuri">namespaceURI</a></code> set to the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#html-namespace">HTML namespace</a>, use the appropriate IDL interface as defined
 in the HTML specification, and, if the corresponding <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-8">WebVTT Internal Node Object</a> has any <a data-link-type="dfn" href="#webvtt-node-objects-applicable-classes" id="ref-for-webvtt-node-objects-applicable-classes-3">applicable classes</a>, must have a <a data-link-type="element-attr">class</a> attribute set to the string obtained by concatenating all those classes, each
 separated from the next by a single U+0020 SPACE character.</p>
    <p>The <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-node-ownerdocument">ownerDocument</a></code> attribute of all nodes in the DOM tree must be set to the given
@@ -4097,9 +4104,9 @@ follows:</p>
    </ol>
    <h2 class="heading settled" data-level="6" id="rendering"><span class="secno">6. </span><span class="content">Rendering</span><a class="self-link" href="#rendering"></a></h2>
    <p class="note" role="note">This section describes in some detail how to visually render WebVTT cues in a user
-agent. It also specifies extra CSS functionality made available to manipulate the visual rendering.
-The processing model is quite tightly linked to media elements in HTML. When supporting WebVTT in
-media players that don’t support CSS, equivalent visual rendering will need to be implemented.</p>
+agent. The processing model is quite tightly linked to media elements in HTML. When supporting
+WebVTT in media players that don’t support CSS, equivalent visual rendering will need to be
+implemented.</p>
    <h3 class="heading settled algorithm" data-algorithm="Processing model" data-level="6.1" id="processing-model"><span class="secno">6.1. </span><span class="content">Processing model</span><a class="self-link" href="#processing-model"></a></h3>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="rules-for-updating-the-display-of-webvtt-text-tracks">rules for updating the display of WebVTT text tracks</dfn> render the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track">text tracks</a> of a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media element</a> (specifically, a <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#video">video</a> element), or
 of another playback mechanism, by applying the steps below. All the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track">text
@@ -4147,7 +4154,7 @@ manner suiting the user.</p>
        <p>Prepare some variables for the application of CSS properties to <var>regionNode</var> as follows:</p>
        <ul>
         <li>
-         <p>Let <var>regionWidth</var> be the <a data-link-type="dfn" href="#webvtt-region-width" id="ref-for-webvtt-region-width-3">WebVTT region width</a>. Let <var>width</var> be <span class="css"><var>regionWidth</var> vw</span> (<a class="css" data-link-type="maybe" href="https://html.spec.whatwg.org/multipage/infrastructure.html#&apos;vw&apos;">vw</a> is a CSS unit). <a data-link-type="biblio" href="#biblio-css-values">[CSS-VALUES]</a></p>
+         <p>Let <var>regionWidth</var> be the <a data-link-type="dfn" href="#webvtt-region-width" id="ref-for-webvtt-region-width-3">WebVTT region width</a>. Let <var>width</var> be <span class="css"><var>regionWidth</var> vw</span> (<a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-values-4/#vw">vw</a> is a CSS unit). <a data-link-type="biblio" href="#biblio-css-values">[CSS-VALUES]</a></p>
         <li>
          <p>Let <var>lineHeight</var> be <span class="css">5.33vh</span> (<a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-values-4/#vh">vh</a> is a CSS unit) <a data-link-type="biblio" href="#biblio-css-values">[CSS-VALUES]</a> and <var>regionHeight</var> be the <a data-link-type="dfn" href="#webvtt-region-lines" id="ref-for-webvtt-region-lines-3">WebVTT region lines</a>. Let <var>lines</var> be <var>lineHeight</var> multiplied by <var>regionHeight</var>.</p>
         <li>
@@ -4279,7 +4286,7 @@ following algorithm.</p>
  size</a>. Otherwise, let <var>size</var> be <var>maximum size</var>.</p>
     <li>
      <p>If the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-19">WebVTT cue writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction-15">horizontal</a>, then let <var>width</var> be <span class="css"><var>size</var> vw</span> and <var>height</var> be <span class="css">auto</span>. Otherwise, let <var>width</var> be <span class="css">auto</span> and <var>height</var> be <span class="css"><var>size</var> vh</span>.
- (These are CSS values used by the next section to set CSS properties for the rendering; <a class="css" data-link-type="maybe" href="https://html.spec.whatwg.org/multipage/infrastructure.html#&apos;vw&apos;">vw</a> and <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-values-4/#vh">vh</a> are CSS units.) <a data-link-type="biblio" href="#biblio-css-values">[CSS-VALUES]</a></p>
+ (These are CSS values used by the next section to set CSS properties for the rendering; <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-values-4/#vw">vw</a> and <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-values-4/#vh">vh</a> are CSS units.) <a data-link-type="biblio" href="#biblio-css-values">[CSS-VALUES]</a></p>
     <li>
      <p>Determine the value of <var>x-position</var> or <var>y-position</var> for <var>cue</var> as per the appropriate rules from
   the following list:</p>
@@ -4384,7 +4391,7 @@ following algorithm.</p>
      </dl>
     <li>
      <p>Let <var>left</var> be <span class="css"><var>x-position</var> vw</span> and <var>top</var> be <span class="css"><var>y-position</var> vh</span>. (These are
- CSS values used by the next section to set CSS properties for the rendering; <a class="css" data-link-type="maybe" href="https://html.spec.whatwg.org/multipage/infrastructure.html#&apos;vw&apos;">vw</a> and <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-values-4/#vh">vh</a> are
+ CSS values used by the next section to set CSS properties for the rendering; <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-values-4/#vw">vw</a> and <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-values-4/#vh">vh</a> are
  CSS units.) <a data-link-type="biblio" href="#biblio-css-values">[CSS-VALUES]</a></p>
     <li>
      <p>Apply the terms of the CSS specifications to <var>nodes</var> within the following constraints, thus
@@ -4399,7 +4406,7 @@ following algorithm.</p>
     given WebVTT file. The selectors must not match other <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track">text tracks</a> for the same <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media element</a>. In this hypothetical document, the element must not match any
     selector that would match the element itself.</p>
        <p class="note" role="note">This element exists only to be the <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#originating-element">originating element</a> for
-    the <a class="css" data-link-type="maybe" href="#selectordef-cue" id="ref-for-selectordef-cue-2">::cue</a>, <a class="css" data-link-type="maybe" href="#selectordef-cue-selector" id="ref-for-selectordef-cue-selector-2">::cue()</a> and <a class="css" data-link-type="maybe" href="#selectordef-cue-region" id="ref-for-selectordef-cue-region-2">::cue-region</a> pseudo-elements.</p>
+    the <span class="css">::cue</span>, <span class="css">::cue()</span> and <span class="css">::cue-region</span> pseudo-elements.</p>
       <li>
        <p>For the purpose of determining the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-4/#cascade">cascade</a> of the declarations in
     STYLE blocks of a WebVTT file, the relative order of appearance of the style sheets must be the
@@ -4432,7 +4439,7 @@ Red or green?
       <li>
        <p>For the purpose of resolving URLs in STYLE blocks of a WebVTT file, if the URL’s scheme is
     not "<code>data</code>", then the user agent must act as if the URL failed to resolve.</p>
-       <p><strong class="advisement">Supporting external resources with <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-cascade-4/#at-ruledef-import">@import</a> or <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#background-image">background-image</a> would be a new ability for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media elements</a> and <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-track-element">track</a> elements to issue network requests as the user watches the video, which could be a privacy
+       <p><strong class="advisement">Supporting external resources with <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css2/cascade.html#x7">@import</a> or <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/colors.html#propdef-background-image">background-image</a> would be a new ability for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media elements</a> and <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-track-element">track</a> elements to issue network requests as the user watches the video, which could be a privacy
     issue.</strong></p>
       <li>
        <p>For the purposes of processing by the CSS specification, <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-9">WebVTT Internal Node Objects</a> are equivalent to elements with the same
@@ -4441,10 +4448,10 @@ Red or green?
    Text Objects</a> are equivalent to <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#text">Text</a></code> nodes.
       <li>No style sheets are associated with <var>nodes</var>. (The nodes are subsequently restyled using style
    sheets after their boxes are generated, as described below.)
-      <li>The children of the <var>nodes</var> must be wrapped in an anonymous box whose <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-display-3/#propdef-display">display</a> property has
+      <li>The children of the <var>nodes</var> must be wrapped in an anonymous box whose <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visuren.html#propdef-display">display</a> property has
    the value <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-display-3/#valdef-display-inline">inline</a>. This is the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue-background-box">WebVTT cue background box</dfn>.
       <li>Runs of children of <a data-link-type="dfn" href="#webvtt-ruby-object" id="ref-for-webvtt-ruby-object-5">WebVTT Ruby Objects</a> that are not <a data-link-type="dfn" href="#webvtt-ruby-text-object" id="ref-for-webvtt-ruby-text-object-6">WebVTT Ruby Text Objects</a> must be wrapped in anonymous boxes
-   whose <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-display-3/#propdef-display">display</a> property has the value <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-ruby-1/#valdef-display-ruby-base">ruby-base</a>. <a data-link-type="biblio" href="#biblio-css3-ruby">[CSS3-RUBY]</a>
+   whose <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visuren.html#propdef-display">display</a> property has the value <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-ruby-1/#valdef-display-ruby-base">ruby-base</a>. <a data-link-type="biblio" href="#biblio-css3-ruby">[CSS3-RUBY]</a>
       <li>Properties on <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-10">WebVTT Node Objects</a> have their values set as
    defined in the next section. (That section uses some of the variables whose values were
    calculated earlier in this algorithm.)
@@ -4607,7 +4614,7 @@ layer as defined in this section. <a data-link-type="biblio" href="#biblio-css21
     <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-position-3/#propdef-position">position</a> property must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-position-3/#valdef-position-absolute">absolute</a>
     <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi">unicode-bidi</a> property must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-writing-modes-3/#valdef-unicode-bidi-plaintext">plaintext</a>
     <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-writing-modes-3/#propdef-writing-mode">writing-mode</a> property must be set to <var>writing-mode</var>
-    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-position-3/#propdef-top">top</a> property must be set to <var>top</var>
+    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visuren.html#propdef-top">top</a> property must be set to <var>top</var>
     <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-position-3/#propdef-left">left</a> property must be set to <var>left</var>
     <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css21/visudet.html#propdef-width">width</a> property must be set to <var>width</var>
     <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css21/visudet.html#propdef-height">height</a> property must be set to <var>height</var>
@@ -4644,21 +4651,21 @@ corresponding <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
    </table>
    <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-fonts-3/#propdef-font">font</a> shorthand property on the (root) <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-12">list of WebVTT Node Objects</a> must be set to <span class="css">5vh sans-serif</span>. <a data-link-type="biblio" href="#biblio-css3-ruby">[CSS3-RUBY]</a> <a data-link-type="biblio" href="#biblio-css-values">[CSS-VALUES]</a></p>
    <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-color-4/#propdef-color">color</a> property on the (root) <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-13">list of WebVTT Node Objects</a> must be set to <span class="css">rgba(255,255,255,1)</span>. <a data-link-type="biblio" href="#biblio-css3-color">[CSS3-COLOR]</a></p>
-   <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#background">background</a> shorthand property on the <a data-link-type="dfn" href="#webvtt-cue-background-box" id="ref-for-webvtt-cue-background-box-1">WebVTT cue background box</a> and on <a data-link-type="dfn" href="#webvtt-ruby-text-object" id="ref-for-webvtt-ruby-text-object-7">WebVTT Ruby
+   <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/colors.html#propdef-background">background</a> shorthand property on the <a data-link-type="dfn" href="#webvtt-cue-background-box" id="ref-for-webvtt-cue-background-box-1">WebVTT cue background box</a> and on <a data-link-type="dfn" href="#webvtt-ruby-text-object" id="ref-for-webvtt-ruby-text-object-7">WebVTT Ruby
 Text Objects</a> must be set to <span class="css">rgba(0,0,0,0.8)</span>. <a data-link-type="biblio" href="#biblio-css3-color">[CSS3-COLOR]</a></p>
-   <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-3/#propdef-white-space">white-space</a> property on the (root) <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-14">list of WebVTT Node Objects</a> must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-text-3/#valdef-white-space-pre-line">pre-line</a>. <a data-link-type="biblio" href="#biblio-css21">[CSS21]</a></p>
+   <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/text.html#propdef-white-space">white-space</a> property on the (root) <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-14">list of WebVTT Node Objects</a> must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-text-3/#valdef-white-space-pre-line">pre-line</a>. <a data-link-type="biblio" href="#biblio-css21">[CSS21]</a></p>
    <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-fonts-3/#propdef-font-style">font-style</a> property on <a data-link-type="dfn" href="#webvtt-italic-object" id="ref-for-webvtt-italic-object-4">WebVTT Italic Objects</a> must be set
 to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-fonts-4/#valdef-font-style-italic">italic</a>.</p>
    <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-fonts-3/#propdef-font-weight">font-weight</a> property on <a data-link-type="dfn" href="#webvtt-bold-object" id="ref-for-webvtt-bold-object-5">WebVTT Bold Objects</a> must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-fonts-4/#valdef-font-weight-bold">bold</a>.</p>
    <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-decor-3/#propdef-text-decoration">text-decoration</a> property on <a data-link-type="dfn" href="#webvtt-underline-object" id="ref-for-webvtt-underline-object-4">WebVTT Underline Objects</a> must be set to <span class="css">underline</span>.</p>
-   <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-display-3/#propdef-display">display</a> property on <a data-link-type="dfn" href="#webvtt-ruby-object" id="ref-for-webvtt-ruby-object-6">WebVTT Ruby Objects</a> must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-ruby-1/#valdef-display-ruby">ruby</a>. <a data-link-type="biblio" href="#biblio-css3-ruby">[CSS3-RUBY]</a></p>
-   <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-display-3/#propdef-display">display</a> property on <a data-link-type="dfn" href="#webvtt-ruby-text-object" id="ref-for-webvtt-ruby-text-object-8">WebVTT Ruby Text Objects</a> must be
+   <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visuren.html#propdef-display">display</a> property on <a data-link-type="dfn" href="#webvtt-ruby-object" id="ref-for-webvtt-ruby-object-6">WebVTT Ruby Objects</a> must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-ruby-1/#valdef-display-ruby">ruby</a>. <a data-link-type="biblio" href="#biblio-css3-ruby">[CSS3-RUBY]</a></p>
+   <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visuren.html#propdef-display">display</a> property on <a data-link-type="dfn" href="#webvtt-ruby-text-object" id="ref-for-webvtt-ruby-text-object-8">WebVTT Ruby Text Objects</a> must be
 set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-ruby-1/#valdef-display-ruby-text">ruby-text</a>. <a data-link-type="biblio" href="#biblio-css3-ruby">[CSS3-RUBY]</a></p>
    <p>Every <a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object-6">WebVTT region object</a> is initialized with the following CSS settings:</p>
    <ul>
     <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-position-3/#propdef-position">position</a> property must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-position-3/#valdef-position-absolute">absolute</a>
     <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-writing-modes-3/#propdef-writing-mode">writing-mode</a> property must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-writing-modes-3/#valdef-writing-mode-horizontal-tb">horizontal-tb</a>
-    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#background">background</a> shorthand property must be set to <span class="css">rgba(0,0,0,0.8)</span>
+    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/colors.html#propdef-background">background</a> shorthand property must be set to <span class="css">rgba(0,0,0,0.8)</span>
     <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-3/#propdef-overflow-wrap">overflow-wrap</a> property must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-break-word">break-word</a>
     <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-fonts-3/#propdef-font">font</a> shorthand property must be set to <span class="css">5vh sans-serif</span>
     <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-color-4/#propdef-color">color</a> property must be set to <span class="css">rgba(255,255,255,1)</span>
@@ -4667,8 +4674,8 @@ set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-
     <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css21/visudet.html#propdef-min-height">min-height</a> property must be set to <span class="css">0px</span>
     <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css21/visudet.html#propdef-max-height">max-height</a> property must be set to <var>height</var>
     <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-position-3/#propdef-left">left</a> property must be set to <var>left</var>
-    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-position-3/#propdef-top">top</a> property must be set to <var>top</var>
-    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-display-3/#propdef-display">display</a> property must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-flexbox-1/#valdef-display-inline-flex">inline-flex</a>
+    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visuren.html#propdef-top">top</a> property must be set to <var>top</var>
+    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visuren.html#propdef-display">display</a> property must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-flexbox-1/#valdef-display-inline-flex">inline-flex</a>
     <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-flow">flex-flow</a> property must be set to <span class="css">column</span>
     <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-align-3/#propdef-justify-content">justify-content</a> property must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-flexbox-1/#valdef-justify-content-flex-end">flex-end</a>
    </ul>
@@ -4692,13 +4699,223 @@ if the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embe
 properties on the root <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-17">list of WebVTT Node Objects</a> and the <a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object-9">WebVTT region objects</a> must take their initial values.</p>
    <p>If there are style sheets that apply to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media element</a> or other playback mechanism,
 then they must be interpreted as defined in the next section.</p>
-   <h4 class="heading settled" data-level="6.1.2" id="css-extensions"><span class="secno">6.1.2. </span><span class="content">CSS extensions</span><a class="self-link" href="#css-extensions"></a></h4>
+   <h2 class="heading settled" data-level="7" id="css-extensions"><span class="secno">7. </span><span class="content">CSS extensions</span><a class="self-link" href="#css-extensions"></a></h2>
+   <p class="note" role="note">This section specifies some CSS pseudo-elements and pseudo-classes and how they
+apply to WebVTT. This section does not apply to user agents that don’t support CSS.</p>
+   <h3 class="heading settled" data-level="7.1" id="css-extensions-introduction"><span class="secno">7.1. </span><span class="content">Introduction</span><a class="self-link" href="#css-extensions-introduction"></a></h3>
+   <p><i>This section is non-normative.</i></p>
+   <p>The <span class="css">::cue</span> pseudo-element represents a cue.</p>
+   <p>The <span class="css">::cue(<var>selector</var>)</span> pseudo-element represents a cue or element inside a cue that match the
+given selector.</p>
+   <p>The <span class="css">::cue-region</span> pseudo-element represents a region.</p>
+   <p class="note" role="note">Similarly to all other pseudo-elements, these pseudo-elements are not directly
+present in the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#video">video</a></code> element’s document tree.</p>
+   <p>The <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#past-pseudo">:past</a> and <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#future-pseudo">:future</a> pseudo-classes can be used in <span class="css">::cue(<var>selector</var>)</span> to match <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-10">WebVTT Internal Node Objects</a> based on the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#current-playback-position">current playback position</a>.</p>
+   <div class="example" id="example-cue-selector">
+    <a class="self-link" href="#example-cue-selector"></a> 
+    <p>The following table shows examples of what can be selected with a given selector, together with
+ WebVTT syntax to produce the relevant objects.</p>
+    <table class="data">
+     <thead>
+      <tr>
+       <th>Selector (CSS syntax example) 
+       <th>Matches (WebVTT syntax example) 
+     <tbody>
+      <tr>
+       <td class="long">
+        <p><span class="css">::cue</span></p>
+<pre>video::cue {
+  color: yellow;
+}</pre>
+       <td class="long">
+        <p>Any <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-18">list of WebVTT Node Objects</a>.</p>
+<pre>WEBVTT
+
+00:00:00.000 --> 00:00:08.000
+Yellow!
+
+00:00:08.000 --> 00:00:16.000
+Also yellow!
+</pre>
+      <tr>
+       <td class="long">
+        <p><a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#id-selector">ID selector</a> in <span class="css">::cue()</span></p>
+<pre>video::cue(#cue1) {
+  color: yellow;
+}</pre>
+       <td class="long">
+        <p>Any <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-19">list of WebVTT Node Objects</a> with the cue’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-identifier">text track cue identifier</a> matching the given ID.</p>
+<pre>WEBVTT
+
+cue1
+00:00:00.000 --> 00:00:08.000
+Yellow!
+</pre>
+      <tr>
+       <td class="long">
+        <p><a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#type-selector">Type selector</a> in <span class="css">::cue()</span></p>
+<pre>video::cue(c),
+video::cue(i),
+video::cue(b),
+video::cue(u),
+video::cue(ruby),
+video::cue(rt),
+video::cue(v),
+video::cue(lang) {
+  color: yellow;
+}
+</pre>
+       <td class="long">
+        <p><a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-11">WebVTT Internal Node Objects</a> (except the root <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-20">list of WebVTT Node Objects</a>)
+     with the given name.</p>
+<pre>WEBVTT
+
+00:00:00.000 --> 00:00:08.000
+&lt;c>Yellow!&lt;/c>
+&lt;i>Yellow!&lt;/i>
+&lt;u>Yellow!&lt;/u>
+&lt;b>Yellow!&lt;/b>
+&lt;u>Yellow!&lt;/u>
+&lt;ruby>Yellow! &lt;rt>Yellow!&lt;/rt>&lt;/ruby>
+&lt;v Kathryn>Yellow!&lt;/v>
+&lt;lang en>Yellow!&lt;/lang>
+</pre>
+      <tr>
+       <td class="long">
+        <p><a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#class-selector">Class selector</a> in <span class="css">::cue()</span></p>
+<pre>video::cue(.loud) {
+  color: yellow;
+}</pre>
+       <td class="long">
+        <p><a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-12">WebVTT Internal Node Objects</a> (except the root <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-21">list of WebVTT Node Objects</a>)
+     with the given <a data-link-type="dfn" href="#webvtt-node-objects-applicable-classes" id="ref-for-webvtt-node-objects-applicable-classes-4">applicable classes.</a></p>
+<pre><a data-link-type="dfn" href="#webvtt-node-objects-applicable-classes" id="ref-for-webvtt-node-objects-applicable-classes-5">WEBVTT
+
+00:00:00.000 --> 00:00:08.000
+&lt;c.loud>Yellow!&lt;/c>
+&lt;i.loud>Yellow!&lt;/i>
+&lt;u.loud>Yellow!&lt;/u>
+&lt;b.loud>Yellow!&lt;/b>
+&lt;u.loud>Yellow!&lt;/u>
+&lt;ruby.loud>Yellow! &lt;rt.loud>Yellow!&lt;/rt>&lt;/ruby>
+&lt;v.loud Kathryn>Yellow!&lt;/v>
+&lt;lang.loud en>Yellow!&lt;/lang>
+</a></pre>
+      <tr>
+       <td class="long">
+        <p><a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#attribute-selector">Attribute selector</a> in <span class="css">::cue()</span></p>
+<pre>video::cue([lang="en-US"]) {
+  color: yellow;
+}
+video::cue(lang[lang="en-GB"]) {
+  color: cyan;
+}
+video::cue(v[voice="Kathryn"] {
+  color: lime;
+}
+</pre>
+       <td class="long">
+        <p>For "lang", the root <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-22">list of WebVTT Node Objects</a> or <a data-link-type="dfn" href="#webvtt-language-object" id="ref-for-webvtt-language-object-5">WebVTT Language Object</a> with the given <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language-6">applicable language</a>; for
+     "voice", the <a data-link-type="dfn" href="#webvtt-voice-object" id="ref-for-webvtt-voice-object-6">WebVTT Voice Object</a> with the given voice.</p>
+<pre>WEBVTT
+
+00:00:00.000 --> 00:00:08.000
+Yellow!
+
+00:00:08.000 --> 00:00:16.000
+&lt;lang en-GB>Cyan!&lt;/lang>
+
+00:00:16.000 --> 00:00:24.000
+&lt;v Kathryn>I like lime.&lt;/v>
+</pre>
+        <p>The <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language-7">applicable language</a> for the <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-23">list
+     of WebVTT Node Objects</a> can be set by the <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-track-srclang">srclang</a></code> attribute in HTML.</p>
+<pre>&lt;video ...>
+ &lt;track src="example-attr.vtt"
+        <mark>srclang="en-US"</mark> default>
+&lt;/video>
+</pre>
+      <tr>
+       <td class="long">
+        <p><a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#lang-pseudo">:lang()</a> pseudo-class in <span class="css">::cue()</span></p>
+<pre>video::cue(:lang(en)) {
+  color: yellow;
+}
+video::cue(:lang(en-GB)) {
+  color: cyan;
+}
+</pre>
+       <td class="long">
+        <p><a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-13">WebVTT Internal Node Objects</a> with an <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language-8">applicable language</a> matching the given language range.</p>
+<pre>WEBVTT
+
+00:00:00.000 --> 00:00:08.000
+Yellow!
+
+00:00:08.000 --> 00:00:16.000
+&lt;lang en-GB>Cyan!&lt;/lang>
+</pre>
+        <p>As above, the <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language-9">applicable language</a> for
+     the <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-24">list of WebVTT Node Objects</a> can be set by the <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-track-srclang">srclang</a></code> attribute in
+     HTML.</p>
+      <tr>
+       <td class="long">
+        <p><a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#past-pseudo">:past</a> and <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#future-pseudo">:future</a> pseudo-classes in <span class="css">::cue()</span></p>
+<pre>video::cue(:past) {
+  color: yellow;
+}
+video::cue(:future) {
+  color: cyan;
+}
+</pre>
+       <td class="long">
+        <p>In cues that have <a data-link-type="dfn" href="#webvtt-timestamp-object" id="ref-for-webvtt-timestamp-object-5">WebVTT Timestamp Objects</a>, <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-14">WebVTT Internal Node Objects</a>,
+     depending on the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#current-playback-position">current playback position</a>.</p>
+<pre>WEBVTT
+
+00:00:00.000 --> 00:00:08.000
+&lt;c>No match (no timestamps)&lt;/c>
+
+00:00:08.000 --> 00:00:16.000
+No match &lt;00:00:12.000> (no elements)
+
+00:00:16.000 --> 00:00:24.000
+&lt;00:00:16.000> &lt;c>This&lt;/c>
+&lt;00:00:18.000> &lt;c>can&lt;/c>
+&lt;00:00:20.000> &lt;c>match&lt;/c>
+&lt;00:00:22.000> &lt;c>:past/:future&lt;/c>
+&lt;00:00:24.000>
+</pre>
+      <tr>
+       <td class="long">
+        <p><span class="css">::cue-region</span></p>
+<pre>video::cue-region {
+  color: yellow;
+}</pre>
+       <td class="long">
+        <p>Any region (list of <a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object-10">WebVTT region objects</a>).</p>
+<pre>WEBVTT
+
+REGION
+id:editor-comments
+regionanchor:0%,0%
+viewportanchor:0%,0%
+
+00:00:00.000 --> 00:00:08.000
+No match (normal cue)
+
+00:00:08.000 --> 00:00:16.000 region:editor-comments
+Yellow!
+</pre>
+    </table>
+   </div>
+   <h3 class="heading settled" data-level="7.2" id="css-extensions-processing-model"><span class="secno">7.2. </span><span class="content">Processing model</span><a class="self-link" href="#css-extensions-processing-model"></a></h3>
    <p>When a user agent is rendering one or more <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-25">WebVTT cues</a> according to the <a data-link-type="dfn" href="#rules-for-updating-the-display-of-webvtt-text-tracks" id="ref-for-rules-for-updating-the-display-of-webvtt-text-tracks-7">rules for updating the display of WebVTT text tracks</a>, <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-13">WebVTT Node
-Objects</a> in the <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-18">list of WebVTT Node Objects</a> used in the rendering can be matched by
+Objects</a> in the <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-25">list of WebVTT Node Objects</a> used in the rendering can be matched by
 certain pseudo-selectors as defined below. These selectors can begin or stop matching individual <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-14">WebVTT Node Objects</a> while a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue">cue</a> is being
 rendered, even in between applications of the <a data-link-type="dfn" href="#rules-for-updating-the-display-of-webvtt-text-tracks" id="ref-for-rules-for-updating-the-display-of-webvtt-text-tracks-8">rules for updating the display of WebVTT text
 tracks</a> (which are only run when the set of active cues changes). User agents that support the
-pseudo-element described below must dynamically update renderings accordingly. When either <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-3/#propdef-white-space">white-space</a> or one of the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-fonts-3/#propdef-font">font</a> shorthand (including <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css21/visudet.html#propdef-line-height">line-height</a>) changes value, then the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-26">WebVTT cue</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-display-state">text track cue display state</a> must
+pseudo-element described below must dynamically update renderings accordingly. When either <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/text.html#propdef-white-space">white-space</a> or one of the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-fonts-3/#propdef-font">font</a> shorthand (including <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css21/visudet.html#propdef-line-height">line-height</a>) changes value, then the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-26">WebVTT cue</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-display-state">text track cue display state</a> must
 be emptied and the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track">text track</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#rules-for-updating-the-text-track-rendering">rules for updating the text track rendering</a> must be
 immediately rerun.</p>
    <p>Pseudo-elements apply to elements that are matched by selectors. For the purpose of this section,
@@ -4706,38 +4923,38 @@ that element is the <i>matched element</i>. The pseudo-elements defined in the f
 affect the styling of parts of <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-27">WebVTT cues</a> that are being rendered for the <i>matched element</i>.</p>
    <p class="note" role="note">If the <i>matched element</i> is not a <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#video">video</a> element, the
 pseudo-elements defined below won’t have any effect according to this specification.</p>
-   <p>A CSS user agent that implements the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track">text tracks</a> model must implement the <a class="css" data-link-type="maybe" href="#selectordef-cue" id="ref-for-selectordef-cue-3">::cue</a> and <span class="css">::cue(<var>selector</var>)</span> pseudo-elements, and the <a class="css" data-link-type="maybe" href="#selectordef-past" id="ref-for-selectordef-past-1">:past</a> and <a class="css" data-link-type="maybe" href="#selectordef-future" id="ref-for-selectordef-future-1">:future</a> pseudo-classes.</p>
-   <h5 class="heading settled" data-level="6.1.2.1" id="the-cue-pseudo-element"><span class="secno">6.1.2.1. </span><span class="content">The <a class="css" data-link-type="maybe" href="#selectordef-cue" id="ref-for-selectordef-cue-4">::cue</a> pseudo-element</span><a class="self-link" href="#the-cue-pseudo-element"></a></h5>
-   <p>The <dfn class="dfn-paneled css" data-dfn-type="selector" data-export="" id="selectordef-cue">::cue</dfn> pseudo-element (with no argument) matches any <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-19">list of WebVTT Node
+   <p>A CSS user agent that implements the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track">text tracks</a> model must implement the <span class="css">::cue</span> and <span class="css">::cue(<var>selector</var>)</span> pseudo-elements, and the <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#past-pseudo">:past</a> and <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#future-pseudo">:future</a> pseudo-classes.</p>
+   <h4 class="heading settled" data-level="7.2.1" id="the-cue-pseudo-element"><span class="secno">7.2.1. </span><span class="content">The <span class="css">::cue</span> pseudo-element</span><a class="self-link" href="#the-cue-pseudo-element"></a></h4>
+   <p>The <dfn data-dfn-type="dfn" data-noexport="" id="cue">::cue<a class="self-link" href="#cue"></a></dfn> pseudo-element (with no argument) matches any <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-26">list of WebVTT Node
 Objects</a> constructed for the <i>matched element</i>, with the exception that the properties
-corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#background">background</a> shorthand must be applied to the <a data-link-type="dfn" href="#webvtt-cue-background-box" id="ref-for-webvtt-cue-background-box-2">WebVTT cue background box</a> rather than the <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-20">list of WebVTT Node Objects</a>.</p>
-   <p>The following properties apply to the <a class="css" data-link-type="maybe" href="#selectordef-cue" id="ref-for-selectordef-cue-5">::cue</a> pseudo-element with no argument; other properties
+corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/colors.html#propdef-background">background</a> shorthand must be applied to the <a data-link-type="dfn" href="#webvtt-cue-background-box" id="ref-for-webvtt-cue-background-box-2">WebVTT cue background box</a> rather than the <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-27">list of WebVTT Node Objects</a>.</p>
+   <p>The following properties apply to the <span class="css">::cue</span> pseudo-element with no argument; other properties
 set on the pseudo-element must be ignored:</p>
    <ul class="brief">
     <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-color-4/#propdef-color">color</a>
     <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-color-4/#propdef-opacity">opacity</a>
-    <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css21/visufx.html#propdef-visibility">visibility</a>
+    <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visufx.html#propdef-visibility">visibility</a>
     <li>the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-decor-3/#propdef-text-decoration">text-decoration</a> shorthand
     <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-decor-3/#propdef-text-shadow">text-shadow</a>
-    <li>the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#background">background</a> shorthand
-    <li>the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-ui-3/#propdef-outline">outline</a> shorthand
+    <li>the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/colors.html#propdef-background">background</a> shorthand
+    <li>the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/ui.html#propdef-outline">outline</a> shorthand
     <li>the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-fonts-3/#propdef-font">font</a> shorthand, including <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css21/visudet.html#propdef-line-height">line-height</a>
-    <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-3/#propdef-white-space">white-space</a>
+    <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/text.html#propdef-white-space">white-space</a>
     <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-writing-modes-3/#propdef-text-combine-upright">text-combine-upright</a>
     <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-ruby-1/#propdef-ruby-position">ruby-position</a>
    </ul>
-   <p>The <dfn class="dfn-paneled css" data-dfn-type="selector" data-export="" id="selectordef-cue-selector">::cue(<var>selector</var>)</dfn> pseudo-element with an argument must have an argument that
-consists of a CSS selector <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a>. It matches any <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-10">WebVTT Internal Node Object</a> constructed for the <i>matched element</i> that also matches the given CSS selector, with the nodes
+   <p>The <dfn data-dfn-type="dfn" data-noexport="" id="cue-selector">::cue(<var>selector</var>)<a class="self-link" href="#cue-selector"></a></dfn> pseudo-element with an argument must have an argument that
+consists of a CSS selector <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a>. It matches any <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-15">WebVTT Internal Node Object</a> constructed for the <i>matched element</i> that also matches the given CSS selector, with the nodes
 being treated as follows:</p>
    <ul>
     <li>
-     <p>The <i>document tree</i> against which the selectors are matched is the tree of <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-15">WebVTT Node Objects</a> rooted at the <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-21">list of WebVTT Node Objects</a> for the cue.</p>
+     <p>The <i>document tree</i> against which the selectors are matched is the tree of <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-15">WebVTT Node Objects</a> rooted at the <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-28">list of WebVTT Node Objects</a> for the cue.</p>
     <li>
-     <p><a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-11">WebVTT Internal Node Objects</a> are elements in the
+     <p><a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-16">WebVTT Internal Node Objects</a> are elements in the
  tree.</p>
     <li><a data-link-type="dfn" href="#webvtt-leaf-node-object" id="ref-for-webvtt-leaf-node-object-3">WebVTT Leaf Node Objects</a> cannot be matched.
     <li>
-     <p>For the purposes of element type selectors, the names of <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-12">WebVTT Internal Node Objects</a> are as given by the following table, where objects having
+     <p>For the purposes of element type selectors, the names of <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-17">WebVTT Internal Node Objects</a> are as given by the following table, where objects having
   the concrete class given in a cell in the first column have the name given by the second column of
   the same row:</p>
      <table class="complex data">
@@ -4765,94 +4982,94 @@ being treated as follows:</p>
         <td><a data-link-type="dfn" href="#webvtt-ruby-text-object" id="ref-for-webvtt-ruby-text-object-9">WebVTT Ruby Text Objects</a>
         <td><code>rt</code>
        <tr>
-        <td><a data-link-type="dfn" href="#webvtt-voice-object" id="ref-for-webvtt-voice-object-6">WebVTT Voice Objects</a>
+        <td><a data-link-type="dfn" href="#webvtt-voice-object" id="ref-for-webvtt-voice-object-7">WebVTT Voice Objects</a>
         <td><code>v</code>
        <tr>
-        <td><a data-link-type="dfn" href="#webvtt-language-object" id="ref-for-webvtt-language-object-5">WebVTT Language Objects</a>
+        <td><a data-link-type="dfn" href="#webvtt-language-object" id="ref-for-webvtt-language-object-6">WebVTT Language Objects</a>
         <td><code>lang</code>
        <tr>
-        <td>Other elements (specifically, <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-22">lists of WebVTT Node
+        <td>Other elements (specifically, <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-29">lists of WebVTT Node
      Objects</a>)
         <td>No explicit name.
      </table>
     <li>
-     <p>For the purposes of element type and universal selectors, <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-13">WebVTT Internal Node Objects</a> are considered as being in the namespace expressed as the
+     <p>For the purposes of element type and universal selectors, <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-18">WebVTT Internal Node Objects</a> are considered as being in the namespace expressed as the
  empty string.</p>
     <li>
-     <p>For the purposes of attribute selector matching, <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-14">WebVTT
- Internal Node Objects</a> have no attributes, except for <a data-link-type="dfn" href="#webvtt-voice-object" id="ref-for-webvtt-voice-object-7">WebVTT Voice
+     <p>For the purposes of attribute selector matching, <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-19">WebVTT
+ Internal Node Objects</a> have no attributes, except for <a data-link-type="dfn" href="#webvtt-voice-object" id="ref-for-webvtt-voice-object-8">WebVTT Voice
  Objects</a>, which have a single attribute named "<code>voice</code>" whose value is the value of
- the <a data-link-type="dfn" href="#webvtt-voice-object" id="ref-for-webvtt-voice-object-8">WebVTT Voice Object</a>, <a data-link-type="dfn" href="#webvtt-language-object" id="ref-for-webvtt-language-object-6">WebVTT Language Objects</a>, which
- have a single attribute named "<code>lang</code>" whose value is the object’s <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language-6">applicable language</a>, and <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-23">lists of WebVTT Node Objects</a> that have a non-empty <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language-7">applicable language</a>, which have a single attribute named
- "<code>lang</code>" whose value is the object’s <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language-8">applicable language</a>.</p>
+ the <a data-link-type="dfn" href="#webvtt-voice-object" id="ref-for-webvtt-voice-object-9">WebVTT Voice Object</a>, <a data-link-type="dfn" href="#webvtt-language-object" id="ref-for-webvtt-language-object-7">WebVTT Language Objects</a>, which
+ have a single attribute named "<code>lang</code>" whose value is the object’s <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language-10">applicable language</a>, and <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-30">lists of WebVTT Node Objects</a> that have a non-empty <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language-11">applicable language</a>, which have a single attribute named
+ "<code>lang</code>" whose value is the object’s <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language-12">applicable language</a>.</p>
     <li>
-     <p>For the purposes of class selector matching, <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-15">WebVTT
- Internal Node Objects</a> have the classes described as the <a data-link-type="dfn" href="#webvtt-node-objects-applicable-classes" id="ref-for-webvtt-node-objects-applicable-classes-4">WebVTT Node Object’s applicable
+     <p>For the purposes of class selector matching, <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-20">WebVTT
+ Internal Node Objects</a> have the classes described as the <a data-link-type="dfn" href="#webvtt-node-objects-applicable-classes" id="ref-for-webvtt-node-objects-applicable-classes-6">WebVTT Node Object’s applicable
  classes</a>.</p>
     <li>
-     <p>For the purposes of the <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#lang-pseudo">:lang()</a> pseudo-class, <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-16">WebVTT
- Internal Node Objects</a> have the language described as the <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language-9">WebVTT Node Object’s applicable
+     <p>For the purposes of the <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#lang-pseudo">:lang()</a> pseudo-class, <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-21">WebVTT
+ Internal Node Objects</a> have the language described as the <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language-13">WebVTT Node Object’s applicable
  language</a>.</p>
     <li>
-     <p>For the purposes of ID selector matching, <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-24">lists of
+     <p>For the purposes of ID selector matching, <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-31">lists of
  WebVTT Node Objects</a> have the ID given by the cue’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-identifier">text track cue identifier</a>, if
  any.</p>
    </ul>
-   <p>The following properties apply to the <a class="css" data-link-type="maybe" href="#selectordef-cue-selector" id="ref-for-selectordef-cue-selector-3">::cue()</a> pseudo-element with an argument:</p>
+   <p>The following properties apply to the <span class="css">::cue()</span> pseudo-element with an argument:</p>
    <ul class="brief">
     <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-color-4/#propdef-color">color</a>
     <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-color-4/#propdef-opacity">opacity</a>
-    <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css21/visufx.html#propdef-visibility">visibility</a>
+    <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visufx.html#propdef-visibility">visibility</a>
     <li>the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-decor-3/#propdef-text-decoration">text-decoration</a> shorthand
     <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-decor-3/#propdef-text-shadow">text-shadow</a>
-    <li>the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#background">background</a> shorthand
-    <li>the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-ui-3/#propdef-outline">outline</a> shorthand
+    <li>the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/colors.html#propdef-background">background</a> shorthand
+    <li>the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/ui.html#propdef-outline">outline</a> shorthand
     <li>properties relating to the transition and animation features
    </ul>
-   <p>In addition, the following properties apply to the <a class="css" data-link-type="maybe" href="#selectordef-cue-selector" id="ref-for-selectordef-cue-selector-4">::cue()</a> pseudo-element with an argument
-when the selector does not contain the <a class="css" data-link-type="maybe" href="#selectordef-past" id="ref-for-selectordef-past-2">:past</a> and <a class="css" data-link-type="maybe" href="#selectordef-future" id="ref-for-selectordef-future-2">:future</a> pseudo-classes:</p>
+   <p>In addition, the following properties apply to the <span class="css">::cue()</span> pseudo-element with an argument
+when the selector does not contain the <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#past-pseudo">:past</a> and <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#future-pseudo">:future</a> pseudo-classes:</p>
    <ul class="brief">
     <li>the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-fonts-3/#propdef-font">font</a> shorthand, including <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css21/visudet.html#propdef-line-height">line-height</a>
-    <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-3/#propdef-white-space">white-space</a>
+    <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/text.html#propdef-white-space">white-space</a>
     <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-writing-modes-3/#propdef-text-combine-upright">text-combine-upright</a>
     <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-ruby-1/#propdef-ruby-position">ruby-position</a>
    </ul>
    <p>Properties that do not apply must be ignored.</p>
-   <p>As a special exception, the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#background">background</a> shorthand, when they
-would have been applied to the <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-25">list of WebVTT Node Objects</a>, must instead be applied to the <a data-link-type="dfn" href="#webvtt-cue-background-box" id="ref-for-webvtt-cue-background-box-3">WebVTT cue background box</a>.</p>
-   <h5 class="heading settled" data-level="6.1.2.2" id="the-past-and-future-pseudo-classes"><span class="secno">6.1.2.2. </span><span class="content">The <a class="css" data-link-type="maybe" href="#selectordef-past" id="ref-for-selectordef-past-3">:past</a> and <a class="css" data-link-type="maybe" href="#selectordef-future" id="ref-for-selectordef-future-3">:future</a> pseudo-classes</span><a class="self-link" href="#the-past-and-future-pseudo-classes"></a></h5>
-   <p>The <a class="css" data-link-type="maybe" href="#selectordef-past" id="ref-for-selectordef-past-4">:past</a> and <a class="css" data-link-type="maybe" href="#selectordef-future" id="ref-for-selectordef-future-4">:future</a> pseudo-classes sometimes match <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-16">WebVTT
+   <p>As a special exception, the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/colors.html#propdef-background">background</a> shorthand, when they
+would have been applied to the <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-32">list of WebVTT Node Objects</a>, must instead be applied to the <a data-link-type="dfn" href="#webvtt-cue-background-box" id="ref-for-webvtt-cue-background-box-3">WebVTT cue background box</a>.</p>
+   <h4 class="heading settled" data-level="7.2.2" id="the-past-and-future-pseudo-classes"><span class="secno">7.2.2. </span><span class="content">The <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#past-pseudo">:past</a> and <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#future-pseudo">:future</a> pseudo-classes</span><a class="self-link" href="#the-past-and-future-pseudo-classes"></a></h4>
+   <p>The <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#past-pseudo">:past</a> and <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#future-pseudo">:future</a> pseudo-classes sometimes match <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-16">WebVTT
 Node Objects</a>. <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a></p>
-   <p>The <dfn class="dfn-paneled css" data-dfn-type="selector" data-export="" id="selectordef-past">:past</dfn> pseudo-class only matches <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-17">WebVTT Node Objects</a> that are <i>in the past</i>.</p>
+   <p>The <dfn data-dfn-type="dfn" data-noexport="" id="past">:past<a class="self-link" href="#past"></a></dfn> pseudo-class only matches <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-17">WebVTT Node Objects</a> that are <i>in the past</i>.</p>
    <p class="algorithm" data-algorithm="in the past">A <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-18">WebVTT Node Object</a> <var>c</var> is <dfn data-dfn-type="dfn" data-noexport="" id="in-the-past">in the past<a class="self-link" href="#in-the-past"></a></dfn> if, in a
-pre-order, depth-first traversal of the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-28">WebVTT cue</a>’s <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-26">list of WebVTT Node Objects</a>,
-there exists a <a data-link-type="dfn" href="#webvtt-timestamp-object" id="ref-for-webvtt-timestamp-object-5">WebVTT Timestamp Object</a> whose value is less than the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#current-playback-position">current playback
+pre-order, depth-first traversal of the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-28">WebVTT cue</a>’s <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-33">list of WebVTT Node Objects</a>,
+there exists a <a data-link-type="dfn" href="#webvtt-timestamp-object" id="ref-for-webvtt-timestamp-object-6">WebVTT Timestamp Object</a> whose value is less than the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#current-playback-position">current playback
 position</a> of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media element</a> that is the <i>matched element</i>, entirely after the <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-19">WebVTT Node Object</a> <var>c</var>.</p>
-   <p>The <dfn class="dfn-paneled css" data-dfn-type="selector" data-export="" id="selectordef-future">:future</dfn> pseudo-class only matches <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-20">WebVTT Node
+   <p>The <dfn data-dfn-type="dfn" data-noexport="" id="future">:future<a class="self-link" href="#future"></a></dfn> pseudo-class only matches <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-20">WebVTT Node
 Objects</a> that are <i>in the future</i>.</p>
    <p class="algorithm" data-algorithm="in the future">A <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-21">WebVTT Node Object</a> <var>c</var> is <dfn data-dfn-type="dfn" data-noexport="" id="in-the-future">in the future<a class="self-link" href="#in-the-future"></a></dfn> if, in a
-pre-order, depth-first traversal of the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-29">WebVTT cue</a>’s <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-27">list of WebVTT Node Objects</a>,
-there exists a <a data-link-type="dfn" href="#webvtt-timestamp-object" id="ref-for-webvtt-timestamp-object-6">WebVTT Timestamp Object</a> whose value is greater than the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#current-playback-position">current playback
+pre-order, depth-first traversal of the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-29">WebVTT cue</a>’s <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-34">list of WebVTT Node Objects</a>,
+there exists a <a data-link-type="dfn" href="#webvtt-timestamp-object" id="ref-for-webvtt-timestamp-object-7">WebVTT Timestamp Object</a> whose value is greater than the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#current-playback-position">current playback
 position</a> of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media element</a> that is the <i>matched element</i>, entirely before the <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-22">WebVTT Node Object</a> <var>c</var>.</p>
-   <h5 class="heading settled" data-level="6.1.2.3" id="the-cue-region-pseudo-element"><span class="secno">6.1.2.3. </span><span class="content">The <a class="css" data-link-type="maybe" href="#selectordef-cue-region" id="ref-for-selectordef-cue-region-3">::cue-region</a> pseudo-element</span><a class="self-link" href="#the-cue-region-pseudo-element"></a></h5>
+   <h4 class="heading settled" data-level="7.2.3" id="the-cue-region-pseudo-element"><span class="secno">7.2.3. </span><span class="content">The <span class="css">::cue-region</span> pseudo-element</span><a class="self-link" href="#the-cue-region-pseudo-element"></a></h4>
    <p>Pseudo-elements apply to elements that are matched by selectors. For the purpose of this section,
 that element is the matched element. The pseudo-element defined below affects the styling of text
 track regions that are being rendered for the matched element.</p>
    <p class="note" role="note">If the matched element is not a video element, the pseudo-element defined below
 won’t have any effect according to this specification.</p>
-   <p>The <dfn class="dfn-paneled css" data-dfn-type="selector" data-export="" id="selectordef-cue-region">::cue-region</dfn> pseudo-element (with no argument) matches any list of <a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object-10">WebVTT region objects</a> constructed for the <i>matched element</i>.</p>
-   <p>The same properties that apply to <a class="css" data-link-type="maybe" href="#selectordef-cue" id="ref-for-selectordef-cue-6">::cue</a> apply to the <a class="css" data-link-type="maybe" href="#selectordef-cue-region" id="ref-for-selectordef-cue-region-4">::cue-region</a> pseudo-element with no
+   <p>The <dfn data-dfn-type="dfn" data-noexport="" id="cue-region">::cue-region<a class="self-link" href="#cue-region"></a></dfn> pseudo-element (with no argument) matches any list of <a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object-11">WebVTT region objects</a> constructed for the <i>matched element</i>.</p>
+   <p>The same properties that apply to <span class="css">::cue</span> apply to the <span class="css">::cue-region</span> pseudo-element with no
 argument; other properties set on the pseudo-element must be ignored.</p>
    <p>When a user agent is rendering one or more text track regions according to the <a data-link-type="dfn" href="#rules-for-updating-the-display-of-webvtt-text-tracks" id="ref-for-rules-for-updating-the-display-of-webvtt-text-tracks-9">rules for
-updating the display of WebVTT text tracks</a>, <a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object-11">WebVTT region
+updating the display of WebVTT text tracks</a>, <a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object-12">WebVTT region
 objects</a> used in the rendering can be matched by the above pseudo-element. User agents that
-support the pseudo-element must dynamically update renderings accordingly. When either <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-3/#propdef-white-space">white-space</a> or one of the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-fonts-3/#propdef-font">font</a> shorthand (including <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css21/visudet.html#propdef-line-height">line-height</a>) changes
+support the pseudo-element must dynamically update renderings accordingly. When either <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/text.html#propdef-white-space">white-space</a> or one of the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-fonts-3/#propdef-font">font</a> shorthand (including <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css21/visudet.html#propdef-line-height">line-height</a>) changes
 value, then the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-display-state">text track cue display state</a> of all the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-30">WebVTT cues</a> in
 the region must be emptied and the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track">text track</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#rules-for-updating-the-text-track-rendering">rules for updating the text track
 rendering</a> must be immediately rerun.</p>
-   <p>A CSS user agent that implements the text tracks model must implement the <a class="css" data-link-type="maybe" href="#selectordef-cue-region" id="ref-for-selectordef-cue-region-5">::cue-region</a> pseudo-element.</p>
-   <h2 class="heading settled" data-level="7" id="api"><span class="secno">7. </span><span class="content">API</span><a class="self-link" href="#api"></a></h2>
-   <h3 class="heading settled algorithm" data-algorithm="The VTTCue interface" data-level="7.1" id="the-vttcue-interface"><span class="secno">7.1. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#vttcue" id="ref-for-vttcue-2">VTTCue</a></code> interface</span><a class="self-link" href="#the-vttcue-interface"></a></h3>
+   <p>A CSS user agent that implements the text tracks model must implement the <span class="css">::cue-region</span> pseudo-element.</p>
+   <h2 class="heading settled" data-level="8" id="api"><span class="secno">8. </span><span class="content">API</span><a class="self-link" href="#api"></a></h2>
+   <h3 class="heading settled algorithm" data-algorithm="The VTTCue interface" data-level="8.1" id="the-vttcue-interface"><span class="secno">8.1. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#vttcue" id="ref-for-vttcue-2">VTTCue</a></code> interface</span><a class="self-link" href="#the-vttcue-interface"></a></h3>
    <p>The following interface is used to expose WebVTT cues in the DOM API:</p>
 <pre class="idl highlight def"><span class="kt">enum</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="enum" data-export="" id="enumdef-autokeyword">AutoKeyword</dfn> { <dfn class="s idl-code" data-dfn-for="AutoKeyword" data-dfn-type="enum-value" data-export="" data-lt="&quot;auto&quot;|auto" id="dom-autokeyword-auto">"auto"<a class="self-link" href="#dom-autokeyword-auto"></a></dfn> };
 <span class="kt">enum</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="enum" data-export="" id="enumdef-directionsetting">DirectionSetting</dfn> { <dfn class="s idl-code" data-dfn-for="DirectionSetting" data-dfn-type="enum-value" data-export="" data-lt="&quot;&quot;|" id="dom-directionsetting">""<a class="self-link" href="#dom-directionsetting"></a></dfn> /* horizontal */, <dfn class="s idl-code" data-dfn-for="DirectionSetting" data-dfn-type="enum-value" data-export="" data-lt="&quot;rl&quot;|rl" id="dom-directionsetting-rl">"rl"<a class="self-link" href="#dom-directionsetting-rl"></a></dfn>, <dfn class="s idl-code" data-dfn-for="DirectionSetting" data-dfn-type="enum-value" data-export="" data-lt="&quot;lr&quot;|lr" id="dom-directionsetting-lr">"lr"<a class="self-link" href="#dom-directionsetting-lr"></a></dfn> };
@@ -5145,7 +5362,7 @@ text</a> to a <code class="idl"><a data-link-type="idl" href="https://dom.spec.w
 the result of applying the <a data-link-type="dfn" href="#webvtt-cue-text-parsing-rules" id="ref-for-webvtt-cue-text-parsing-rules-3">WebVTT cue text parsing rules</a> to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-text">text track cue
 text</a>.</p>
    <p class="note" role="note">A fallback language is not provided for <code class="idl"><a data-link-type="idl" href="#dom-vttcue-getcueashtml" id="ref-for-dom-vttcue-getcueashtml-4">getCueAsHTML()</a></code> since a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#documentfragment">DocumentFragment</a></code> cannot expose language information.</p>
-   <h3 class="heading settled algorithm" data-algorithm="The VTTRegion interface" data-level="7.2" id="the-vttregion-interface"><span class="secno">7.2. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#vttregion" id="ref-for-vttregion-4">VTTRegion</a></code> interface</span><a class="self-link" href="#the-vttregion-interface"></a></h3>
+   <h3 class="heading settled algorithm" data-algorithm="The VTTRegion interface" data-level="8.2" id="the-vttregion-interface"><span class="secno">8.2. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#vttregion" id="ref-for-vttregion-4">VTTRegion</a></code> interface</span><a class="self-link" href="#the-vttregion-interface"></a></h3>
    <p>The following interface is used to expose WebVTT regions in the DOM API:</p>
 <pre class="idl highlight def"><span class="kt">enum</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="enum" data-export="" id="enumdef-scrollsetting">ScrollSetting</dfn> { <dfn class="s idl-code" data-dfn-for="ScrollSetting" data-dfn-type="enum-value" data-export="" data-lt="&quot;&quot;|" id="dom-scrollsetting">""<a class="self-link" href="#dom-scrollsetting"></a></dfn> /* none */, <dfn class="s idl-code" data-dfn-for="ScrollSetting" data-dfn-type="enum-value" data-export="" data-lt="&quot;up&quot;|up" id="dom-scrollsetting-up">"up"<a class="self-link" href="#dom-scrollsetting-up"></a></dfn> };
 [<a class="nv idl-code" data-link-type="constructor" href="#dom-vttregion-vttregion" id="ref-for-dom-vttregion-vttregion-1">Constructor</a>]
@@ -5258,8 +5475,8 @@ the second cell of the row in the table below whose first cell is the <a data-li
    </table>
    <p>On setting, the <a data-link-type="dfn" href="#webvtt-region-scroll" id="ref-for-webvtt-region-scroll-8">WebVTT region scroll</a> must be set to the value given on the first cell of
 the row in the table above whose second cell is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">case-sensitive</a> match for the new value.</p>
-   <h2 class="heading settled" data-level="8" id="iana"><span class="secno">8. </span><span class="content">IANA considerations</span><a class="self-link" href="#iana"></a></h2>
-   <h3 class="heading settled" data-level="8.1" id="iana-text-vtt"><span class="secno">8.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="text-vtt"><code>text/vtt</code></dfn></span><a class="self-link" href="#iana-text-vtt"></a></h3>
+   <h2 class="heading settled" data-level="9" id="iana"><span class="secno">9. </span><span class="content">IANA considerations</span><a class="self-link" href="#iana"></a></h2>
+   <h3 class="heading settled" data-level="9.1" id="iana-text-vtt"><span class="secno">9.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="text-vtt"><code>text/vtt</code></dfn></span><a class="self-link" href="#iana-text-vtt"></a></h3>
    <p>This registration is for community review and will be submitted to the IESG for review, approval,
 and registration with IANA.</p>
    <dl>
@@ -5371,127 +5588,127 @@ originally specified. <a data-link-type="biblio" href="#biblio-html">[HTML]</a><
    <li>
     ""
     <ul>
-     <li><a href="#dom-directionsetting">enum-value for DirectionSetting</a><span>, in §7.1</span>
-     <li><a href="#dom-scrollsetting">enum-value for ScrollSetting</a><span>, in §7.2</span>
+     <li><a href="#dom-directionsetting">enum-value for DirectionSetting</a><span>, in §8.1</span>
+     <li><a href="#dom-scrollsetting">enum-value for ScrollSetting</a><span>, in §8.2</span>
     </ul>
-   <li><a href="#dom-vttcue-align">align</a><span>, in §7.1</span>
-   <li><a href="#enumdef-alignsetting">AlignSetting</a><span>, in §7.1</span>
+   <li><a href="#dom-vttcue-align">align</a><span>, in §8.1</span>
+   <li><a href="#enumdef-alignsetting">AlignSetting</a><span>, in §8.1</span>
    <li><a href="#apply-webvtt-cue-settings">apply WebVTT cue settings</a><span>, in §6.1</span>
    <li><a href="#attach-a-webvtt-internal-node-object">attach a WebVTT Internal Node Object</a><span>, in §5.4</span>
    <li>
     auto
     <ul>
-     <li><a href="#dom-autokeyword-auto">enum-value for AutoKeyword</a><span>, in §7.1</span>
-     <li><a href="#dom-positionalignsetting-auto">enum-value for PositionAlignSetting</a><span>, in §7.1</span>
+     <li><a href="#dom-autokeyword-auto">enum-value for AutoKeyword</a><span>, in §8.1</span>
+     <li><a href="#dom-positionalignsetting-auto">enum-value for PositionAlignSetting</a><span>, in §8.1</span>
     </ul>
    <li>
     "auto"
     <ul>
-     <li><a href="#dom-autokeyword-auto">enum-value for AutoKeyword</a><span>, in §7.1</span>
-     <li><a href="#dom-positionalignsetting-auto">enum-value for PositionAlignSetting</a><span>, in §7.1</span>
+     <li><a href="#dom-autokeyword-auto">enum-value for AutoKeyword</a><span>, in §8.1</span>
+     <li><a href="#dom-positionalignsetting-auto">enum-value for PositionAlignSetting</a><span>, in §8.1</span>
     </ul>
-   <li><a href="#enumdef-autokeyword">AutoKeyword</a><span>, in §7.1</span>
+   <li><a href="#enumdef-autokeyword">AutoKeyword</a><span>, in §8.1</span>
    <li>
     "center"
     <ul>
-     <li><a href="#dom-linealignsetting-center">enum-value for LineAlignSetting</a><span>, in §7.1</span>
-     <li><a href="#dom-positionalignsetting-center">enum-value for PositionAlignSetting</a><span>, in §7.1</span>
-     <li><a href="#dom-alignsetting-center">enum-value for AlignSetting</a><span>, in §7.1</span>
+     <li><a href="#dom-linealignsetting-center">enum-value for LineAlignSetting</a><span>, in §8.1</span>
+     <li><a href="#dom-positionalignsetting-center">enum-value for PositionAlignSetting</a><span>, in §8.1</span>
+     <li><a href="#dom-alignsetting-center">enum-value for AlignSetting</a><span>, in §8.1</span>
     </ul>
    <li>
     center
     <ul>
-     <li><a href="#dom-linealignsetting-center">enum-value for LineAlignSetting</a><span>, in §7.1</span>
-     <li><a href="#dom-positionalignsetting-center">enum-value for PositionAlignSetting</a><span>, in §7.1</span>
-     <li><a href="#dom-alignsetting-center">enum-value for AlignSetting</a><span>, in §7.1</span>
+     <li><a href="#dom-linealignsetting-center">enum-value for LineAlignSetting</a><span>, in §8.1</span>
+     <li><a href="#dom-positionalignsetting-center">enum-value for PositionAlignSetting</a><span>, in §8.1</span>
+     <li><a href="#dom-alignsetting-center">enum-value for AlignSetting</a><span>, in §8.1</span>
     </ul>
    <li><a href="#collect-a-webvtt-block">collect a WebVTT block</a><span>, in §5.1</span>
    <li><a href="#collect-a-webvtt-timestamp">collect a WebVTT timestamp</a><span>, in §5.3</span>
    <li><a href="#collect-webvtt-cue-timings-and-settings">collect WebVTT cue timings and settings</a><span>, in §5.3</span>
    <li><a href="#collect-webvtt-region-settings">collect WebVTT region settings</a><span>, in §5.2</span>
    <li><a href="#consume-an-html-character-reference">consume an HTML character reference</a><span>, in §5.4</span>
-   <li><a href="#selectordef-cue">::cue</a><span>, in §6.1.2.1</span>
+   <li><a href="#cue">::cue</a><span>, in §7.2.1</span>
    <li><a href="#cue-computed-line">cue computed line</a><span>, in §3.1</span>
    <li><a href="#cue-computed-position">cue computed position</a><span>, in §3.1</span>
    <li><a href="#cue-computed-position-alignment">cue computed position alignment</a><span>, in §3.1</span>
    <li><a href="#cue-payload">cue payload</a><span>, in §4.1</span>
-   <li><a href="#selectordef-cue-region">::cue-region</a><span>, in §6.1.2.3</span>
-   <li><a href="#selectordef-cue-selector">::cue(selector)</a><span>, in §6.1.2.1</span>
-   <li><a href="#enumdef-directionsetting">DirectionSetting</a><span>, in §7.1</span>
+   <li><a href="#cue-region">::cue-region</a><span>, in §7.2.3</span>
+   <li><a href="#cue-selector">::cue(selector)</a><span>, in §7.2.1</span>
+   <li><a href="#enumdef-directionsetting">DirectionSetting</a><span>, in §8.1</span>
    <li>
     "end"
     <ul>
-     <li><a href="#dom-linealignsetting-end">enum-value for LineAlignSetting</a><span>, in §7.1</span>
-     <li><a href="#dom-alignsetting-end">enum-value for AlignSetting</a><span>, in §7.1</span>
+     <li><a href="#dom-linealignsetting-end">enum-value for LineAlignSetting</a><span>, in §8.1</span>
+     <li><a href="#dom-alignsetting-end">enum-value for AlignSetting</a><span>, in §8.1</span>
     </ul>
    <li>
     end
     <ul>
-     <li><a href="#dom-linealignsetting-end">enum-value for LineAlignSetting</a><span>, in §7.1</span>
-     <li><a href="#dom-alignsetting-end">enum-value for AlignSetting</a><span>, in §7.1</span>
+     <li><a href="#dom-linealignsetting-end">enum-value for LineAlignSetting</a><span>, in §8.1</span>
+     <li><a href="#dom-alignsetting-end">enum-value for AlignSetting</a><span>, in §8.1</span>
     </ul>
-   <li><a href="#selectordef-future">:future</a><span>, in §6.1.2.2</span>
-   <li><a href="#dom-vttcue-getcueashtml">getCueAsHTML()</a><span>, in §7.1</span>
+   <li><a href="#future">:future</a><span>, in §7.2.2</span>
+   <li><a href="#dom-vttcue-getcueashtml">getCueAsHTML()</a><span>, in §8.1</span>
    <li><a href="#html-character-reference-in-annotation-state">HTML character reference in annotation state</a><span>, in §5.4</span>
    <li><a href="#html-character-reference-in-data-state">HTML character reference in data state</a><span>, in §5.4</span>
    <li><a href="#incremental-webvtt-parser">incremental WebVTT parser</a><span>, in §5.1</span>
-   <li><a href="#in-the-future">in the future</a><span>, in §6.1.2.2</span>
-   <li><a href="#in-the-past">in the past</a><span>, in §6.1.2.2</span>
-   <li><a href="#dom-alignsetting-left">"left"</a><span>, in §7.1</span>
-   <li><a href="#dom-alignsetting-left">left</a><span>, in §7.1</span>
-   <li><a href="#dom-vttcue-line">line</a><span>, in §7.1</span>
-   <li><a href="#dom-vttcue-linealign">lineAlign</a><span>, in §7.1</span>
-   <li><a href="#enumdef-linealignsetting">LineAlignSetting</a><span>, in §7.1</span>
-   <li><a href="#dom-positionalignsetting-line-left">"line-left"</a><span>, in §7.1</span>
-   <li><a href="#dom-positionalignsetting-line-left">line-left</a><span>, in §7.1</span>
-   <li><a href="#dom-positionalignsetting-line-right">"line-right"</a><span>, in §7.1</span>
-   <li><a href="#dom-positionalignsetting-line-right">line-right</a><span>, in §7.1</span>
-   <li><a href="#dom-vttregion-lines">lines</a><span>, in §7.2</span>
+   <li><a href="#in-the-future">in the future</a><span>, in §7.2.2</span>
+   <li><a href="#in-the-past">in the past</a><span>, in §7.2.2</span>
+   <li><a href="#dom-alignsetting-left">"left"</a><span>, in §8.1</span>
+   <li><a href="#dom-alignsetting-left">left</a><span>, in §8.1</span>
+   <li><a href="#dom-vttcue-line">line</a><span>, in §8.1</span>
+   <li><a href="#dom-vttcue-linealign">lineAlign</a><span>, in §8.1</span>
+   <li><a href="#enumdef-linealignsetting">LineAlignSetting</a><span>, in §8.1</span>
+   <li><a href="#dom-positionalignsetting-line-left">"line-left"</a><span>, in §8.1</span>
+   <li><a href="#dom-positionalignsetting-line-left">line-left</a><span>, in §8.1</span>
+   <li><a href="#dom-positionalignsetting-line-right">"line-right"</a><span>, in §8.1</span>
+   <li><a href="#dom-positionalignsetting-line-right">line-right</a><span>, in §8.1</span>
+   <li><a href="#dom-vttregion-lines">lines</a><span>, in §8.2</span>
    <li><a href="#list-of-webvtt-node-objects">List of WebVTT Node Objects</a><span>, in §5.4</span>
-   <li><a href="#dom-directionsetting-lr">"lr"</a><span>, in §7.1</span>
-   <li><a href="#dom-directionsetting-lr">lr</a><span>, in §7.1</span>
+   <li><a href="#dom-directionsetting-lr">"lr"</a><span>, in §8.1</span>
+   <li><a href="#dom-directionsetting-lr">lr</a><span>, in §8.1</span>
    <li><a href="#parse-a-percentage-string">parse a percentage string</a><span>, in §5.2</span>
    <li><a href="#parse-the-webvtt-cue-settings">parse the WebVTT cue settings</a><span>, in §5.3</span>
-   <li><a href="#selectordef-past">:past</a><span>, in §6.1.2.2</span>
-   <li><a href="#dom-vttcue-position">position</a><span>, in §7.1</span>
-   <li><a href="#dom-vttcue-positionalign">positionAlign</a><span>, in §7.1</span>
-   <li><a href="#enumdef-positionalignsetting">PositionAlignSetting</a><span>, in §7.1</span>
-   <li><a href="#dom-vttcue-region">region</a><span>, in §7.1</span>
-   <li><a href="#dom-vttregion-regionanchorx">regionAnchorX</a><span>, in §7.2</span>
-   <li><a href="#dom-vttregion-regionanchory">regionAnchorY</a><span>, in §7.2</span>
-   <li><a href="#dom-alignsetting-right">right</a><span>, in §7.1</span>
-   <li><a href="#dom-alignsetting-right">"right"</a><span>, in §7.1</span>
-   <li><a href="#dom-directionsetting-rl">rl</a><span>, in §7.1</span>
-   <li><a href="#dom-directionsetting-rl">"rl"</a><span>, in §7.1</span>
+   <li><a href="#past">:past</a><span>, in §7.2.2</span>
+   <li><a href="#dom-vttcue-position">position</a><span>, in §8.1</span>
+   <li><a href="#dom-vttcue-positionalign">positionAlign</a><span>, in §8.1</span>
+   <li><a href="#enumdef-positionalignsetting">PositionAlignSetting</a><span>, in §8.1</span>
+   <li><a href="#dom-vttcue-region">region</a><span>, in §8.1</span>
+   <li><a href="#dom-vttregion-regionanchorx">regionAnchorX</a><span>, in §8.2</span>
+   <li><a href="#dom-vttregion-regionanchory">regionAnchorY</a><span>, in §8.2</span>
+   <li><a href="#dom-alignsetting-right">right</a><span>, in §8.1</span>
+   <li><a href="#dom-alignsetting-right">"right"</a><span>, in §8.1</span>
+   <li><a href="#dom-directionsetting-rl">rl</a><span>, in §8.1</span>
+   <li><a href="#dom-directionsetting-rl">"rl"</a><span>, in §8.1</span>
    <li><a href="#rules-for-updating-the-display-of-webvtt-text-tracks">rules for updating the display of WebVTT text tracks</a><span>, in §6.1</span>
-   <li><a href="#dom-vttregion-scroll">scroll</a><span>, in §7.2</span>
-   <li><a href="#enumdef-scrollsetting">ScrollSetting</a><span>, in §7.2</span>
-   <li><a href="#dom-vttcue-size">size</a><span>, in §7.1</span>
-   <li><a href="#dom-vttcue-snaptolines">snapToLines</a><span>, in §7.1</span>
+   <li><a href="#dom-vttregion-scroll">scroll</a><span>, in §8.2</span>
+   <li><a href="#enumdef-scrollsetting">ScrollSetting</a><span>, in §8.2</span>
+   <li><a href="#dom-vttcue-size">size</a><span>, in §8.1</span>
+   <li><a href="#dom-vttcue-snaptolines">snapToLines</a><span>, in §8.1</span>
    <li>
     "start"
     <ul>
-     <li><a href="#dom-linealignsetting-start">enum-value for LineAlignSetting</a><span>, in §7.1</span>
-     <li><a href="#dom-alignsetting-start">enum-value for AlignSetting</a><span>, in §7.1</span>
+     <li><a href="#dom-linealignsetting-start">enum-value for LineAlignSetting</a><span>, in §8.1</span>
+     <li><a href="#dom-alignsetting-start">enum-value for AlignSetting</a><span>, in §8.1</span>
     </ul>
    <li>
     start
     <ul>
-     <li><a href="#dom-linealignsetting-start">enum-value for LineAlignSetting</a><span>, in §7.1</span>
-     <li><a href="#dom-alignsetting-start">enum-value for AlignSetting</a><span>, in §7.1</span>
+     <li><a href="#dom-linealignsetting-start">enum-value for LineAlignSetting</a><span>, in §8.1</span>
+     <li><a href="#dom-alignsetting-start">enum-value for AlignSetting</a><span>, in §8.1</span>
     </ul>
-   <li><a href="#dom-vttcue-text">text</a><span>, in §7.1</span>
+   <li><a href="#dom-vttcue-text">text</a><span>, in §8.1</span>
    <li><a href="#text-track-list-of-regions">text track list of regions</a><span>, in §3.2</span>
-   <li><a href="#text-vtt">text/vtt</a><span>, in §8.1</span>
-   <li><a href="#dom-scrollsetting-up">up</a><span>, in §7.2</span>
-   <li><a href="#dom-scrollsetting-up">"up"</a><span>, in §7.2</span>
-   <li><a href="#dom-vttcue-vertical">vertical</a><span>, in §7.1</span>
-   <li><a href="#dom-vttregion-viewportanchorx">viewportAnchorX</a><span>, in §7.2</span>
-   <li><a href="#dom-vttregion-viewportanchory">viewportAnchorY</a><span>, in §7.2</span>
-   <li><a href="#vttcue">VTTCue</a><span>, in §7.1</span>
-   <li><a href="#dom-vttcue-vttcue">VTTCue(startTime, endTime, text)</a><span>, in §7.1</span>
-   <li><a href="#dom-vttregion-vttregion">VTTRegion()</a><span>, in §7.2</span>
-   <li><a href="#vttregion">VTTRegion</a><span>, in §7.2</span>
+   <li><a href="#text-vtt">text/vtt</a><span>, in §9.1</span>
+   <li><a href="#dom-scrollsetting-up">up</a><span>, in §8.2</span>
+   <li><a href="#dom-scrollsetting-up">"up"</a><span>, in §8.2</span>
+   <li><a href="#dom-vttcue-vertical">vertical</a><span>, in §8.1</span>
+   <li><a href="#dom-vttregion-viewportanchorx">viewportAnchorX</a><span>, in §8.2</span>
+   <li><a href="#dom-vttregion-viewportanchory">viewportAnchorY</a><span>, in §8.2</span>
+   <li><a href="#vttcue">VTTCue</a><span>, in §8.1</span>
+   <li><a href="#dom-vttcue-vttcue">VTTCue(startTime, endTime, text)</a><span>, in §8.1</span>
+   <li><a href="#dom-vttregion-vttregion">VTTRegion()</a><span>, in §8.2</span>
+   <li><a href="#vttregion">VTTRegion</a><span>, in §8.2</span>
    <li><a href="#webvtt">WebVTT</a><span>, in §1</span>
    <li><a href="#webvtt-alignment-cue-setting">WebVTT alignment cue setting</a><span>, in §4.4</span>
    <li><a href="#webvtt-bold-object">WebVTT Bold Object</a><span>, in §5.4</span>
@@ -5610,7 +5827,7 @@ originally specified. <a data-link-type="biblio" href="#biblio-html">[HTML]</a><
    <li><a href="#webvtt-underline-object">WebVTT Underline Object</a><span>, in §5.4</span>
    <li><a href="#webvtt-vertical-text-cue-setting">WebVTT vertical text cue setting</a><span>, in §4.4</span>
    <li><a href="#webvtt-voice-object">WebVTT Voice Object</a><span>, in §5.4</span>
-   <li><a href="#dom-vttregion-width">width</a><span>, in §7.2</span>
+   <li><a href="#dom-vttregion-width">width</a><span>, in §8.2</span>
   </ul>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
@@ -5620,15 +5837,8 @@ originally specified. <a data-link-type="biblio" href="#biblio-html">[HTML]</a><
      <li><a href="https://drafts.csswg.org/css-align-3/#propdef-justify-content">justify-content</a>
     </ul>
    <li>
-    <a data-link-type="biblio">[css-backgrounds-3]</a> defines the following terms:
-    <ul>
-     <li><a href="https://drafts.csswg.org/css-backgrounds-3/#background">background</a>
-     <li><a href="https://drafts.csswg.org/css-backgrounds-3/#background-image">background-image</a>
-    </ul>
-   <li>
     <a data-link-type="biblio">[css-cascade-4]</a> defines the following terms:
     <ul>
-     <li><a href="https://drafts.csswg.org/css-cascade-4/#at-ruledef-import">@import</a>
      <li><a href="https://drafts.csswg.org/css-cascade-4/#cascade">cascade</a>
     </ul>
    <li>
@@ -5640,7 +5850,6 @@ originally specified. <a data-link-type="biblio" href="#biblio-html">[HTML]</a><
    <li>
     <a data-link-type="biblio">[css-display-3]</a> defines the following terms:
     <ul>
-     <li><a href="https://drafts.csswg.org/css-display-3/#propdef-display">display</a>
      <li><a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline">inline</a>
     </ul>
    <li>
@@ -5676,7 +5885,6 @@ originally specified. <a data-link-type="biblio" href="#biblio-html">[HTML]</a><
      <li><a href="https://drafts.csswg.org/css-position-3/#propdef-left">left</a>
      <li><a href="https://drafts.csswg.org/css-position-3/#propdef-position">position</a>
      <li><a href="https://drafts.csswg.org/css-position-3/#valdef-position-relative">relative</a>
-     <li><a href="https://drafts.csswg.org/css-position-3/#propdef-top">top</a>
     </ul>
    <li>
     <a data-link-type="biblio">[CSS3-RUBY]</a> defines the following terms:
@@ -5703,7 +5911,6 @@ originally specified. <a data-link-type="biblio" href="#biblio-html">[HTML]</a><
      <li><a href="https://drafts.csswg.org/css-text-3/#valdef-text-align-right">right</a>
      <li><a href="https://drafts.csswg.org/css-text-3/#valdef-text-align-start">start</a>
      <li><a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">text-align</a>
-     <li><a href="https://drafts.csswg.org/css-text-3/#propdef-white-space">white-space</a>
     </ul>
    <li>
     <a data-link-type="biblio">[css-text-decor-3]</a> defines the following terms:
@@ -5718,14 +5925,10 @@ originally specified. <a data-link-type="biblio" href="#biblio-html">[HTML]</a><
      <li><a href="https://drafts.csswg.org/css-transitions-1/#propdef-transition-property">transition-property</a>
     </ul>
    <li>
-    <a data-link-type="biblio">[css-ui-3]</a> defines the following terms:
-    <ul>
-     <li><a href="https://drafts.csswg.org/css-ui-3/#propdef-outline">outline</a>
-    </ul>
-   <li>
     <a data-link-type="biblio">[CSS-VALUES]</a> defines the following terms:
     <ul>
      <li><a href="https://drafts.csswg.org/css-values-4/#vh">vh</a>
+     <li><a href="https://drafts.csswg.org/css-values-4/#vw">vw</a>
     </ul>
    <li>
     <a data-link-type="biblio">[CSS-WRITING-MODES-3]</a> defines the following terms:
@@ -5743,8 +5946,19 @@ originally specified. <a data-link-type="biblio" href="#biblio-html">[HTML]</a><
      <li><a href="https://drafts.csswg.org/css21/visudet.html#propdef-line-height">line-height</a>
      <li><a href="https://drafts.csswg.org/css21/visudet.html#propdef-max-height">max-height</a>
      <li><a href="https://drafts.csswg.org/css21/visudet.html#propdef-min-height">min-height</a>
-     <li><a href="https://drafts.csswg.org/css21/visufx.html#propdef-visibility">visibility</a>
      <li><a href="https://drafts.csswg.org/css21/visudet.html#propdef-width">width</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[CSS22]</a> defines the following terms:
+    <ul>
+     <li><a href="https://drafts.csswg.org/css2/cascade.html#x7">@import</a>
+     <li><a href="https://drafts.csswg.org/css2/colors.html#propdef-background">background</a>
+     <li><a href="https://drafts.csswg.org/css2/colors.html#propdef-background-image">background-image</a>
+     <li><a href="https://drafts.csswg.org/css2/visuren.html#propdef-display">display</a>
+     <li><a href="https://drafts.csswg.org/css2/ui.html#propdef-outline">outline</a>
+     <li><a href="https://drafts.csswg.org/css2/visuren.html#propdef-top">top</a>
+     <li><a href="https://drafts.csswg.org/css2/visufx.html#propdef-visibility">visibility</a>
+     <li><a href="https://drafts.csswg.org/css2/text.html#propdef-white-space">white-space</a>
     </ul>
    <li>
     <a data-link-type="biblio">[CSSOM]</a> defines the following terms:
@@ -5769,7 +5983,6 @@ originally specified. <a data-link-type="biblio" href="#biblio-html">[HTML]</a><
      <li><a href="https://dom.spec.whatwg.org/#processinginstruction">ProcessingInstruction</a>
      <li><a href="https://dom.spec.whatwg.org/#text">Text</a>
      <li><a href="https://dom.spec.whatwg.org/#dom-characterdata-data">data</a>
-     <li><a href="https://dom.spec.whatwg.org/#html-namespace">html namespace</a>
      <li><a href="https://dom.spec.whatwg.org/#dom-node-namespaceuri">namespaceURI</a>
      <li><a href="https://dom.spec.whatwg.org/#dom-node-ownerdocument">ownerDocument</a>
      <li><a href="https://dom.spec.whatwg.org/#dom-processinginstruction-target">target</a>
@@ -5796,19 +6009,30 @@ originally specified. <a data-link-type="biblio" href="#biblio-html">[HTML]</a><
      <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-ruby-element">ruby</a>
      <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#space-character">space characters</a>
      <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-span-element">span</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-track-srclang">srclang</a>
      <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element">style</a>
      <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track">text tracks</a>
      <li><a href="https://html.spec.whatwg.org/multipage/dom.html#attr-title">title</a>
      <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-track-element">track</a>
      <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-u-element">u</a>
      <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#video">video</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#&apos;vw&apos;">vw</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[INFRA]</a> defines the following terms:
+    <ul>
+     <li><a href="https://infra.spec.whatwg.org/#html-namespace">html namespace</a>
     </ul>
    <li>
     <a data-link-type="biblio">[selectors-4]</a> defines the following terms:
     <ul>
+     <li><a href="https://drafts.csswg.org/selectors-4/#future-pseudo">:future</a>
      <li><a href="https://drafts.csswg.org/selectors-4/#lang-pseudo">:lang()</a>
+     <li><a href="https://drafts.csswg.org/selectors-4/#past-pseudo">:past</a>
+     <li><a href="https://drafts.csswg.org/selectors-4/#attribute-selector">attribute selector</a>
+     <li><a href="https://drafts.csswg.org/selectors-4/#class-selector">class selector</a>
+     <li><a href="https://drafts.csswg.org/selectors-4/#id-selector">id selector</a>
      <li><a href="https://drafts.csswg.org/selectors-4/#originating-element">originating element</a>
+     <li><a href="https://drafts.csswg.org/selectors-4/#type-selector">type selector</a>
     </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
@@ -5817,51 +6041,51 @@ originally specified. <a data-link-type="biblio" href="#biblio-html">[HTML]</a><
    <dt id="biblio-bcp47">[BCP47]
    <dd>A. Phillips; M. Davis. <a href="https://tools.ietf.org/html/bcp47">Tags for Identifying Languages</a>. September 2009. IETF Best Current Practice. URL: <a href="https://tools.ietf.org/html/bcp47">https://tools.ietf.org/html/bcp47</a>
    <dt id="biblio-css-align-3">[CSS-ALIGN-3]
-   <dd>Elika Etemad; Tab Atkins Jr.. <a href="https://drafts.csswg.org/css-align/">CSS Box Alignment Module Level 3</a>. 14 June 2016. WD. URL: <a href="https://drafts.csswg.org/css-align/">https://drafts.csswg.org/css-align/</a>
-   <dt id="biblio-css-backgrounds-3">[CSS-BACKGROUNDS-3]
-   <dd>CSS Backgrounds and Borders Module Level 3 URL: <a href="https://drafts.csswg.org/css-backgrounds-3/">https://drafts.csswg.org/css-backgrounds-3/</a>
+   <dd>Elika Etemad; Tab Atkins Jr.. <a href="https://drafts.csswg.org/css-align/">CSS Box Alignment Module Level 3</a>. URL: <a href="https://drafts.csswg.org/css-align/">https://drafts.csswg.org/css-align/</a>
    <dt id="biblio-css-cascade-4">[CSS-CASCADE-4]
-   <dd>Elika Etemad; Tab Atkins Jr.. <a href="http://dev.w3.org/csswg/css-cascade/">CSS Cascading and Inheritance Level 4</a>. 14 January 2016. CR. URL: <a href="http://dev.w3.org/csswg/css-cascade/">http://dev.w3.org/csswg/css-cascade/</a>
+   <dd>Elika Etemad; Tab Atkins Jr.. <a href="http://dev.w3.org/csswg/css-cascade/">CSS Cascading and Inheritance Level 4</a>. URL: <a href="http://dev.w3.org/csswg/css-cascade/">http://dev.w3.org/csswg/css-cascade/</a>
    <dt id="biblio-css-color-4">[CSS-COLOR-4]
-   <dd>Tab Atkins Jr.; Chris Lilley. <a href="https://drafts.csswg.org/css-color/">CSS Color Module Level 4</a>. 5 July 2016. WD. URL: <a href="https://drafts.csswg.org/css-color/">https://drafts.csswg.org/css-color/</a>
+   <dd>Tab Atkins Jr.; Chris Lilley. <a href="https://drafts.csswg.org/css-color/">CSS Color Module Level 4</a>. URL: <a href="https://drafts.csswg.org/css-color/">https://drafts.csswg.org/css-color/</a>
    <dt id="biblio-css-display-3">[CSS-DISPLAY-3]
-   <dd>Tab Atkins Jr.; Elika Etemad. <a href="http://dev.w3.org/csswg/css-display/">CSS Display Module Level 3</a>. 15 October 2015. WD. URL: <a href="http://dev.w3.org/csswg/css-display/">http://dev.w3.org/csswg/css-display/</a>
+   <dd>Tab Atkins Jr.; Elika Etemad. <a href="http://dev.w3.org/csswg/css-display/">CSS Display Module Level 3</a>. URL: <a href="http://dev.w3.org/csswg/css-display/">http://dev.w3.org/csswg/css-display/</a>
    <dt id="biblio-css-flexbox-1">[CSS-FLEXBOX-1]
-   <dd>Tab Atkins Jr.; Elika Etemad; Rossen Atanassov. <a href="https://drafts.csswg.org/css-flexbox/">CSS Flexible Box Layout Module Level 1</a>. 26 May 2016. CR. URL: <a href="https://drafts.csswg.org/css-flexbox/">https://drafts.csswg.org/css-flexbox/</a>
+   <dd>Tab Atkins Jr.; Elika Etemad; Rossen Atanassov. <a href="https://drafts.csswg.org/css-flexbox/">CSS Flexible Box Layout Module Level 1</a>. URL: <a href="https://drafts.csswg.org/css-flexbox/">https://drafts.csswg.org/css-flexbox/</a>
    <dt id="biblio-css-fonts-3">[CSS-FONTS-3]
-   <dd>John Daggett. <a href="http://dev.w3.org/csswg/css-fonts/">CSS Fonts Module Level 3</a>. 3 October 2013. CR. URL: <a href="http://dev.w3.org/csswg/css-fonts/">http://dev.w3.org/csswg/css-fonts/</a>
+   <dd>John Daggett. <a href="http://dev.w3.org/csswg/css-fonts/">CSS Fonts Module Level 3</a>. URL: <a href="http://dev.w3.org/csswg/css-fonts/">http://dev.w3.org/csswg/css-fonts/</a>
    <dt id="biblio-css-fonts-4">[CSS-FONTS-4]
    <dd>CSS Fonts Module Level 4 URL: <a href="https://drafts.csswg.org/css-fonts-4/">https://drafts.csswg.org/css-fonts-4/</a>
    <dt id="biblio-css-overflow-4">[CSS-OVERFLOW-4]
    <dd>CSS Overflow Module Level 4 URL: <a href="https://drafts.csswg.org/css-overflow-4/">https://drafts.csswg.org/css-overflow-4/</a>
    <dt id="biblio-css-position-3">[CSS-POSITION-3]
-   <dd>Rossen Atanassov; Arron Eicholz. <a href="https://drafts.csswg.org/css-position/">CSS Positioned Layout Module Level 3</a>. 17 May 2016. WD. URL: <a href="https://drafts.csswg.org/css-position/">https://drafts.csswg.org/css-position/</a>
+   <dd>Rossen Atanassov; Arron Eicholz. <a href="https://drafts.csswg.org/css-position/">CSS Positioned Layout Module Level 3</a>. URL: <a href="https://drafts.csswg.org/css-position/">https://drafts.csswg.org/css-position/</a>
    <dt id="biblio-css-syntax-3">[CSS-SYNTAX-3]
-   <dd>Tab Atkins Jr.; Simon Sapin. <a href="http://dev.w3.org/csswg/css-syntax/">CSS Syntax Module Level 3</a>. 20 February 2014. CR. URL: <a href="http://dev.w3.org/csswg/css-syntax/">http://dev.w3.org/csswg/css-syntax/</a>
+   <dd>Tab Atkins Jr.; Simon Sapin. <a href="http://dev.w3.org/csswg/css-syntax/">CSS Syntax Module Level 3</a>. URL: <a href="http://dev.w3.org/csswg/css-syntax/">http://dev.w3.org/csswg/css-syntax/</a>
    <dt id="biblio-css-text-3">[CSS-TEXT-3]
-   <dd>Elika Etemad; Koji Ishii. <a href="http://dev.w3.org/csswg/css-text-3/">CSS Text Module Level 3</a>. 10 October 2013. LCWD. URL: <a href="http://dev.w3.org/csswg/css-text-3/">http://dev.w3.org/csswg/css-text-3/</a>
+   <dd>Elika Etemad; Koji Ishii. <a href="http://dev.w3.org/csswg/css-text-3/">CSS Text Module Level 3</a>. URL: <a href="http://dev.w3.org/csswg/css-text-3/">http://dev.w3.org/csswg/css-text-3/</a>
    <dt id="biblio-css-text-4">[CSS-TEXT-4]
-   <dd>Elika Etemad; Koji Ishii; Alan Stearns. <a href="http://dev.w3.org/csswg/css-text-4/">CSS Text Module Level 4</a>. 22 September 2015. WD. URL: <a href="http://dev.w3.org/csswg/css-text-4/">http://dev.w3.org/csswg/css-text-4/</a>
+   <dd>Elika Etemad; Koji Ishii; Alan Stearns. <a href="http://dev.w3.org/csswg/css-text-4/">CSS Text Module Level 4</a>. URL: <a href="http://dev.w3.org/csswg/css-text-4/">http://dev.w3.org/csswg/css-text-4/</a>
    <dt id="biblio-css-text-decor-3">[CSS-TEXT-DECOR-3]
-   <dd>Elika Etemad; Koji Ishii. <a href="http://dev.w3.org/csswg/css-text-decor-3/">CSS Text Decoration Module Level 3</a>. 1 August 2013. CR. URL: <a href="http://dev.w3.org/csswg/css-text-decor-3/">http://dev.w3.org/csswg/css-text-decor-3/</a>
+   <dd>Elika Etemad; Koji Ishii. <a href="http://dev.w3.org/csswg/css-text-decor-3/">CSS Text Decoration Module Level 3</a>. URL: <a href="http://dev.w3.org/csswg/css-text-decor-3/">http://dev.w3.org/csswg/css-text-decor-3/</a>
    <dt id="biblio-css-transitions-1">[CSS-TRANSITIONS-1]
    <dd>CSS Transitions Module Level 1 URL: <a href="https://drafts.csswg.org/css-transitions-1/">https://drafts.csswg.org/css-transitions-1/</a>
-   <dt id="biblio-css-ui-3">[CSS-UI-3]
-   <dd>Tantek Çelik; Florian Rivoal. <a href="http://dev.w3.org/csswg/css-ui/">CSS Basic User Interface Module Level 3 (CSS3 UI)</a>. 7 July 2015. CR. URL: <a href="http://dev.w3.org/csswg/css-ui/">http://dev.w3.org/csswg/css-ui/</a>
    <dt id="biblio-css-values">[CSS-VALUES]
    <dd>Tab Atkins Jr.; Elika Etemad. <a href="https://www.w3.org/TR/css-values-3/">CSS Values and Units Module Level 3</a>. 29 September 2016. CR. URL: <a href="https://www.w3.org/TR/css-values-3/">https://www.w3.org/TR/css-values-3/</a>
    <dt id="biblio-css-writing-modes-3">[CSS-WRITING-MODES-3]
-   <dd>Elika Etemad; Koji Ishii. <a href="http://dev.w3.org/csswg/css-writing-modes-3/">CSS Writing Modes Level 3</a>. 15 December 2015. CR. URL: <a href="http://dev.w3.org/csswg/css-writing-modes-3/">http://dev.w3.org/csswg/css-writing-modes-3/</a>
+   <dd>Elika Etemad; Koji Ishii. <a href="http://dev.w3.org/csswg/css-writing-modes-3/">CSS Writing Modes Level 3</a>. URL: <a href="http://dev.w3.org/csswg/css-writing-modes-3/">http://dev.w3.org/csswg/css-writing-modes-3/</a>
    <dt id="biblio-css21">[CSS21]
    <dd>Bert Bos; et al. <a href="https://www.w3.org/TR/CSS2">Cascading Style Sheets Level 2 Revision 1 (CSS 2.1) Specification</a>. 7 June 2011. REC. URL: <a href="https://www.w3.org/TR/CSS2">https://www.w3.org/TR/CSS2</a>
+   <dt id="biblio-css22">[CSS22]
+   <dd>Bert Bos. <a href="http://dev.w3.org/csswg/css2/">Cascading Style Sheets Level 2 Revision 2 (CSS 2.2) Specification</a>. URL: <a href="http://dev.w3.org/csswg/css2/">http://dev.w3.org/csswg/css2/</a>
    <dt id="biblio-css3-color">[CSS3-COLOR]
    <dd>Tantek Çelik; Chris Lilley; David Baron. <a href="https://www.w3.org/TR/css3-color">CSS Color Module Level 3</a>. 7 June 2011. REC. URL: <a href="https://www.w3.org/TR/css3-color">https://www.w3.org/TR/css3-color</a>
    <dt id="biblio-css3-ruby">[CSS3-RUBY]
-   <dd>Elika Etemad; Koji Ishii. <a href="http://dev.w3.org/csswg/css-ruby-1/">CSS Ruby Layout Module Level 1</a>. 5 August 2014. WD. URL: <a href="http://dev.w3.org/csswg/css-ruby-1/">http://dev.w3.org/csswg/css-ruby-1/</a>
+   <dd>Elika Etemad; Koji Ishii. <a href="http://dev.w3.org/csswg/css-ruby-1/">CSS Ruby Layout Module Level 1</a>. URL: <a href="http://dev.w3.org/csswg/css-ruby-1/">http://dev.w3.org/csswg/css-ruby-1/</a>
    <dt id="biblio-cssom">[CSSOM]
-   <dd>Simon Pieters; Glenn Adams. <a href="https://drafts.csswg.org/cssom/">CSS Object Model (CSSOM)</a>. 17 March 2016. WD. URL: <a href="https://drafts.csswg.org/cssom/">https://drafts.csswg.org/cssom/</a>
+   <dd>Simon Pieters; Glenn Adams. <a href="https://drafts.csswg.org/cssom/">CSS Object Model (CSSOM)</a>. URL: <a href="https://drafts.csswg.org/cssom/">https://drafts.csswg.org/cssom/</a>
    <dt id="biblio-html">[HTML]
-   <dd>Ian Hickson. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
+   <dd>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
+   <dt id="biblio-infra">[INFRA]
+   <dd>Anne van Kesteren; Domenic Denicola. <a href="https://infra.spec.whatwg.org/">Infra Standard</a>. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
    <dt id="biblio-rfc3629">[RFC3629]
@@ -5871,7 +6095,7 @@ originally specified. <a data-link-type="biblio" href="#biblio-html">[HTML]</a><
    <dt id="biblio-selectors4">[SELECTORS4]
    <dd>Elika Etemad; Tab Atkins Jr.. <a href="https://www.w3.org/TR/selectors4/">Selectors Level 4</a>. 2 May 2013. WD. URL: <a href="https://www.w3.org/TR/selectors4/">https://www.w3.org/TR/selectors4/</a>
    <dt id="biblio-webidl">[WEBIDL]
-   <dd>Cameron McCormack; Boris Zbarsky. <a href="https://heycam.github.io/webidl/">WebIDL Level 1</a>. 15 September 2016. PR. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
+   <dd>Cameron McCormack; Boris Zbarsky; Tobie Langel. <a href="https://heycam.github.io/webidl/">Web IDL</a>. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
    <dt id="biblio-whatwg-dom">[WHATWG-DOM]
    <dd>Anne van Kesteren. <a href="https://dom.spec.whatwg.org/">DOM Standard</a>. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
   </dl>
@@ -5935,10 +6159,10 @@ originally specified. <a data-link-type="biblio" href="#biblio-html">[HTML]</a><
 title</a>
     <li><a href="#ref-for-webvtt-cue-21">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-22">(2)</a>
     <li><a href="#ref-for-webvtt-cue-23">6.1.1. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-webvtt-cue-24">(2)</a>
-    <li><a href="#ref-for-webvtt-cue-25">6.1.2. CSS extensions</a> <a href="#ref-for-webvtt-cue-26">(2)</a> <a href="#ref-for-webvtt-cue-27">(3)</a>
-    <li><a href="#ref-for-webvtt-cue-28">6.1.2.2. The :past and :future pseudo-classes</a> <a href="#ref-for-webvtt-cue-29">(2)</a>
-    <li><a href="#ref-for-webvtt-cue-30">6.1.2.3. The ::cue-region pseudo-element</a>
-    <li><a href="#ref-for-webvtt-cue-31">7.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-32">(2)</a> <a href="#ref-for-webvtt-cue-33">(3)</a> <a href="#ref-for-webvtt-cue-34">(4)</a> <a href="#ref-for-webvtt-cue-35">(5)</a> <a href="#ref-for-webvtt-cue-36">(6)</a> <a href="#ref-for-webvtt-cue-37">(7)</a> <a href="#ref-for-webvtt-cue-38">(8)</a> <a href="#ref-for-webvtt-cue-39">(9)</a> <a href="#ref-for-webvtt-cue-40">(10)</a> <a href="#ref-for-webvtt-cue-41">(11)</a> <a href="#ref-for-webvtt-cue-42">(12)</a>
+    <li><a href="#ref-for-webvtt-cue-25">7.2. Processing model</a> <a href="#ref-for-webvtt-cue-26">(2)</a> <a href="#ref-for-webvtt-cue-27">(3)</a>
+    <li><a href="#ref-for-webvtt-cue-28">7.2.2. The :past and :future pseudo-classes</a> <a href="#ref-for-webvtt-cue-29">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-30">7.2.3. The ::cue-region pseudo-element</a>
+    <li><a href="#ref-for-webvtt-cue-31">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-32">(2)</a> <a href="#ref-for-webvtt-cue-33">(3)</a> <a href="#ref-for-webvtt-cue-34">(4)</a> <a href="#ref-for-webvtt-cue-35">(5)</a> <a href="#ref-for-webvtt-cue-36">(6)</a> <a href="#ref-for-webvtt-cue-37">(7)</a> <a href="#ref-for-webvtt-cue-38">(8)</a> <a href="#ref-for-webvtt-cue-39">(9)</a> <a href="#ref-for-webvtt-cue-40">(10)</a> <a href="#ref-for-webvtt-cue-41">(11)</a> <a href="#ref-for-webvtt-cue-42">(12)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-box">
@@ -5957,7 +6181,7 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-writing-direction-13">5.1. WebVTT file parsing</a>
     <li><a href="#ref-for-webvtt-cue-writing-direction-14">5.3. WebVTT cue timings and settings parsing</a> <a href="#ref-for-webvtt-cue-writing-direction-15">(2)</a>
     <li><a href="#ref-for-webvtt-cue-writing-direction-16">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-writing-direction-17">(2)</a> <a href="#ref-for-webvtt-cue-writing-direction-18">(3)</a> <a href="#ref-for-webvtt-cue-writing-direction-19">(4)</a> <a href="#ref-for-webvtt-cue-writing-direction-20">(5)</a> <a href="#ref-for-webvtt-cue-writing-direction-21">(6)</a> <a href="#ref-for-webvtt-cue-writing-direction-22">(7)</a> <a href="#ref-for-webvtt-cue-writing-direction-23">(8)</a> <a href="#ref-for-webvtt-cue-writing-direction-24">(9)</a> <a href="#ref-for-webvtt-cue-writing-direction-25">(10)</a> <a href="#ref-for-webvtt-cue-writing-direction-26">(11)</a> <a href="#ref-for-webvtt-cue-writing-direction-27">(12)</a> <a href="#ref-for-webvtt-cue-writing-direction-28">(13)</a> <a href="#ref-for-webvtt-cue-writing-direction-29">(14)</a> <a href="#ref-for-webvtt-cue-writing-direction-30">(15)</a> <a href="#ref-for-webvtt-cue-writing-direction-31">(16)</a> <a href="#ref-for-webvtt-cue-writing-direction-32">(17)</a> <a href="#ref-for-webvtt-cue-writing-direction-33">(18)</a> <a href="#ref-for-webvtt-cue-writing-direction-34">(19)</a>
-    <li><a href="#ref-for-webvtt-cue-writing-direction-35">7.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-writing-direction-36">(2)</a> <a href="#ref-for-webvtt-cue-writing-direction-37">(3)</a> <a href="#ref-for-webvtt-cue-writing-direction-38">(4)</a> <a href="#ref-for-webvtt-cue-writing-direction-39">(5)</a>
+    <li><a href="#ref-for-webvtt-cue-writing-direction-35">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-writing-direction-36">(2)</a> <a href="#ref-for-webvtt-cue-writing-direction-37">(3)</a> <a href="#ref-for-webvtt-cue-writing-direction-38">(4)</a> <a href="#ref-for-webvtt-cue-writing-direction-39">(5)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-horizontal-writing-direction">
@@ -5966,7 +6190,7 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-horizontal-writing-direction-1">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-2">(2)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-3">(3)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-4">(4)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-5">(5)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-6">(6)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-7">(7)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-8">(8)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-9">(9)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-10">(10)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-11">(11)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-12">(12)</a>
     <li><a href="#ref-for-webvtt-cue-horizontal-writing-direction-13">5.1. WebVTT file parsing</a>
     <li><a href="#ref-for-webvtt-cue-horizontal-writing-direction-14">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-15">(2)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-16">(3)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-17">(4)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-18">(5)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-19">(6)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-20">(7)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-21">(8)</a>
-    <li><a href="#ref-for-webvtt-cue-horizontal-writing-direction-22">7.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-23">(2)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-24">(3)</a>
+    <li><a href="#ref-for-webvtt-cue-horizontal-writing-direction-22">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-23">(2)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-24">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-vertical-growing-left-writing-direction">
@@ -5975,7 +6199,7 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction-1">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction-2">(2)</a> <a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction-3">(3)</a>
     <li><a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction-4">5.3. WebVTT cue timings and settings parsing</a>
     <li><a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction-5">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction-6">(2)</a> <a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction-7">(3)</a> <a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction-8">(4)</a> <a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction-9">(5)</a> <a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction-10">(6)</a> <a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction-11">(7)</a> <a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction-12">(8)</a>
-    <li><a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction-13">7.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction-14">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction-13">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction-14">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-vertical-growing-right-writing-direction">
@@ -5984,7 +6208,7 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction-1">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction-2">(2)</a> <a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction-3">(3)</a>
     <li><a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction-4">5.3. WebVTT cue timings and settings parsing</a>
     <li><a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction-5">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction-6">(2)</a> <a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction-7">(3)</a> <a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction-8">(4)</a> <a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction-9">(5)</a> <a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction-10">(6)</a> <a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction-11">(7)</a> <a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction-12">(8)</a>
-    <li><a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction-13">7.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction-14">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction-13">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction-14">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-snap-to-lines-flag">
@@ -5994,7 +6218,7 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-snap-to-lines-flag-9">5.1. WebVTT file parsing</a>
     <li><a href="#ref-for-webvtt-cue-snap-to-lines-flag-10">5.3. WebVTT cue timings and settings parsing</a>
     <li><a href="#ref-for-webvtt-cue-snap-to-lines-flag-11">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag-12">(2)</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag-13">(3)</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag-14">(4)</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag-15">(5)</a>
-    <li><a href="#ref-for-webvtt-cue-snap-to-lines-flag-16">7.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag-17">(2)</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag-18">(3)</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag-19">(4)</a>
+    <li><a href="#ref-for-webvtt-cue-snap-to-lines-flag-16">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag-17">(2)</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag-18">(3)</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag-19">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-line">
@@ -6003,7 +6227,7 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-line-1">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-line-2">(2)</a> <a href="#ref-for-webvtt-cue-line-3">(3)</a> <a href="#ref-for-webvtt-cue-line-4">(4)</a> <a href="#ref-for-webvtt-cue-line-5">(5)</a> <a href="#ref-for-webvtt-cue-line-6">(6)</a> <a href="#ref-for-webvtt-cue-line-7">(7)</a> <a href="#ref-for-webvtt-cue-line-8">(8)</a> <a href="#ref-for-webvtt-cue-line-9">(9)</a> <a href="#ref-for-webvtt-cue-line-10">(10)</a> <a href="#ref-for-webvtt-cue-line-11">(11)</a> <a href="#ref-for-webvtt-cue-line-12">(12)</a> <a href="#ref-for-webvtt-cue-line-13">(13)</a> <a href="#ref-for-webvtt-cue-line-14">(14)</a> <a href="#ref-for-webvtt-cue-line-15">(15)</a> <a href="#ref-for-webvtt-cue-line-16">(16)</a> <a href="#ref-for-webvtt-cue-line-17">(17)</a> <a href="#ref-for-webvtt-cue-line-18">(18)</a> <a href="#ref-for-webvtt-cue-line-19">(19)</a> <a href="#ref-for-webvtt-cue-line-20">(20)</a>
     <li><a href="#ref-for-webvtt-cue-line-21">5.1. WebVTT file parsing</a>
     <li><a href="#ref-for-webvtt-cue-line-22">5.3. WebVTT cue timings and settings parsing</a>
-    <li><a href="#ref-for-webvtt-cue-line-23">7.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-line-24">(2)</a> <a href="#ref-for-webvtt-cue-line-25">(3)</a> <a href="#ref-for-webvtt-cue-line-26">(4)</a>
+    <li><a href="#ref-for-webvtt-cue-line-23">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-line-24">(2)</a> <a href="#ref-for-webvtt-cue-line-25">(3)</a> <a href="#ref-for-webvtt-cue-line-26">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-line-automatic">
@@ -6011,7 +6235,7 @@ title</a>
    <ul>
     <li><a href="#ref-for-webvtt-cue-line-automatic-1">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-line-automatic-2">(2)</a> <a href="#ref-for-webvtt-cue-line-automatic-3">(3)</a>
     <li><a href="#ref-for-webvtt-cue-line-automatic-4">5.1. WebVTT file parsing</a>
-    <li><a href="#ref-for-webvtt-cue-line-automatic-5">7.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-line-automatic-6">(2)</a> <a href="#ref-for-webvtt-cue-line-automatic-7">(3)</a> <a href="#ref-for-webvtt-cue-line-automatic-8">(4)</a>
+    <li><a href="#ref-for-webvtt-cue-line-automatic-5">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-line-automatic-6">(2)</a> <a href="#ref-for-webvtt-cue-line-automatic-7">(3)</a> <a href="#ref-for-webvtt-cue-line-automatic-8">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="cue-computed-line">
@@ -6029,7 +6253,7 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-line-alignment-6">5.1. WebVTT file parsing</a>
     <li><a href="#ref-for-webvtt-cue-line-alignment-7">5.3. WebVTT cue timings and settings parsing</a> <a href="#ref-for-webvtt-cue-line-alignment-8">(2)</a> <a href="#ref-for-webvtt-cue-line-alignment-9">(3)</a>
     <li><a href="#ref-for-webvtt-cue-line-alignment-10">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-line-alignment-11">(2)</a> <a href="#ref-for-webvtt-cue-line-alignment-12">(3)</a> <a href="#ref-for-webvtt-cue-line-alignment-13">(4)</a>
-    <li><a href="#ref-for-webvtt-cue-line-alignment-14">7.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-line-alignment-15">(2)</a> <a href="#ref-for-webvtt-cue-line-alignment-16">(3)</a> <a href="#ref-for-webvtt-cue-line-alignment-17">(4)</a> <a href="#ref-for-webvtt-cue-line-alignment-18">(5)</a>
+    <li><a href="#ref-for-webvtt-cue-line-alignment-14">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-line-alignment-15">(2)</a> <a href="#ref-for-webvtt-cue-line-alignment-16">(3)</a> <a href="#ref-for-webvtt-cue-line-alignment-17">(4)</a> <a href="#ref-for-webvtt-cue-line-alignment-18">(5)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-line-start-alignment">
@@ -6039,7 +6263,7 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-line-start-alignment-2">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-cue-line-start-alignment-3">(2)</a>
     <li><a href="#ref-for-webvtt-cue-line-start-alignment-4">5.1. WebVTT file parsing</a>
     <li><a href="#ref-for-webvtt-cue-line-start-alignment-5">5.3. WebVTT cue timings and settings parsing</a>
-    <li><a href="#ref-for-webvtt-cue-line-start-alignment-6">7.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-line-start-alignment-7">(2)</a> <a href="#ref-for-webvtt-cue-line-start-alignment-8">(3)</a>
+    <li><a href="#ref-for-webvtt-cue-line-start-alignment-6">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-line-start-alignment-7">(2)</a> <a href="#ref-for-webvtt-cue-line-start-alignment-8">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-line-center-alignment">
@@ -6048,7 +6272,7 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-line-center-alignment-1">4.4. WebVTT cue settings</a>
     <li><a href="#ref-for-webvtt-cue-line-center-alignment-2">5.3. WebVTT cue timings and settings parsing</a>
     <li><a href="#ref-for-webvtt-cue-line-center-alignment-3">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-line-center-alignment-4">(2)</a>
-    <li><a href="#ref-for-webvtt-cue-line-center-alignment-5">7.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-line-center-alignment-6">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-line-center-alignment-5">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-line-center-alignment-6">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-line-end-alignment">
@@ -6057,7 +6281,7 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-line-end-alignment-1">4.4. WebVTT cue settings</a>
     <li><a href="#ref-for-webvtt-cue-line-end-alignment-2">5.3. WebVTT cue timings and settings parsing</a>
     <li><a href="#ref-for-webvtt-cue-line-end-alignment-3">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-line-end-alignment-4">(2)</a>
-    <li><a href="#ref-for-webvtt-cue-line-end-alignment-5">7.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-line-end-alignment-6">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-line-end-alignment-5">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-line-end-alignment-6">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-position">
@@ -6066,7 +6290,7 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-position-1">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-position-2">(2)</a> <a href="#ref-for-webvtt-cue-position-3">(3)</a> <a href="#ref-for-webvtt-cue-position-4">(4)</a> <a href="#ref-for-webvtt-cue-position-5">(5)</a> <a href="#ref-for-webvtt-cue-position-6">(6)</a> <a href="#ref-for-webvtt-cue-position-7">(7)</a> <a href="#ref-for-webvtt-cue-position-8">(8)</a> <a href="#ref-for-webvtt-cue-position-9">(9)</a> <a href="#ref-for-webvtt-cue-position-10">(10)</a> <a href="#ref-for-webvtt-cue-position-11">(11)</a> <a href="#ref-for-webvtt-cue-position-12">(12)</a> <a href="#ref-for-webvtt-cue-position-13">(13)</a> <a href="#ref-for-webvtt-cue-position-14">(14)</a> <a href="#ref-for-webvtt-cue-position-15">(15)</a> <a href="#ref-for-webvtt-cue-position-16">(16)</a> <a href="#ref-for-webvtt-cue-position-17">(17)</a> <a href="#ref-for-webvtt-cue-position-18">(18)</a> <a href="#ref-for-webvtt-cue-position-19">(19)</a>
     <li><a href="#ref-for-webvtt-cue-position-20">5.1. WebVTT file parsing</a>
     <li><a href="#ref-for-webvtt-cue-position-21">5.3. WebVTT cue timings and settings parsing</a> <a href="#ref-for-webvtt-cue-position-22">(2)</a>
-    <li><a href="#ref-for-webvtt-cue-position-23">7.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-position-24">(2)</a> <a href="#ref-for-webvtt-cue-position-25">(3)</a> <a href="#ref-for-webvtt-cue-position-26">(4)</a>
+    <li><a href="#ref-for-webvtt-cue-position-23">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-position-24">(2)</a> <a href="#ref-for-webvtt-cue-position-25">(3)</a> <a href="#ref-for-webvtt-cue-position-26">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-automatic-position">
@@ -6075,7 +6299,7 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-automatic-position-1">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-automatic-position-2">(2)</a> <a href="#ref-for-webvtt-cue-automatic-position-3">(3)</a> <a href="#ref-for-webvtt-cue-automatic-position-4">(4)</a> <a href="#ref-for-webvtt-cue-automatic-position-5">(5)</a>
     <li><a href="#ref-for-webvtt-cue-automatic-position-6">5.1. WebVTT file parsing</a>
     <li><a href="#ref-for-webvtt-cue-automatic-position-7">5.3. WebVTT cue timings and settings parsing</a>
-    <li><a href="#ref-for-webvtt-cue-automatic-position-8">7.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-automatic-position-9">(2)</a> <a href="#ref-for-webvtt-cue-automatic-position-10">(3)</a> <a href="#ref-for-webvtt-cue-automatic-position-11">(4)</a>
+    <li><a href="#ref-for-webvtt-cue-automatic-position-8">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-automatic-position-9">(2)</a> <a href="#ref-for-webvtt-cue-automatic-position-10">(3)</a> <a href="#ref-for-webvtt-cue-automatic-position-11">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="cue-computed-position">
@@ -6090,7 +6314,7 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-position-alignment-1">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-position-alignment-2">(2)</a> <a href="#ref-for-webvtt-cue-position-alignment-3">(3)</a> <a href="#ref-for-webvtt-cue-position-alignment-4">(4)</a> <a href="#ref-for-webvtt-cue-position-alignment-5">(5)</a> <a href="#ref-for-webvtt-cue-position-alignment-6">(6)</a>
     <li><a href="#ref-for-webvtt-cue-position-alignment-7">5.1. WebVTT file parsing</a>
     <li><a href="#ref-for-webvtt-cue-position-alignment-8">5.3. WebVTT cue timings and settings parsing</a> <a href="#ref-for-webvtt-cue-position-alignment-9">(2)</a> <a href="#ref-for-webvtt-cue-position-alignment-10">(3)</a>
-    <li><a href="#ref-for-webvtt-cue-position-alignment-11">7.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-position-alignment-12">(2)</a> <a href="#ref-for-webvtt-cue-position-alignment-13">(3)</a> <a href="#ref-for-webvtt-cue-position-alignment-14">(4)</a> <a href="#ref-for-webvtt-cue-position-alignment-15">(5)</a>
+    <li><a href="#ref-for-webvtt-cue-position-alignment-11">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-position-alignment-12">(2)</a> <a href="#ref-for-webvtt-cue-position-alignment-13">(3)</a> <a href="#ref-for-webvtt-cue-position-alignment-14">(4)</a> <a href="#ref-for-webvtt-cue-position-alignment-15">(5)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-position-line-left-alignment">
@@ -6100,7 +6324,7 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-position-line-left-alignment-3">4.4. WebVTT cue settings</a>
     <li><a href="#ref-for-webvtt-cue-position-line-left-alignment-4">5.3. WebVTT cue timings and settings parsing</a>
     <li><a href="#ref-for-webvtt-cue-position-line-left-alignment-5">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-position-line-left-alignment-6">(2)</a> <a href="#ref-for-webvtt-cue-position-line-left-alignment-7">(3)</a>
-    <li><a href="#ref-for-webvtt-cue-position-line-left-alignment-8">7.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-position-line-left-alignment-9">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-position-line-left-alignment-8">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-position-line-left-alignment-9">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-position-center-alignment">
@@ -6109,7 +6333,7 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-position-center-alignment-1">4.4. WebVTT cue settings</a>
     <li><a href="#ref-for-webvtt-cue-position-center-alignment-2">5.3. WebVTT cue timings and settings parsing</a>
     <li><a href="#ref-for-webvtt-cue-position-center-alignment-3">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-position-center-alignment-4">(2)</a> <a href="#ref-for-webvtt-cue-position-center-alignment-5">(3)</a> <a href="#ref-for-webvtt-cue-position-center-alignment-6">(4)</a> <a href="#ref-for-webvtt-cue-position-center-alignment-7">(5)</a>
-    <li><a href="#ref-for-webvtt-cue-position-center-alignment-8">7.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-position-center-alignment-9">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-position-center-alignment-8">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-position-center-alignment-9">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-position-line-right-alignment">
@@ -6119,7 +6343,7 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-position-line-right-alignment-2">4.4. WebVTT cue settings</a>
     <li><a href="#ref-for-webvtt-cue-position-line-right-alignment-3">5.3. WebVTT cue timings and settings parsing</a>
     <li><a href="#ref-for-webvtt-cue-position-line-right-alignment-4">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-position-line-right-alignment-5">(2)</a> <a href="#ref-for-webvtt-cue-position-line-right-alignment-6">(3)</a> <a href="#ref-for-webvtt-cue-position-line-right-alignment-7">(4)</a>
-    <li><a href="#ref-for-webvtt-cue-position-line-right-alignment-8">7.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-position-line-right-alignment-9">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-position-line-right-alignment-8">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-position-line-right-alignment-9">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-position-automatic-alignment">
@@ -6127,7 +6351,7 @@ title</a>
    <ul>
     <li><a href="#ref-for-webvtt-cue-position-automatic-alignment-1">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-position-automatic-alignment-2">(2)</a>
     <li><a href="#ref-for-webvtt-cue-position-automatic-alignment-3">5.1. WebVTT file parsing</a>
-    <li><a href="#ref-for-webvtt-cue-position-automatic-alignment-4">7.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-position-automatic-alignment-5">(2)</a> <a href="#ref-for-webvtt-cue-position-automatic-alignment-6">(3)</a>
+    <li><a href="#ref-for-webvtt-cue-position-automatic-alignment-4">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-position-automatic-alignment-5">(2)</a> <a href="#ref-for-webvtt-cue-position-automatic-alignment-6">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="cue-computed-position-alignment">
@@ -6144,7 +6368,7 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-size-7">5.1. WebVTT file parsing</a>
     <li><a href="#ref-for-webvtt-cue-size-8">5.3. WebVTT cue timings and settings parsing</a>
     <li><a href="#ref-for-webvtt-cue-size-9">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-size-10">(2)</a>
-    <li><a href="#ref-for-webvtt-cue-size-11">7.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-size-12">(2)</a> <a href="#ref-for-webvtt-cue-size-13">(3)</a> <a href="#ref-for-webvtt-cue-size-14">(4)</a>
+    <li><a href="#ref-for-webvtt-cue-size-11">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-size-12">(2)</a> <a href="#ref-for-webvtt-cue-size-13">(3)</a> <a href="#ref-for-webvtt-cue-size-14">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-text-alignment">
@@ -6154,7 +6378,7 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-text-alignment-13">5.1. WebVTT file parsing</a>
     <li><a href="#ref-for-webvtt-cue-text-alignment-14">5.3. WebVTT cue timings and settings parsing</a> <a href="#ref-for-webvtt-cue-text-alignment-15">(2)</a> <a href="#ref-for-webvtt-cue-text-alignment-16">(3)</a> <a href="#ref-for-webvtt-cue-text-alignment-17">(4)</a> <a href="#ref-for-webvtt-cue-text-alignment-18">(5)</a>
     <li><a href="#ref-for-webvtt-cue-text-alignment-19">6.1.1. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-webvtt-cue-text-alignment-20">(2)</a>
-    <li><a href="#ref-for-webvtt-cue-text-alignment-21">7.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-text-alignment-22">(2)</a> <a href="#ref-for-webvtt-cue-text-alignment-23">(3)</a> <a href="#ref-for-webvtt-cue-text-alignment-24">(4)</a> <a href="#ref-for-webvtt-cue-text-alignment-25">(5)</a>
+    <li><a href="#ref-for-webvtt-cue-text-alignment-21">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-text-alignment-22">(2)</a> <a href="#ref-for-webvtt-cue-text-alignment-23">(3)</a> <a href="#ref-for-webvtt-cue-text-alignment-24">(4)</a> <a href="#ref-for-webvtt-cue-text-alignment-25">(5)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-start-alignment">
@@ -6163,7 +6387,7 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-start-alignment-1">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-start-alignment-2">(2)</a> <a href="#ref-for-webvtt-cue-start-alignment-3">(3)</a> <a href="#ref-for-webvtt-cue-start-alignment-4">(4)</a> <a href="#ref-for-webvtt-cue-start-alignment-5">(5)</a>
     <li><a href="#ref-for-webvtt-cue-start-alignment-6">5.3. WebVTT cue timings and settings parsing</a>
     <li><a href="#ref-for-webvtt-cue-start-alignment-7">6.1.1. Applying CSS properties to WebVTT Node Objects</a>
-    <li><a href="#ref-for-webvtt-cue-start-alignment-8">7.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-start-alignment-9">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-start-alignment-8">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-start-alignment-9">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-center-alignment">
@@ -6173,7 +6397,7 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-center-alignment-5">5.1. WebVTT file parsing</a>
     <li><a href="#ref-for-webvtt-cue-center-alignment-6">5.3. WebVTT cue timings and settings parsing</a>
     <li><a href="#ref-for-webvtt-cue-center-alignment-7">6.1.1. Applying CSS properties to WebVTT Node Objects</a>
-    <li><a href="#ref-for-webvtt-cue-center-alignment-8">7.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-center-alignment-9">(2)</a> <a href="#ref-for-webvtt-cue-center-alignment-10">(3)</a>
+    <li><a href="#ref-for-webvtt-cue-center-alignment-8">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-center-alignment-9">(2)</a> <a href="#ref-for-webvtt-cue-center-alignment-10">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-end-alignment">
@@ -6182,7 +6406,7 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-end-alignment-1">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-end-alignment-2">(2)</a> <a href="#ref-for-webvtt-cue-end-alignment-3">(3)</a> <a href="#ref-for-webvtt-cue-end-alignment-4">(4)</a>
     <li><a href="#ref-for-webvtt-cue-end-alignment-5">5.3. WebVTT cue timings and settings parsing</a>
     <li><a href="#ref-for-webvtt-cue-end-alignment-6">6.1.1. Applying CSS properties to WebVTT Node Objects</a>
-    <li><a href="#ref-for-webvtt-cue-end-alignment-7">7.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-end-alignment-8">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-end-alignment-7">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-end-alignment-8">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-left-alignment">
@@ -6191,7 +6415,7 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-left-alignment-1">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-left-alignment-2">(2)</a> <a href="#ref-for-webvtt-cue-left-alignment-3">(3)</a> <a href="#ref-for-webvtt-cue-left-alignment-4">(4)</a>
     <li><a href="#ref-for-webvtt-cue-left-alignment-5">5.3. WebVTT cue timings and settings parsing</a>
     <li><a href="#ref-for-webvtt-cue-left-alignment-6">6.1.1. Applying CSS properties to WebVTT Node Objects</a>
-    <li><a href="#ref-for-webvtt-cue-left-alignment-7">7.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-left-alignment-8">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-left-alignment-7">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-left-alignment-8">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-right-alignment">
@@ -6200,7 +6424,7 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-right-alignment-1">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-right-alignment-2">(2)</a> <a href="#ref-for-webvtt-cue-right-alignment-3">(3)</a> <a href="#ref-for-webvtt-cue-right-alignment-4">(4)</a>
     <li><a href="#ref-for-webvtt-cue-right-alignment-5">5.3. WebVTT cue timings and settings parsing</a>
     <li><a href="#ref-for-webvtt-cue-right-alignment-6">6.1.1. Applying CSS properties to WebVTT Node Objects</a>
-    <li><a href="#ref-for-webvtt-cue-right-alignment-7">7.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-right-alignment-8">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-right-alignment-7">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-right-alignment-8">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-region">
@@ -6210,7 +6434,7 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-region-2">5.1. WebVTT file parsing</a>
     <li><a href="#ref-for-webvtt-cue-region-3">5.3. WebVTT cue timings and settings parsing</a>
     <li><a href="#ref-for-webvtt-cue-region-4">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-region-5">(2)</a> <a href="#ref-for-webvtt-cue-region-6">(3)</a>
-    <li><a href="#ref-for-webvtt-cue-region-7">7.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-region-8">(2)</a> <a href="#ref-for-webvtt-cue-region-9">(3)</a>
+    <li><a href="#ref-for-webvtt-cue-region-7">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-region-8">(2)</a> <a href="#ref-for-webvtt-cue-region-9">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-region">
@@ -6224,7 +6448,7 @@ title</a>
     <li><a href="#ref-for-webvtt-region-10">5.3. WebVTT cue timings and settings parsing</a>
     <li><a href="#ref-for-webvtt-region-11">6.1. Processing model</a> <a href="#ref-for-webvtt-region-12">(2)</a> <a href="#ref-for-webvtt-region-13">(3)</a>
     <li><a href="#ref-for-webvtt-region-14">6.1.1. Applying CSS properties to WebVTT Node Objects</a>
-    <li><a href="#ref-for-webvtt-region-15">7.2. The VTTRegion interface</a> <a href="#ref-for-webvtt-region-16">(2)</a> <a href="#ref-for-webvtt-region-17">(3)</a> <a href="#ref-for-webvtt-region-18">(4)</a> <a href="#ref-for-webvtt-region-19">(5)</a> <a href="#ref-for-webvtt-region-20">(6)</a> <a href="#ref-for-webvtt-region-21">(7)</a> <a href="#ref-for-webvtt-region-22">(8)</a> <a href="#ref-for-webvtt-region-23">(9)</a>
+    <li><a href="#ref-for-webvtt-region-15">8.2. The VTTRegion interface</a> <a href="#ref-for-webvtt-region-16">(2)</a> <a href="#ref-for-webvtt-region-17">(3)</a> <a href="#ref-for-webvtt-region-18">(4)</a> <a href="#ref-for-webvtt-region-19">(5)</a> <a href="#ref-for-webvtt-region-20">(6)</a> <a href="#ref-for-webvtt-region-21">(7)</a> <a href="#ref-for-webvtt-region-22">(8)</a> <a href="#ref-for-webvtt-region-23">(9)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-region-identifier">
@@ -6233,7 +6457,7 @@ title</a>
     <li><a href="#ref-for-webvtt-region-identifier-1">5.1. WebVTT file parsing</a>
     <li><a href="#ref-for-webvtt-region-identifier-2">5.2. WebVTT region settings parsing</a>
     <li><a href="#ref-for-webvtt-region-identifier-3">5.3. WebVTT cue timings and settings parsing</a>
-    <li><a href="#ref-for-webvtt-region-identifier-4">7.2. The VTTRegion interface</a>
+    <li><a href="#ref-for-webvtt-region-identifier-4">8.2. The VTTRegion interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-region-width">
@@ -6242,7 +6466,7 @@ title</a>
     <li><a href="#ref-for-webvtt-region-width-1">5.1. WebVTT file parsing</a>
     <li><a href="#ref-for-webvtt-region-width-2">5.2. WebVTT region settings parsing</a>
     <li><a href="#ref-for-webvtt-region-width-3">6.1. Processing model</a> <a href="#ref-for-webvtt-region-width-4">(2)</a> <a href="#ref-for-webvtt-region-width-5">(3)</a> <a href="#ref-for-webvtt-region-width-6">(4)</a>
-    <li><a href="#ref-for-webvtt-region-width-7">7.2. The VTTRegion interface</a> <a href="#ref-for-webvtt-region-width-8">(2)</a> <a href="#ref-for-webvtt-region-width-9">(3)</a>
+    <li><a href="#ref-for-webvtt-region-width-7">8.2. The VTTRegion interface</a> <a href="#ref-for-webvtt-region-width-8">(2)</a> <a href="#ref-for-webvtt-region-width-9">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-region-lines">
@@ -6251,7 +6475,7 @@ title</a>
     <li><a href="#ref-for-webvtt-region-lines-1">5.1. WebVTT file parsing</a>
     <li><a href="#ref-for-webvtt-region-lines-2">5.2. WebVTT region settings parsing</a>
     <li><a href="#ref-for-webvtt-region-lines-3">6.1. Processing model</a>
-    <li><a href="#ref-for-webvtt-region-lines-4">7.2. The VTTRegion interface</a> <a href="#ref-for-webvtt-region-lines-5">(2)</a> <a href="#ref-for-webvtt-region-lines-6">(3)</a>
+    <li><a href="#ref-for-webvtt-region-lines-4">8.2. The VTTRegion interface</a> <a href="#ref-for-webvtt-region-lines-5">(2)</a> <a href="#ref-for-webvtt-region-lines-6">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-region-anchor">
@@ -6260,7 +6484,7 @@ title</a>
     <li><a href="#ref-for-webvtt-region-anchor-1">5.1. WebVTT file parsing</a>
     <li><a href="#ref-for-webvtt-region-anchor-2">5.2. WebVTT region settings parsing</a>
     <li><a href="#ref-for-webvtt-region-anchor-3">6.1. Processing model</a> <a href="#ref-for-webvtt-region-anchor-4">(2)</a> <a href="#ref-for-webvtt-region-anchor-5">(3)</a> <a href="#ref-for-webvtt-region-anchor-6">(4)</a>
-    <li><a href="#ref-for-webvtt-region-anchor-7">7.2. The VTTRegion interface</a> <a href="#ref-for-webvtt-region-anchor-8">(2)</a> <a href="#ref-for-webvtt-region-anchor-9">(3)</a> <a href="#ref-for-webvtt-region-anchor-10">(4)</a> <a href="#ref-for-webvtt-region-anchor-11">(5)</a> <a href="#ref-for-webvtt-region-anchor-12">(6)</a>
+    <li><a href="#ref-for-webvtt-region-anchor-7">8.2. The VTTRegion interface</a> <a href="#ref-for-webvtt-region-anchor-8">(2)</a> <a href="#ref-for-webvtt-region-anchor-9">(3)</a> <a href="#ref-for-webvtt-region-anchor-10">(4)</a> <a href="#ref-for-webvtt-region-anchor-11">(5)</a> <a href="#ref-for-webvtt-region-anchor-12">(6)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-region-viewport-anchor">
@@ -6268,7 +6492,7 @@ title</a>
    <ul>
     <li><a href="#ref-for-webvtt-region-viewport-anchor-1">5.1. WebVTT file parsing</a>
     <li><a href="#ref-for-webvtt-region-viewport-anchor-2">5.2. WebVTT region settings parsing</a>
-    <li><a href="#ref-for-webvtt-region-viewport-anchor-3">7.2. The VTTRegion interface</a> <a href="#ref-for-webvtt-region-viewport-anchor-4">(2)</a> <a href="#ref-for-webvtt-region-viewport-anchor-5">(3)</a> <a href="#ref-for-webvtt-region-viewport-anchor-6">(4)</a> <a href="#ref-for-webvtt-region-viewport-anchor-7">(5)</a> <a href="#ref-for-webvtt-region-viewport-anchor-8">(6)</a>
+    <li><a href="#ref-for-webvtt-region-viewport-anchor-3">8.2. The VTTRegion interface</a> <a href="#ref-for-webvtt-region-viewport-anchor-4">(2)</a> <a href="#ref-for-webvtt-region-viewport-anchor-5">(3)</a> <a href="#ref-for-webvtt-region-viewport-anchor-6">(4)</a> <a href="#ref-for-webvtt-region-viewport-anchor-7">(5)</a> <a href="#ref-for-webvtt-region-viewport-anchor-8">(6)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-region-scroll">
@@ -6277,14 +6501,14 @@ title</a>
     <li><a href="#ref-for-webvtt-region-scroll-1">5.1. WebVTT file parsing</a>
     <li><a href="#ref-for-webvtt-region-scroll-2">5.2. WebVTT region settings parsing</a>
     <li><a href="#ref-for-webvtt-region-scroll-3">6.1. Processing model</a>
-    <li><a href="#ref-for-webvtt-region-scroll-4">7.2. The VTTRegion interface</a> <a href="#ref-for-webvtt-region-scroll-5">(2)</a> <a href="#ref-for-webvtt-region-scroll-6">(3)</a> <a href="#ref-for-webvtt-region-scroll-7">(4)</a> <a href="#ref-for-webvtt-region-scroll-8">(5)</a>
+    <li><a href="#ref-for-webvtt-region-scroll-4">8.2. The VTTRegion interface</a> <a href="#ref-for-webvtt-region-scroll-5">(2)</a> <a href="#ref-for-webvtt-region-scroll-6">(3)</a> <a href="#ref-for-webvtt-region-scroll-7">(4)</a> <a href="#ref-for-webvtt-region-scroll-8">(5)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-region-scroll-none">
    <b><a href="#webvtt-region-scroll-none">#webvtt-region-scroll-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-region-scroll-none-1">5.1. WebVTT file parsing</a>
-    <li><a href="#ref-for-webvtt-region-scroll-none-2">7.2. The VTTRegion interface</a>
+    <li><a href="#ref-for-webvtt-region-scroll-none-2">8.2. The VTTRegion interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-region-scroll-up">
@@ -6292,7 +6516,7 @@ title</a>
    <ul>
     <li><a href="#ref-for-webvtt-region-scroll-up-1">5.2. WebVTT region settings parsing</a>
     <li><a href="#ref-for-webvtt-region-scroll-up-2">6.1. Processing model</a>
-    <li><a href="#ref-for-webvtt-region-scroll-up-3">7.2. The VTTRegion interface</a>
+    <li><a href="#ref-for-webvtt-region-scroll-up-3">8.2. The VTTRegion interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="text-track-list-of-regions">
@@ -6673,7 +6897,8 @@ title</a>
     <li><a href="#ref-for-webvtt-region-object-4">5.5. WebVTT cue text DOM construction rules</a>
     <li><a href="#ref-for-webvtt-region-object-5">6.1. Processing model</a>
     <li><a href="#ref-for-webvtt-region-object-6">6.1.1. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-webvtt-region-object-7">(2)</a> <a href="#ref-for-webvtt-region-object-8">(3)</a> <a href="#ref-for-webvtt-region-object-9">(4)</a>
-    <li><a href="#ref-for-webvtt-region-object-10">6.1.2.3. The ::cue-region pseudo-element</a> <a href="#ref-for-webvtt-region-object-11">(2)</a>
+    <li><a href="#ref-for-webvtt-region-object-10">7.1. Introduction</a>
+    <li><a href="#ref-for-webvtt-region-object-11">7.2.3. The ::cue-region pseudo-element</a> <a href="#ref-for-webvtt-region-object-12">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="parse-a-percentage-string">
@@ -6709,9 +6934,9 @@ title</a>
     <li><a href="#ref-for-webvtt-node-object-6">5.5. WebVTT cue text DOM construction rules</a> <a href="#ref-for-webvtt-node-object-7">(2)</a> <a href="#ref-for-webvtt-node-object-8">(3)</a>
     <li><a href="#ref-for-webvtt-node-object-9">6.1. Processing model</a> <a href="#ref-for-webvtt-node-object-10">(2)</a>
     <li><a href="#ref-for-webvtt-node-object-11">6.1.1. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-webvtt-node-object-12">(2)</a>
-    <li><a href="#ref-for-webvtt-node-object-13">6.1.2. CSS extensions</a> <a href="#ref-for-webvtt-node-object-14">(2)</a>
-    <li><a href="#ref-for-webvtt-node-object-15">6.1.2.1. The ::cue pseudo-element</a>
-    <li><a href="#ref-for-webvtt-node-object-16">6.1.2.2. The :past and :future pseudo-classes</a> <a href="#ref-for-webvtt-node-object-17">(2)</a> <a href="#ref-for-webvtt-node-object-18">(3)</a> <a href="#ref-for-webvtt-node-object-19">(4)</a> <a href="#ref-for-webvtt-node-object-20">(5)</a> <a href="#ref-for-webvtt-node-object-21">(6)</a> <a href="#ref-for-webvtt-node-object-22">(7)</a>
+    <li><a href="#ref-for-webvtt-node-object-13">7.2. Processing model</a> <a href="#ref-for-webvtt-node-object-14">(2)</a>
+    <li><a href="#ref-for-webvtt-node-object-15">7.2.1. The ::cue pseudo-element</a>
+    <li><a href="#ref-for-webvtt-node-object-16">7.2.2. The :past and :future pseudo-classes</a> <a href="#ref-for-webvtt-node-object-17">(2)</a> <a href="#ref-for-webvtt-node-object-18">(3)</a> <a href="#ref-for-webvtt-node-object-19">(4)</a> <a href="#ref-for-webvtt-node-object-20">(5)</a> <a href="#ref-for-webvtt-node-object-21">(6)</a> <a href="#ref-for-webvtt-node-object-22">(7)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-internal-node-object">
@@ -6720,7 +6945,8 @@ title</a>
     <li><a href="#ref-for-webvtt-internal-node-object-1">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-internal-node-object-2">(2)</a> <a href="#ref-for-webvtt-internal-node-object-3">(3)</a> <a href="#ref-for-webvtt-internal-node-object-4">(4)</a> <a href="#ref-for-webvtt-internal-node-object-5">(5)</a> <a href="#ref-for-webvtt-internal-node-object-6">(6)</a> <a href="#ref-for-webvtt-internal-node-object-7">(7)</a>
     <li><a href="#ref-for-webvtt-internal-node-object-8">5.5. WebVTT cue text DOM construction rules</a>
     <li><a href="#ref-for-webvtt-internal-node-object-9">6.1. Processing model</a>
-    <li><a href="#ref-for-webvtt-internal-node-object-10">6.1.2.1. The ::cue pseudo-element</a> <a href="#ref-for-webvtt-internal-node-object-11">(2)</a> <a href="#ref-for-webvtt-internal-node-object-12">(3)</a> <a href="#ref-for-webvtt-internal-node-object-13">(4)</a> <a href="#ref-for-webvtt-internal-node-object-14">(5)</a> <a href="#ref-for-webvtt-internal-node-object-15">(6)</a> <a href="#ref-for-webvtt-internal-node-object-16">(7)</a>
+    <li><a href="#ref-for-webvtt-internal-node-object-10">7.1. Introduction</a> <a href="#ref-for-webvtt-internal-node-object-11">(2)</a> <a href="#ref-for-webvtt-internal-node-object-12">(3)</a> <a href="#ref-for-webvtt-internal-node-object-13">(4)</a> <a href="#ref-for-webvtt-internal-node-object-14">(5)</a>
+    <li><a href="#ref-for-webvtt-internal-node-object-15">7.2.1. The ::cue pseudo-element</a> <a href="#ref-for-webvtt-internal-node-object-16">(2)</a> <a href="#ref-for-webvtt-internal-node-object-17">(3)</a> <a href="#ref-for-webvtt-internal-node-object-18">(4)</a> <a href="#ref-for-webvtt-internal-node-object-19">(5)</a> <a href="#ref-for-webvtt-internal-node-object-20">(6)</a> <a href="#ref-for-webvtt-internal-node-object-21">(7)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-node-objects-applicable-classes">
@@ -6728,7 +6954,8 @@ title</a>
    <ul>
     <li><a href="#ref-for-webvtt-node-objects-applicable-classes-1">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-node-objects-applicable-classes-2">(2)</a>
     <li><a href="#ref-for-webvtt-node-objects-applicable-classes-3">5.5. WebVTT cue text DOM construction rules</a>
-    <li><a href="#ref-for-webvtt-node-objects-applicable-classes-4">6.1.2.1. The ::cue pseudo-element</a>
+    <li><a href="#ref-for-webvtt-node-objects-applicable-classes-4">7.1. Introduction</a> <a href="#ref-for-webvtt-node-objects-applicable-classes-5">(2)</a>
+    <li><a href="#ref-for-webvtt-node-objects-applicable-classes-6">7.2.1. The ::cue pseudo-element</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-node-objects-applicable-language">
@@ -6736,7 +6963,8 @@ title</a>
    <ul>
     <li><a href="#ref-for-webvtt-node-objects-applicable-language-1">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-node-objects-applicable-language-2">(2)</a> <a href="#ref-for-webvtt-node-objects-applicable-language-3">(3)</a> <a href="#ref-for-webvtt-node-objects-applicable-language-4">(4)</a>
     <li><a href="#ref-for-webvtt-node-objects-applicable-language-5">5.5. WebVTT cue text DOM construction rules</a>
-    <li><a href="#ref-for-webvtt-node-objects-applicable-language-6">6.1.2.1. The ::cue pseudo-element</a> <a href="#ref-for-webvtt-node-objects-applicable-language-7">(2)</a> <a href="#ref-for-webvtt-node-objects-applicable-language-8">(3)</a> <a href="#ref-for-webvtt-node-objects-applicable-language-9">(4)</a>
+    <li><a href="#ref-for-webvtt-node-objects-applicable-language-6">7.1. Introduction</a> <a href="#ref-for-webvtt-node-objects-applicable-language-7">(2)</a> <a href="#ref-for-webvtt-node-objects-applicable-language-8">(3)</a> <a href="#ref-for-webvtt-node-objects-applicable-language-9">(4)</a>
+    <li><a href="#ref-for-webvtt-node-objects-applicable-language-10">7.2.1. The ::cue pseudo-element</a> <a href="#ref-for-webvtt-node-objects-applicable-language-11">(2)</a> <a href="#ref-for-webvtt-node-objects-applicable-language-12">(3)</a> <a href="#ref-for-webvtt-node-objects-applicable-language-13">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="list-of-webvtt-node-objects">
@@ -6749,9 +6977,10 @@ title</a>
 title</a>
     <li><a href="#ref-for-list-of-webvtt-node-objects-7">6.1. Processing model</a> <a href="#ref-for-list-of-webvtt-node-objects-8">(2)</a>
     <li><a href="#ref-for-list-of-webvtt-node-objects-9">6.1.1. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-list-of-webvtt-node-objects-10">(2)</a> <a href="#ref-for-list-of-webvtt-node-objects-11">(3)</a> <a href="#ref-for-list-of-webvtt-node-objects-12">(4)</a> <a href="#ref-for-list-of-webvtt-node-objects-13">(5)</a> <a href="#ref-for-list-of-webvtt-node-objects-14">(6)</a> <a href="#ref-for-list-of-webvtt-node-objects-15">(7)</a> <a href="#ref-for-list-of-webvtt-node-objects-16">(8)</a> <a href="#ref-for-list-of-webvtt-node-objects-17">(9)</a>
-    <li><a href="#ref-for-list-of-webvtt-node-objects-18">6.1.2. CSS extensions</a>
-    <li><a href="#ref-for-list-of-webvtt-node-objects-19">6.1.2.1. The ::cue pseudo-element</a> <a href="#ref-for-list-of-webvtt-node-objects-20">(2)</a> <a href="#ref-for-list-of-webvtt-node-objects-21">(3)</a> <a href="#ref-for-list-of-webvtt-node-objects-22">(4)</a> <a href="#ref-for-list-of-webvtt-node-objects-23">(5)</a> <a href="#ref-for-list-of-webvtt-node-objects-24">(6)</a> <a href="#ref-for-list-of-webvtt-node-objects-25">(7)</a>
-    <li><a href="#ref-for-list-of-webvtt-node-objects-26">6.1.2.2. The :past and :future pseudo-classes</a> <a href="#ref-for-list-of-webvtt-node-objects-27">(2)</a>
+    <li><a href="#ref-for-list-of-webvtt-node-objects-18">7.1. Introduction</a> <a href="#ref-for-list-of-webvtt-node-objects-19">(2)</a> <a href="#ref-for-list-of-webvtt-node-objects-20">(3)</a> <a href="#ref-for-list-of-webvtt-node-objects-21">(4)</a> <a href="#ref-for-list-of-webvtt-node-objects-22">(5)</a> <a href="#ref-for-list-of-webvtt-node-objects-23">(6)</a> <a href="#ref-for-list-of-webvtt-node-objects-24">(7)</a>
+    <li><a href="#ref-for-list-of-webvtt-node-objects-25">7.2. Processing model</a>
+    <li><a href="#ref-for-list-of-webvtt-node-objects-26">7.2.1. The ::cue pseudo-element</a> <a href="#ref-for-list-of-webvtt-node-objects-27">(2)</a> <a href="#ref-for-list-of-webvtt-node-objects-28">(3)</a> <a href="#ref-for-list-of-webvtt-node-objects-29">(4)</a> <a href="#ref-for-list-of-webvtt-node-objects-30">(5)</a> <a href="#ref-for-list-of-webvtt-node-objects-31">(6)</a> <a href="#ref-for-list-of-webvtt-node-objects-32">(7)</a>
+    <li><a href="#ref-for-list-of-webvtt-node-objects-33">7.2.2. The :past and :future pseudo-classes</a> <a href="#ref-for-list-of-webvtt-node-objects-34">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-class-object">
@@ -6759,7 +6988,7 @@ title</a>
    <ul>
     <li><a href="#ref-for-webvtt-class-object-1">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-class-object-2">(2)</a>
     <li><a href="#ref-for-webvtt-class-object-3">5.5. WebVTT cue text DOM construction rules</a>
-    <li><a href="#ref-for-webvtt-class-object-4">6.1.2.1. The ::cue pseudo-element</a>
+    <li><a href="#ref-for-webvtt-class-object-4">7.2.1. The ::cue pseudo-element</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-italic-object">
@@ -6768,7 +6997,7 @@ title</a>
     <li><a href="#ref-for-webvtt-italic-object-1">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-italic-object-2">(2)</a>
     <li><a href="#ref-for-webvtt-italic-object-3">5.5. WebVTT cue text DOM construction rules</a>
     <li><a href="#ref-for-webvtt-italic-object-4">6.1.1. Applying CSS properties to WebVTT Node Objects</a>
-    <li><a href="#ref-for-webvtt-italic-object-5">6.1.2.1. The ::cue pseudo-element</a>
+    <li><a href="#ref-for-webvtt-italic-object-5">7.2.1. The ::cue pseudo-element</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-bold-object">
@@ -6778,7 +7007,7 @@ title</a>
     <li><a href="#ref-for-webvtt-bold-object-2">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-bold-object-3">(2)</a>
     <li><a href="#ref-for-webvtt-bold-object-4">5.5. WebVTT cue text DOM construction rules</a>
     <li><a href="#ref-for-webvtt-bold-object-5">6.1.1. Applying CSS properties to WebVTT Node Objects</a>
-    <li><a href="#ref-for-webvtt-bold-object-6">6.1.2.1. The ::cue pseudo-element</a>
+    <li><a href="#ref-for-webvtt-bold-object-6">7.2.1. The ::cue pseudo-element</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-underline-object">
@@ -6787,7 +7016,7 @@ title</a>
     <li><a href="#ref-for-webvtt-underline-object-1">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-underline-object-2">(2)</a>
     <li><a href="#ref-for-webvtt-underline-object-3">5.5. WebVTT cue text DOM construction rules</a>
     <li><a href="#ref-for-webvtt-underline-object-4">6.1.1. Applying CSS properties to WebVTT Node Objects</a>
-    <li><a href="#ref-for-webvtt-underline-object-5">6.1.2.1. The ::cue pseudo-element</a>
+    <li><a href="#ref-for-webvtt-underline-object-5">7.2.1. The ::cue pseudo-element</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-ruby-object">
@@ -6797,7 +7026,7 @@ title</a>
     <li><a href="#ref-for-webvtt-ruby-object-4">5.5. WebVTT cue text DOM construction rules</a>
     <li><a href="#ref-for-webvtt-ruby-object-5">6.1. Processing model</a>
     <li><a href="#ref-for-webvtt-ruby-object-6">6.1.1. Applying CSS properties to WebVTT Node Objects</a>
-    <li><a href="#ref-for-webvtt-ruby-object-7">6.1.2.1. The ::cue pseudo-element</a>
+    <li><a href="#ref-for-webvtt-ruby-object-7">7.2.1. The ::cue pseudo-element</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-ruby-text-object">
@@ -6809,7 +7038,7 @@ title</a>
 title</a>
     <li><a href="#ref-for-webvtt-ruby-text-object-6">6.1. Processing model</a>
     <li><a href="#ref-for-webvtt-ruby-text-object-7">6.1.1. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-webvtt-ruby-text-object-8">(2)</a>
-    <li><a href="#ref-for-webvtt-ruby-text-object-9">6.1.2.1. The ::cue pseudo-element</a>
+    <li><a href="#ref-for-webvtt-ruby-text-object-9">7.2.1. The ::cue pseudo-element</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-voice-object">
@@ -6817,7 +7046,8 @@ title</a>
    <ul>
     <li><a href="#ref-for-webvtt-voice-object-1">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-voice-object-2">(2)</a> <a href="#ref-for-webvtt-voice-object-3">(3)</a>
     <li><a href="#ref-for-webvtt-voice-object-4">5.5. WebVTT cue text DOM construction rules</a> <a href="#ref-for-webvtt-voice-object-5">(2)</a>
-    <li><a href="#ref-for-webvtt-voice-object-6">6.1.2.1. The ::cue pseudo-element</a> <a href="#ref-for-webvtt-voice-object-7">(2)</a> <a href="#ref-for-webvtt-voice-object-8">(3)</a>
+    <li><a href="#ref-for-webvtt-voice-object-6">7.1. Introduction</a>
+    <li><a href="#ref-for-webvtt-voice-object-7">7.2.1. The ::cue pseudo-element</a> <a href="#ref-for-webvtt-voice-object-8">(2)</a> <a href="#ref-for-webvtt-voice-object-9">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-language-object">
@@ -6825,14 +7055,15 @@ title</a>
    <ul>
     <li><a href="#ref-for-webvtt-language-object-1">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-language-object-2">(2)</a>
     <li><a href="#ref-for-webvtt-language-object-3">5.5. WebVTT cue text DOM construction rules</a> <a href="#ref-for-webvtt-language-object-4">(2)</a>
-    <li><a href="#ref-for-webvtt-language-object-5">6.1.2.1. The ::cue pseudo-element</a> <a href="#ref-for-webvtt-language-object-6">(2)</a>
+    <li><a href="#ref-for-webvtt-language-object-5">7.1. Introduction</a>
+    <li><a href="#ref-for-webvtt-language-object-6">7.2.1. The ::cue pseudo-element</a> <a href="#ref-for-webvtt-language-object-7">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-leaf-node-object">
    <b><a href="#webvtt-leaf-node-object">#webvtt-leaf-node-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-leaf-node-object-1">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-leaf-node-object-2">(2)</a>
-    <li><a href="#ref-for-webvtt-leaf-node-object-3">6.1.2.1. The ::cue pseudo-element</a>
+    <li><a href="#ref-for-webvtt-leaf-node-object-3">7.2.1. The ::cue pseudo-element</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-text-object">
@@ -6850,7 +7081,8 @@ title</a>
    <ul>
     <li><a href="#ref-for-webvtt-timestamp-object-1">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-timestamp-object-2">(2)</a>
     <li><a href="#ref-for-webvtt-timestamp-object-3">5.5. WebVTT cue text DOM construction rules</a> <a href="#ref-for-webvtt-timestamp-object-4">(2)</a>
-    <li><a href="#ref-for-webvtt-timestamp-object-5">6.1.2.2. The :past and :future pseudo-classes</a> <a href="#ref-for-webvtt-timestamp-object-6">(2)</a>
+    <li><a href="#ref-for-webvtt-timestamp-object-5">7.1. Introduction</a>
+    <li><a href="#ref-for-webvtt-timestamp-object-6">7.2.2. The :past and :future pseudo-classes</a> <a href="#ref-for-webvtt-timestamp-object-7">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-text-parsing-rules">
@@ -6859,7 +7091,7 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-text-parsing-rules-1">5.6. WebVTT rules for extracting the chapter
 title</a>
     <li><a href="#ref-for-webvtt-cue-text-parsing-rules-2">6.1. Processing model</a>
-    <li><a href="#ref-for-webvtt-cue-text-parsing-rules-3">7.1. The VTTCue interface</a>
+    <li><a href="#ref-for-webvtt-cue-text-parsing-rules-3">8.1. The VTTCue interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="attach-a-webvtt-internal-node-object">
@@ -6937,13 +7169,13 @@ title</a>
   <aside class="dfn-panel" data-for="webvtt-cue-text-dom-construction-rules">
    <b><a href="#webvtt-cue-text-dom-construction-rules">#webvtt-cue-text-dom-construction-rules</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-text-dom-construction-rules-1">7.1. The VTTCue interface</a>
+    <li><a href="#ref-for-webvtt-cue-text-dom-construction-rules-1">8.1. The VTTCue interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-rules-for-extracting-the-chapter-title">
    <b><a href="#webvtt-rules-for-extracting-the-chapter-title">#webvtt-rules-for-extracting-the-chapter-title</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-rules-for-extracting-the-chapter-title-1">7.1. The VTTCue interface</a>
+    <li><a href="#ref-for-webvtt-rules-for-extracting-the-chapter-title-1">8.1. The VTTCue interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="rules-for-updating-the-display-of-webvtt-text-tracks">
@@ -6952,8 +7184,8 @@ title</a>
     <li><a href="#ref-for-rules-for-updating-the-display-of-webvtt-text-tracks-1">3.1. WebVTT cues</a> <a href="#ref-for-rules-for-updating-the-display-of-webvtt-text-tracks-2">(2)</a>
     <li><a href="#ref-for-rules-for-updating-the-display-of-webvtt-text-tracks-3">6.1. Processing model</a>
     <li><a href="#ref-for-rules-for-updating-the-display-of-webvtt-text-tracks-4">6.1.1. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-rules-for-updating-the-display-of-webvtt-text-tracks-5">(2)</a> <a href="#ref-for-rules-for-updating-the-display-of-webvtt-text-tracks-6">(3)</a>
-    <li><a href="#ref-for-rules-for-updating-the-display-of-webvtt-text-tracks-7">6.1.2. CSS extensions</a> <a href="#ref-for-rules-for-updating-the-display-of-webvtt-text-tracks-8">(2)</a>
-    <li><a href="#ref-for-rules-for-updating-the-display-of-webvtt-text-tracks-9">6.1.2.3. The ::cue-region pseudo-element</a>
+    <li><a href="#ref-for-rules-for-updating-the-display-of-webvtt-text-tracks-7">7.2. Processing model</a> <a href="#ref-for-rules-for-updating-the-display-of-webvtt-text-tracks-8">(2)</a>
+    <li><a href="#ref-for-rules-for-updating-the-display-of-webvtt-text-tracks-9">7.2.3. The ::cue-region pseudo-element</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="apply-webvtt-cue-settings">
@@ -6966,222 +7198,180 @@ title</a>
    <b><a href="#webvtt-cue-background-box">#webvtt-cue-background-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-background-box-1">6.1.1. Applying CSS properties to WebVTT Node Objects</a>
-    <li><a href="#ref-for-webvtt-cue-background-box-2">6.1.2.1. The ::cue pseudo-element</a> <a href="#ref-for-webvtt-cue-background-box-3">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="selectordef-cue">
-   <b><a href="#selectordef-cue">#selectordef-cue</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-selectordef-cue-1">1.3. Styling</a>
-    <li><a href="#ref-for-selectordef-cue-2">6.1. Processing model</a>
-    <li><a href="#ref-for-selectordef-cue-3">6.1.2. CSS extensions</a>
-    <li><a href="#ref-for-selectordef-cue-4">6.1.2.1. The ::cue pseudo-element</a> <a href="#ref-for-selectordef-cue-5">(2)</a>
-    <li><a href="#ref-for-selectordef-cue-6">6.1.2.3. The ::cue-region pseudo-element</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="selectordef-cue-selector">
-   <b><a href="#selectordef-cue-selector">#selectordef-cue-selector</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-selectordef-cue-selector-1">1.3. Styling</a>
-    <li><a href="#ref-for-selectordef-cue-selector-2">6.1. Processing model</a>
-    <li><a href="#ref-for-selectordef-cue-selector-3">6.1.2.1. The ::cue pseudo-element</a> <a href="#ref-for-selectordef-cue-selector-4">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="selectordef-past">
-   <b><a href="#selectordef-past">#selectordef-past</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-selectordef-past-1">6.1.2. CSS extensions</a>
-    <li><a href="#ref-for-selectordef-past-2">6.1.2.1. The ::cue pseudo-element</a>
-    <li><a href="#ref-for-selectordef-past-3">6.1.2.2. The :past and :future pseudo-classes</a> <a href="#ref-for-selectordef-past-4">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="selectordef-future">
-   <b><a href="#selectordef-future">#selectordef-future</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-selectordef-future-1">6.1.2. CSS extensions</a>
-    <li><a href="#ref-for-selectordef-future-2">6.1.2.1. The ::cue pseudo-element</a>
-    <li><a href="#ref-for-selectordef-future-3">6.1.2.2. The :past and :future pseudo-classes</a> <a href="#ref-for-selectordef-future-4">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="selectordef-cue-region">
-   <b><a href="#selectordef-cue-region">#selectordef-cue-region</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-selectordef-cue-region-1">1.3. Styling</a>
-    <li><a href="#ref-for-selectordef-cue-region-2">6.1. Processing model</a>
-    <li><a href="#ref-for-selectordef-cue-region-3">6.1.2.3. The ::cue-region pseudo-element</a> <a href="#ref-for-selectordef-cue-region-4">(2)</a> <a href="#ref-for-selectordef-cue-region-5">(3)</a>
+    <li><a href="#ref-for-webvtt-cue-background-box-2">7.2.1. The ::cue pseudo-element</a> <a href="#ref-for-webvtt-cue-background-box-3">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="enumdef-autokeyword">
    <b><a href="#enumdef-autokeyword">#enumdef-autokeyword</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-enumdef-autokeyword-1">7.1. The VTTCue interface</a> <a href="#ref-for-enumdef-autokeyword-2">(2)</a>
+    <li><a href="#ref-for-enumdef-autokeyword-1">8.1. The VTTCue interface</a> <a href="#ref-for-enumdef-autokeyword-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="enumdef-directionsetting">
    <b><a href="#enumdef-directionsetting">#enumdef-directionsetting</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-enumdef-directionsetting-1">7.1. The VTTCue interface</a>
+    <li><a href="#ref-for-enumdef-directionsetting-1">8.1. The VTTCue interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="enumdef-linealignsetting">
    <b><a href="#enumdef-linealignsetting">#enumdef-linealignsetting</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-enumdef-linealignsetting-1">7.1. The VTTCue interface</a>
+    <li><a href="#ref-for-enumdef-linealignsetting-1">8.1. The VTTCue interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="enumdef-positionalignsetting">
    <b><a href="#enumdef-positionalignsetting">#enumdef-positionalignsetting</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-enumdef-positionalignsetting-1">7.1. The VTTCue interface</a>
+    <li><a href="#ref-for-enumdef-positionalignsetting-1">8.1. The VTTCue interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="enumdef-alignsetting">
    <b><a href="#enumdef-alignsetting">#enumdef-alignsetting</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-enumdef-alignsetting-1">7.1. The VTTCue interface</a>
+    <li><a href="#ref-for-enumdef-alignsetting-1">8.1. The VTTCue interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="vttcue">
    <b><a href="#vttcue">#vttcue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vttcue-1">5.5. WebVTT cue text DOM construction rules</a>
-    <li><a href="#ref-for-vttcue-2">7.1. The VTTCue interface</a> <a href="#ref-for-vttcue-3">(2)</a> <a href="#ref-for-vttcue-4">(3)</a> <a href="#ref-for-vttcue-5">(4)</a> <a href="#ref-for-vttcue-6">(5)</a> <a href="#ref-for-vttcue-7">(6)</a> <a href="#ref-for-vttcue-8">(7)</a> <a href="#ref-for-vttcue-9">(8)</a> <a href="#ref-for-vttcue-10">(9)</a> <a href="#ref-for-vttcue-11">(10)</a> <a href="#ref-for-vttcue-12">(11)</a> <a href="#ref-for-vttcue-13">(12)</a> <a href="#ref-for-vttcue-14">(13)</a>
+    <li><a href="#ref-for-vttcue-2">8.1. The VTTCue interface</a> <a href="#ref-for-vttcue-3">(2)</a> <a href="#ref-for-vttcue-4">(3)</a> <a href="#ref-for-vttcue-5">(4)</a> <a href="#ref-for-vttcue-6">(5)</a> <a href="#ref-for-vttcue-7">(6)</a> <a href="#ref-for-vttcue-8">(7)</a> <a href="#ref-for-vttcue-9">(8)</a> <a href="#ref-for-vttcue-10">(9)</a> <a href="#ref-for-vttcue-11">(10)</a> <a href="#ref-for-vttcue-12">(11)</a> <a href="#ref-for-vttcue-13">(12)</a> <a href="#ref-for-vttcue-14">(13)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttcue-vttcue">
    <b><a href="#dom-vttcue-vttcue">#dom-vttcue-vttcue</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttcue-vttcue-1">7.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-vttcue-2">(2)</a>
+    <li><a href="#ref-for-dom-vttcue-vttcue-1">8.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-vttcue-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttcue-region">
    <b><a href="#dom-vttcue-region">#dom-vttcue-region</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttcue-region-1">7.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-region-2">(2)</a>
+    <li><a href="#ref-for-dom-vttcue-region-1">8.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-region-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttcue-vertical">
    <b><a href="#dom-vttcue-vertical">#dom-vttcue-vertical</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttcue-vertical-1">7.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-vertical-2">(2)</a> <a href="#ref-for-dom-vttcue-vertical-3">(3)</a>
+    <li><a href="#ref-for-dom-vttcue-vertical-1">8.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-vertical-2">(2)</a> <a href="#ref-for-dom-vttcue-vertical-3">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttcue-snaptolines">
    <b><a href="#dom-vttcue-snaptolines">#dom-vttcue-snaptolines</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vttcue-snaptolines-1">3.1. WebVTT cues</a>
-    <li><a href="#ref-for-dom-vttcue-snaptolines-2">7.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-snaptolines-3">(2)</a> <a href="#ref-for-dom-vttcue-snaptolines-4">(3)</a> <a href="#ref-for-dom-vttcue-snaptolines-5">(4)</a>
+    <li><a href="#ref-for-dom-vttcue-snaptolines-2">8.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-snaptolines-3">(2)</a> <a href="#ref-for-dom-vttcue-snaptolines-4">(3)</a> <a href="#ref-for-dom-vttcue-snaptolines-5">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttcue-line">
    <b><a href="#dom-vttcue-line">#dom-vttcue-line</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vttcue-line-1">3.1. WebVTT cues</a>
-    <li><a href="#ref-for-dom-vttcue-line-2">7.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-line-3">(2)</a> <a href="#ref-for-dom-vttcue-line-4">(3)</a> <a href="#ref-for-dom-vttcue-line-5">(4)</a>
+    <li><a href="#ref-for-dom-vttcue-line-2">8.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-line-3">(2)</a> <a href="#ref-for-dom-vttcue-line-4">(3)</a> <a href="#ref-for-dom-vttcue-line-5">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttcue-linealign">
    <b><a href="#dom-vttcue-linealign">#dom-vttcue-linealign</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttcue-linealign-1">7.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-linealign-2">(2)</a> <a href="#ref-for-dom-vttcue-linealign-3">(3)</a>
+    <li><a href="#ref-for-dom-vttcue-linealign-1">8.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-linealign-2">(2)</a> <a href="#ref-for-dom-vttcue-linealign-3">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttcue-position">
    <b><a href="#dom-vttcue-position">#dom-vttcue-position</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttcue-position-1">7.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-position-2">(2)</a>
+    <li><a href="#ref-for-dom-vttcue-position-1">8.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-position-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttcue-positionalign">
    <b><a href="#dom-vttcue-positionalign">#dom-vttcue-positionalign</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttcue-positionalign-1">7.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-positionalign-2">(2)</a> <a href="#ref-for-dom-vttcue-positionalign-3">(3)</a>
+    <li><a href="#ref-for-dom-vttcue-positionalign-1">8.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-positionalign-2">(2)</a> <a href="#ref-for-dom-vttcue-positionalign-3">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttcue-size">
    <b><a href="#dom-vttcue-size">#dom-vttcue-size</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttcue-size-1">7.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-size-2">(2)</a>
+    <li><a href="#ref-for-dom-vttcue-size-1">8.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-size-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttcue-align">
    <b><a href="#dom-vttcue-align">#dom-vttcue-align</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttcue-align-1">7.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-align-2">(2)</a> <a href="#ref-for-dom-vttcue-align-3">(3)</a>
+    <li><a href="#ref-for-dom-vttcue-align-1">8.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-align-2">(2)</a> <a href="#ref-for-dom-vttcue-align-3">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttcue-text">
    <b><a href="#dom-vttcue-text">#dom-vttcue-text</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttcue-text-1">7.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-text-2">(2)</a>
+    <li><a href="#ref-for-dom-vttcue-text-1">8.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-text-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttcue-getcueashtml">
    <b><a href="#dom-vttcue-getcueashtml">#dom-vttcue-getcueashtml</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vttcue-getcueashtml-1">5.5. WebVTT cue text DOM construction rules</a>
-    <li><a href="#ref-for-dom-vttcue-getcueashtml-2">7.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-getcueashtml-3">(2)</a> <a href="#ref-for-dom-vttcue-getcueashtml-4">(3)</a>
+    <li><a href="#ref-for-dom-vttcue-getcueashtml-2">8.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-getcueashtml-3">(2)</a> <a href="#ref-for-dom-vttcue-getcueashtml-4">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="enumdef-scrollsetting">
    <b><a href="#enumdef-scrollsetting">#enumdef-scrollsetting</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-enumdef-scrollsetting-1">7.2. The VTTRegion interface</a>
+    <li><a href="#ref-for-enumdef-scrollsetting-1">8.2. The VTTRegion interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="vttregion">
    <b><a href="#vttregion">#vttregion</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-vttregion-1">7.1. The VTTCue interface</a> <a href="#ref-for-vttregion-2">(2)</a> <a href="#ref-for-vttregion-3">(3)</a>
-    <li><a href="#ref-for-vttregion-4">7.2. The VTTRegion interface</a> <a href="#ref-for-vttregion-5">(2)</a> <a href="#ref-for-vttregion-6">(3)</a> <a href="#ref-for-vttregion-7">(4)</a> <a href="#ref-for-vttregion-8">(5)</a> <a href="#ref-for-vttregion-9">(6)</a> <a href="#ref-for-vttregion-10">(7)</a> <a href="#ref-for-vttregion-11">(8)</a> <a href="#ref-for-vttregion-12">(9)</a> <a href="#ref-for-vttregion-13">(10)</a>
+    <li><a href="#ref-for-vttregion-1">8.1. The VTTCue interface</a> <a href="#ref-for-vttregion-2">(2)</a> <a href="#ref-for-vttregion-3">(3)</a>
+    <li><a href="#ref-for-vttregion-4">8.2. The VTTRegion interface</a> <a href="#ref-for-vttregion-5">(2)</a> <a href="#ref-for-vttregion-6">(3)</a> <a href="#ref-for-vttregion-7">(4)</a> <a href="#ref-for-vttregion-8">(5)</a> <a href="#ref-for-vttregion-9">(6)</a> <a href="#ref-for-vttregion-10">(7)</a> <a href="#ref-for-vttregion-11">(8)</a> <a href="#ref-for-vttregion-12">(9)</a> <a href="#ref-for-vttregion-13">(10)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttregion-vttregion">
    <b><a href="#dom-vttregion-vttregion">#dom-vttregion-vttregion</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttregion-vttregion-1">7.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-vttregion-2">(2)</a>
+    <li><a href="#ref-for-dom-vttregion-vttregion-1">8.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-vttregion-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttregion-width">
    <b><a href="#dom-vttregion-width">#dom-vttregion-width</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttregion-width-1">7.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-width-2">(2)</a>
+    <li><a href="#ref-for-dom-vttregion-width-1">8.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-width-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttregion-lines">
    <b><a href="#dom-vttregion-lines">#dom-vttregion-lines</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttregion-lines-1">7.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-lines-2">(2)</a>
+    <li><a href="#ref-for-dom-vttregion-lines-1">8.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-lines-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttregion-regionanchorx">
    <b><a href="#dom-vttregion-regionanchorx">#dom-vttregion-regionanchorx</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttregion-regionanchorx-1">7.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-regionanchorx-2">(2)</a> <a href="#ref-for-dom-vttregion-regionanchorx-3">(3)</a>
+    <li><a href="#ref-for-dom-vttregion-regionanchorx-1">8.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-regionanchorx-2">(2)</a> <a href="#ref-for-dom-vttregion-regionanchorx-3">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttregion-regionanchory">
    <b><a href="#dom-vttregion-regionanchory">#dom-vttregion-regionanchory</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttregion-regionanchory-1">7.2. The VTTRegion interface</a>
+    <li><a href="#ref-for-dom-vttregion-regionanchory-1">8.2. The VTTRegion interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttregion-viewportanchorx">
    <b><a href="#dom-vttregion-viewportanchorx">#dom-vttregion-viewportanchorx</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttregion-viewportanchorx-1">7.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-viewportanchorx-2">(2)</a>
+    <li><a href="#ref-for-dom-vttregion-viewportanchorx-1">8.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-viewportanchorx-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttregion-viewportanchory">
    <b><a href="#dom-vttregion-viewportanchory">#dom-vttregion-viewportanchory</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttregion-viewportanchory-1">7.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-viewportanchory-2">(2)</a>
+    <li><a href="#ref-for-dom-vttregion-viewportanchory-1">8.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-viewportanchory-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttregion-scroll">
    <b><a href="#dom-vttregion-scroll">#dom-vttregion-scroll</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttregion-scroll-1">7.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-scroll-2">(2)</a> <a href="#ref-for-dom-vttregion-scroll-3">(3)</a>
+    <li><a href="#ref-for-dom-vttregion-scroll-1">8.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-scroll-2">(2)</a> <a href="#ref-for-dom-vttregion-scroll-3">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="text-vtt">


### PR DESCRIPTION
No substantial changes are necessary to the rendering sections, since the new section is merely informative.
Some small cleanup of the rendering section title and subsectioning is included.

Closes #313 
Closes https://www.w3.org/Bugs/Public/show_bug.cgi?id=28408
