### PR TITLE
Clarify the "WebVTT cue settings list" definition.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1783,8 +1783,15 @@ replaced.</p>
 
 <h3 id=cue-settings>WebVTT cue settings</h3>
 
-<p>A <a>WebVTT cue settings list</a> consists of zero or more of the following settings. Each
-setting must not be included more than once per <a>WebVTT cue settings list</a>.</p>
+<p>A <a>WebVTT cue setting</a> is part of a <a>WebVTT cue settings list</a> and provides
+configuration options regarding the position and alignment of the cue box and the cue text
+within.</p>
+
+<p class="note">For example, a set of WebVTT cue settings may allow a cue box to be aligned to the
+left or positioned at the top right with the cue text within center aligned.</p>
+
+<p>The current available <a>WebVTT cue settings</a> that may appear in a <a>WebVTT cue settings
+list</a> are:</p>
 
 <ul class="brief">
  <li>A <a>WebVTT vertical text cue setting</a>.</li>
@@ -1795,9 +1802,8 @@ setting must not be included more than once per <a>WebVTT cue settings list</a>.
  <li>A <a>WebVTT region cue setting</a>.</li>
 </ul>
 
-<p class="note">A <a>WebVTT cue settings list</a> gives configuration options regarding the position
-and alignment of the cue box and the cue text within. For example, it allows a cue box to be aligned
-to the left or positioned at the top right with the cue text within center aligned.</p>
+<p>Each of these setting must not be included more than once per <a>WebVTT cue settings
+list</a>.</p>
 
 <p>A <dfn>WebVTT vertical text cue setting</dfn> is a <a>WebVTT cue setting</a> that consists of the
 following components, in the order given:</p>

--- a/index.html
+++ b/index.html
@@ -1188,7 +1188,7 @@ Possible extra rowspan handling
   </style>
   <meta content="Bikeshed version afd377055fd60b78052b08cc89f300fd74918048" name="generator">
   <link href="https://www.w3.org/TR/webvtt1/" rel="canonical">
-  <meta content="76feac6af2228716ad00a0eaed041a053b9c95d4" name="document-revision">
+  <meta content="5b07860bcee459ea12d00a9bcd7f8733630a6278" name="document-revision">
 <style>
  samp {
    font-family: inherit;
@@ -1444,7 +1444,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">WebVTT: The Web Video Text Tracks Format</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-09-29">29 September 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-10-01">1 October 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2796,8 +2796,13 @@ cue line and allows it to be added.</p>
 the line in the bottom of the region. If no empty line is available, the oldest line is
 replaced.</p>
    <h3 class="heading settled" data-level="4.4" id="cue-settings"><span class="secno">4.4. </span><span class="content">WebVTT cue settings</span><a class="self-link" href="#cue-settings"></a></h3>
-   <p>A <a data-link-type="dfn" href="#webvtt-cue-settings-list" id="ref-for-webvtt-cue-settings-list③">WebVTT cue settings list</a> consists of zero or more of the following settings. Each
-setting must not be included more than once per <a data-link-type="dfn" href="#webvtt-cue-settings-list" id="ref-for-webvtt-cue-settings-list④">WebVTT cue settings list</a>.</p>
+   <p>A <a data-link-type="dfn" href="#webvtt-cue-setting" id="ref-for-webvtt-cue-setting">WebVTT cue setting</a> is part of a <a data-link-type="dfn" href="#webvtt-cue-settings-list" id="ref-for-webvtt-cue-settings-list③">WebVTT cue settings list</a> and provides
+configuration options regarding the position and alignment of the cue box and the cue text
+within.</p>
+   <p class="note" role="note">For example, a set of WebVTT cue settings may allow a cue box to be aligned to the
+left or positioned at the top right with the cue text within center aligned.</p>
+   <p>The current available <a data-link-type="dfn" href="#webvtt-cue-setting" id="ref-for-webvtt-cue-setting①">WebVTT cue settings</a> that may appear in a <a data-link-type="dfn" href="#webvtt-cue-settings-list" id="ref-for-webvtt-cue-settings-list④">WebVTT cue settings
+list</a> are:</p>
    <ul class="brief">
     <li>A <a data-link-type="dfn" href="#webvtt-vertical-text-cue-setting" id="ref-for-webvtt-vertical-text-cue-setting">WebVTT vertical text cue setting</a>.
     <li>A <a data-link-type="dfn" href="#webvtt-line-cue-setting" id="ref-for-webvtt-line-cue-setting">WebVTT line cue setting</a>.
@@ -2806,10 +2811,9 @@ setting must not be included more than once per <a data-link-type="dfn" href="#w
     <li>A <a data-link-type="dfn" href="#webvtt-alignment-cue-setting" id="ref-for-webvtt-alignment-cue-setting">WebVTT alignment cue setting</a>.
     <li>A <a data-link-type="dfn" href="#webvtt-region-cue-setting" id="ref-for-webvtt-region-cue-setting">WebVTT region cue setting</a>.
    </ul>
-   <p class="note" role="note">A <a data-link-type="dfn" href="#webvtt-cue-settings-list" id="ref-for-webvtt-cue-settings-list⑤">WebVTT cue settings list</a> gives configuration options regarding the position
-and alignment of the cue box and the cue text within. For example, it allows a cue box to be aligned
-to the left or positioned at the top right with the cue text within center aligned.</p>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-vertical-text-cue-setting">WebVTT vertical text cue setting</dfn> is a <a data-link-type="dfn" href="#webvtt-cue-setting" id="ref-for-webvtt-cue-setting">WebVTT cue setting</a> that consists of the
+   <p>Each of these setting must not be included more than once per <a data-link-type="dfn" href="#webvtt-cue-settings-list" id="ref-for-webvtt-cue-settings-list⑤">WebVTT cue settings
+list</a>.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-vertical-text-cue-setting">WebVTT vertical text cue setting</dfn> is a <a data-link-type="dfn" href="#webvtt-cue-setting" id="ref-for-webvtt-cue-setting②">WebVTT cue setting</a> that consists of the
 following components, in the order given:</p>
    <ol>
     <li>The string "<code>vertical</code>" as the <a data-link-type="dfn" href="#webvtt-cue-setting-name" id="ref-for-webvtt-cue-setting-name①">WebVTT cue setting name</a>.
@@ -6802,7 +6806,7 @@ title</a>
   <aside class="dfn-panel" data-for="webvtt-cue-setting">
    <b><a href="#webvtt-cue-setting">#webvtt-cue-setting</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-setting">4.4. WebVTT cue settings</a>
+    <li><a href="#ref-for-webvtt-cue-setting">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-cue-setting①">(2)</a> <a href="#ref-for-webvtt-cue-setting②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-setting-name">


### PR DESCRIPTION
This actually introduces a definition for "WebVTT cue setting" and
clarifies how they provide information to position and align the cue
box and cue text.

Closes #360 