### PR TITLE
Set |seen cue| to true when seeing a cue

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2252,7 +2252,8 @@ header</i> set, the user agent must run the following steps:</p>
        </li>
 
        <li><p><a>Collect WebVTT cue timings and settings</a> from |line| using |regions| for |cue|.
-       If that fails, let |cue| be null. Otherwise, let |buffer| be the empty string.</p></li>
+       If that fails, let |cue| be null. Otherwise, let |buffer| be the empty string and let |seen
+       cue| be true.</p></li>
 
       </ol>
 

--- a/index.html
+++ b/index.html
@@ -3152,7 +3152,8 @@ header</i> set, the user agent must run the following steps:</p>
            </ol>
           <li>
            <p><a data-link-type="dfn" href="#collect-webvtt-cue-timings-and-settings" id="ref-for-collect-webvtt-cue-timings-and-settings-1">Collect WebVTT cue timings and settings</a> from <var>line</var> using <var>regions</var> for <var>cue</var>.
-       If that fails, let <var>cue</var> be null. Otherwise, let <var>buffer</var> be the empty string.</p>
+       If that fails, let <var>cue</var> be null. Otherwise, let <var>buffer</var> be the empty string and let <var>seen
+       cue</var> be true.</p>
          </ol>
          <p>Otherwise, let <var>position</var> be <var>previous position</var> and break out of <i>loop</i>.</p>
        </ol>


### PR DESCRIPTION
This variable was intended to ignore STYLE and REGION blocks after
having seen a cue, but it was never set to true.

Fixes #324.