### PR TITLE
Add a "User agents that do not support CSS" conformance class.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -627,10 +627,11 @@ requirements.</p>
  <dd><p>All processing requirements in this specification apply, except those in [[#api]].</p></dd>
 
  <dt>User agents that do not support CSS</dt>
- <dd><p>All processing requirements in this specification apply, except those in [[#rendering]] and
- in [[#css-extensions]]. The user agent must instead implement equivalent visual rendering to what a
- CSS based rendering produces. [[#applying-css-properties]] lists the default styling properties in
- CSS speak that will also define the default styling in such user agents.</p></dd>
+ <dd><p>All processing requirements in this specification apply, except those in
+ [[#css-extensions]]. The user agent must instead implement equivalent visual rendering to what a
+ CSS based renderer produces according to [[#rendering]]. [[#applying-css-properties]] lists the
+ default styling properties in CSS speak that will also define the default styling in such user
+ agents.</p></dd>
 
  <dt>Conformance checkers</dt>
  <dd><p>Conformance checkers must verify that a <a>WebVTT file</a> conforms to the applicable
@@ -2444,8 +2445,8 @@ header</i> set, the user agent must run the following steps:</p>
 
 <h3 id=region-settings-parsing algorithm>WebVTT region settings parsing</h3>
 
-<p>When the <a>WebVTT parser</a> says to <dfn>collect WebVTT region settings</dfn> from a string
-|input| for a <a>text track</a>, the user agent must run the following algorithm.</p>
+<p>When the <a>WebVTT parser algorithm</a> says to <dfn>collect WebVTT region settings</dfn> from a
+string |input| for a <a>text track</a>, the user agent must run the following algorithm.</p>
 
 <p>A <dfn>WebVTT region object</dfn> is a conceptual construct to represent a <a>WebVTT region</a>
 that is used as a root node for <a lt="List of WebVTT node objects">lists of WebVTT node

--- a/index.bs
+++ b/index.bs
@@ -645,14 +645,20 @@ requirements.</p>
  specification. [[!WEBIDL]]</p></dd>
 
  <dt>User agents with no scripting support</dt>
- <dd><p>All processing requirements in this specification apply, except those in [[#api]].</p></dd>
-
- <dt>User agents that do not support CSS</dt>
  <dd><p>All processing requirements in this specification apply, except those in
- [[#css-extensions]]. The user agent must instead implement equivalent visual rendering to what a
- CSS based renderer produces according to [[#rendering]]. [[#applying-css-properties]] lists the
- default styling properties in CSS speak that will also define the default styling in such user
- agents.</p></dd>
+ [[#dom-construction-rules]] and [[#api]].</p></dd>
+
+ <dt><dfn>User agents that do not support CSS</dfn></dt>
+ <dd><p>All processing requirements in this specification apply, except parts of [[#parsing]] that
+ relate to stylesheets and CSS, and all of [[#rendering]] and [[#css-extensions]]. The user agent
+ must instead only render the text inside <a>WebVTT cue text</a> in an appropriate manner. Any other
+ styling and positioning instructions are optional.</p> </dd>
+
+ <dt><dfn>User agents that do not support a full HTML CSS engine</dfn></dt>
+ <dd><p>All processing requirements in this specification apply. However, the user agent will need
+ to interpret the CSS related features in [[#parsing]], [[#rendering]] and [[#css-extensions]] in
+ such a way that the rendered results are equivalent to what a full CSS supporting renderer
+ produces.</p></dd>
 
  <dt>Conformance checkers</dt>
  <dd><p>Conformance checkers must verify that a <a>WebVTT file</a> conforms to the applicable
@@ -2742,9 +2748,9 @@ means that it is aborted at that point and returns nothing.</p>
 
 <h3 id=cue-timings-and-settings-parsing algorithm>WebVTT cue timings and settings parsing</h3>
 
-<p>When the algorithm above requires to <dfn>collect WebVTT cue timings and settings</dfn> from a
-string |input| using a <a>text track list of regions</a> |regions| for a <a>WebVTT cue</a> |cue|,
-the user agent must run the following algorithm.</p>
+<p>When the algorithm above says to <dfn>collect WebVTT cue timings and settings</dfn> from a string
+|input| using a <a>text track list of regions</a> |regions| for a <a>WebVTT cue</a> |cue|, the user
+agent must run the following algorithm.</p>
 
 <ol algorithm="collect WebVTT cue timings and settings">
 
@@ -3921,8 +3927,10 @@ follows:</p>
 
 <p class="note">This section describes in some detail how to visually render WebVTT cues in a user
 agent. The processing model is quite tightly linked to media elements in HTML, where CSS is
-available. When supporting WebVTT in media players that do not support CSS, equivalent visual
-rendering will need to be implemented.</p>
+available. <a>User agents that do not support CSS</a> are expected to render plain text only,
+without styling and positioning features. <a>User agents that do not support a full HTML CSS
+engine</a> are expected to render an equivalent visual representation to what a user agent with a
+full CSS engine would render.</p>
 
 
 <h3 id=processing-model algorithm>Processing model</h3>
@@ -4834,7 +4842,7 @@ then they must be interpreted as defined in the next section.</p>
 <h2 id=css-extensions>CSS extensions</h2>
 
 <p class="note">This section specifies some CSS pseudo-elements and pseudo-classes and how they
-apply to WebVTT. This section does not apply to user agents that do not support CSS.</p>
+apply to WebVTT. This section does not apply to <a>user agents that do not support CSS</a>.</p>
 
 
 <h3 id=css-extensions-introduction>Introduction</h3>

--- a/index.bs
+++ b/index.bs
@@ -750,8 +750,8 @@ requirements.</p>
  <dt><dfn>User agents that do not support CSS</dfn></dt>
  <dd><p>All processing requirements in this specification apply, except parts of [[#parsing]] that
  relate to stylesheets and CSS, and all of [[#rendering]] and [[#css-extensions]]. The user agent
- must instead only render the text inside <a>WebVTT cue text</a> in an appropriate manner. Any other
- styling and positioning instructions are optional.</p> </dd>
+ must instead only render the text inside <a>WebVTT caption or subtitle cue text</a> in an
+ appropriate manner. Any other styling and positioning instructions are optional.</p> </dd>
 
  <dt><dfn>User agents that do not support a full HTML CSS engine</dfn></dt>
  <dd><p>All processing requirements in this specification apply. However, the user agent will need
@@ -4115,11 +4115,11 @@ follows:</p>
 <h2 id=rendering>Rendering</h2>
 
 <p class="note">This section describes in some detail how to visually render <a>WebVTT caption or
-subtitle cues</a> in a user agent. The processing model is quite tightly linked to media elements in HTML, where CSS is
-available. <a>User agents that do not support CSS</a> are expected to render plain text only,
-without styling and positioning features. <a>User agents that do not support a full HTML CSS
-engine</a> are expected to render an equivalent visual representation to what a user agent with a
-full CSS engine would render.</p>
+subtitle cues</a> in a user agent. The processing model is quite tightly linked to media elements in
+HTML, where CSS is available. <a>User agents that do not support CSS</a> are expected to render
+plain text only, without styling and positioning features. <a>User agents that do not support a full
+HTML CSS engine</a> are expected to render an equivalent visual representation to what a user agent
+with a full CSS engine would render.</p>
 
 
 <h3 id=processing-model algorithm>Processing model</h3>

--- a/index.bs
+++ b/index.bs
@@ -751,13 +751,14 @@ requirements.</p>
  <dd><p>All processing requirements in this specification apply, except parts of [[#parsing]] that
  relate to stylesheets and CSS, and all of [[#rendering]] and [[#css-extensions]]. The user agent
  must instead only render the text inside <a>WebVTT caption or subtitle cue text</a> in an
- appropriate manner. Any other styling and positioning instructions are optional.</p> </dd>
+ appropriate manner and specifically support the color classes defined in [[#default-classes]]. Any
+ other styling instructions are optional.</p> </dd>
 
  <dt><dfn>User agents that do not support a full HTML CSS engine</dfn></dt>
- <dd><p>All processing requirements in this specification apply. However, the user agent will need
- to interpret the CSS related features in [[#parsing]], [[#rendering]] and [[#css-extensions]] in
- such a way that the rendered results are equivalent to what a full CSS supporting renderer
- produces.</p></dd>
+ <dd><p>All processing requirements in this specification apply, including the color classes defined
+ in [[#default-classes]]. However, the user agent will need to interpret the CSS related features in
+ [[#parsing]], [[#rendering]] and [[#css-extensions]] in such a way that the rendered results are
+ equivalent to what a full CSS supporting renderer produces.</p></dd>
 
  <dt>Conformance checkers</dt>
  <dd><p>Conformance checkers must verify that a <a>WebVTT file</a> conforms to the applicable

--- a/index.bs
+++ b/index.bs
@@ -626,6 +626,12 @@ requirements.</p>
  <dt>User agents with no scripting support</dt>
  <dd><p>All processing requirements in this specification apply, except those in [[#api]].</p></dd>
 
+ <dt>User agents that do not support CSS</dt>
+ <dd><p>All processing requirements in this specification apply, except those in [[#rendering]] and
+ in [[#css-extensions]]. The user agent must instead implement equivalent visual rendering to what a
+ CSS based rendering produces. [[#applying-css-properties]] lists the default styling properties in
+ CSS speak that will also define the default styling in such user agents.</p></dd>
+
  <dt>Conformance checkers</dt>
  <dd><p>Conformance checkers must verify that a <a>WebVTT file</a> conforms to the applicable
  conformance criteria described in this specification. The term "validator" is equivalent to
@@ -2429,9 +2435,8 @@ header</i> set, the user agent must run the following steps:</p>
 
 <h3 id=region-settings-parsing algorithm>WebVTT region settings parsing</h3>
 
-<p>When the <a>WebVTT parser</a> requires that the user agent <dfn>collect WebVTT region
-settings</dfn> from a string |input| for a <a>text track</a>, the user agent must run the following
-algorithm.</p>
+<p>When the <a>WebVTT parser</a> says to <dfn>collect WebVTT region settings</dfn> from a string
+|input| for a <a>text track</a>, the user agent must run the following algorithm.</p>
 
 <p>A <dfn>WebVTT region object</dfn> is a conceptual construct to represent a <a>WebVTT region</a>
 that is used as a root node for <a lt="List of WebVTT node objects">lists of WebVTT node
@@ -2560,9 +2565,9 @@ means that it is aborted at that point and returns nothing.</p>
 
 <h3 id=cue-timings-and-settings-parsing algorithm>WebVTT cue timings and settings parsing</h3>
 
-<p>When the algorithm above requires that the user agent <dfn>collect WebVTT cue timings and
-settings</dfn> from a string |input| using a <a>text track list of regions</a> |regions| for a
-<a>WebVTT cue</a> |cue|, the user agent must run the following algorithm.</p>
+<p>When the algorithm above requires to <dfn>collect WebVTT cue timings and settings</dfn> from a
+string |input| using a <a>text track list of regions</a> |regions| for a <a>WebVTT cue</a> |cue|,
+the user agent must run the following algorithm.</p>
 
 <ol class=algorithm>
 
@@ -3737,9 +3742,9 @@ follows:</p>
 <h2 id=rendering>Rendering</h2>
 
 <p class="note">This section describes in some detail how to visually render WebVTT cues in a user
-agent. The processing model is quite tightly linked to media elements in HTML. When supporting
-WebVTT in media players that don't support CSS, equivalent visual rendering will need to be
-implemented.</p>
+agent. The processing model is quite tightly linked to media elements in HTML, where CSS is
+available. When supporting WebVTT in media players that do not support CSS, equivalent visual
+rendering will need to be implemented.</p>
 
 
 <h3 id=processing-model algorithm>Processing model</h3>
@@ -3940,9 +3945,9 @@ manner suiting the user.</p>
 dragging them to another location on the <a element>video</a>, or even off the <a element>video</a>
 entirely.</p>
 
-<p>When the algorithm above requires that the user agent <dfn>apply WebVTT cue settings</dfn> to
-obtain CSS boxes from a <a>list of WebVTT Node Objects</a> |nodes|, the user agent must run the
-following algorithm.</p>
+<p>When the algorithm above requires to <dfn>apply WebVTT cue settings</dfn> to obtain CSS boxes
+from a <a>list of WebVTT Node Objects</a> |nodes|, the user agent must run the following
+algorithm.</p>
 
 <ol class=algorithm>
 
@@ -4653,7 +4658,7 @@ then they must be interpreted as defined in the next section.</p>
 <h2 id=css-extensions>CSS extensions</h2>
 
 <p class="note">This section specifies some CSS pseudo-elements and pseudo-classes and how they
-apply to WebVTT. This section does not apply to user agents that don't support CSS.</p>
+apply to WebVTT. This section does not apply to user agents that do not support CSS.</p>
 
 
 <h3 id=css-extensions-introduction>Introduction</h3>

--- a/index.html
+++ b/index.html
@@ -2133,13 +2133,13 @@ requirements.</p>
      <p>All processing requirements in this specification apply, except parts of <a href="#parsing">§6 Parsing</a> that
  relate to stylesheets and CSS, and all of <a href="#rendering">§7 Rendering</a> and <a href="#css-extensions">§8 CSS extensions</a>. The user agent
  must instead only render the text inside <a data-link-type="dfn" href="#webvtt-caption-or-subtitle-cue-text" id="ref-for-webvtt-caption-or-subtitle-cue-text-1">WebVTT caption or subtitle cue text</a> in an
- appropriate manner. Any other styling and positioning instructions are optional.</p>
+ appropriate manner and specifically support the color classes defined in <a href="#default-classes">§5 Default classes for WebVTT Caption or Subtitle Cue Components</a>. Any
+ other styling instructions are optional.</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="user-agents-that-do-not-support-a-full-html-css-engine">User agents that do not support a full HTML CSS engine</dfn>
     <dd>
-     <p>All processing requirements in this specification apply. However, the user agent will need
- to interpret the CSS related features in <a href="#parsing">§6 Parsing</a>, <a href="#rendering">§7 Rendering</a> and <a href="#css-extensions">§8 CSS extensions</a> in
- such a way that the rendered results are equivalent to what a full CSS supporting renderer
- produces.</p>
+     <p>All processing requirements in this specification apply, including the color classes defined
+ in <a href="#default-classes">§5 Default classes for WebVTT Caption or Subtitle Cue Components</a>. However, the user agent will need to interpret the CSS related features in <a href="#parsing">§6 Parsing</a>, <a href="#rendering">§7 Rendering</a> and <a href="#css-extensions">§8 CSS extensions</a> in such a way that the rendered results are
+ equivalent to what a full CSS supporting renderer produces.</p>
     <dt>Conformance checkers
     <dd>
      <p>Conformance checkers must verify that a <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file-4">WebVTT file</a> conforms to the applicable

--- a/index.html
+++ b/index.html
@@ -1186,9 +1186,8 @@ Possible extra rowspan handling
       background-repeat: no-repeat;
     }
   </style>
-  <meta content="Bikeshed version afd377055fd60b78052b08cc89f300fd74918048" name="generator">
+  <meta content="Bikeshed version 5dff6b06be1856d0a5e62cf40e9cc21c06bfb098" name="generator">
   <link href="https://www.w3.org/TR/webvtt1/" rel="canonical">
-  <meta content="5b07860bcee459ea12d00a9bcd7f8733630a6278" name="document-revision">
 <style>
  samp {
    font-family: inherit;
@@ -1200,151 +1199,151 @@ Possible extra rowspan handling
 </style>
 <style>/* style-md-lists */
 
-/* This is a weird hack for me not yet following the commonmark spec
-   regarding paragraph and lists. */
-[data-md] > :first-child {
-    margin-top: 0;
-}
-[data-md] > :last-child {
-    margin-bottom: 0;
-}</style>
+            /* This is a weird hack for me not yet following the commonmark spec
+               regarding paragraph and lists. */
+            [data-md] > :first-child {
+                margin-top: 0;
+            }
+            [data-md] > :last-child {
+                margin-bottom: 0;
+            }</style>
 <style>/* style-selflinks */
 
-.heading, .issue, .note, .example, li, dt {
-    position: relative;
-}
-a.self-link {
-    position: absolute;
-    top: 0;
-    left: calc(-1 * (3.5rem - 26px));
-    width: calc(3.5rem - 26px);
-    height: 2em;
-    text-align: center;
-    border: none;
-    transition: opacity .2s;
-    opacity: .5;
-}
-a.self-link:hover {
-    opacity: 1;
-}
-.heading > a.self-link {
-    font-size: 83%;
-}
-li > a.self-link {
-    left: calc(-1 * (3.5rem - 26px) - 2em);
-}
-dfn > a.self-link {
-    top: auto;
-    left: auto;
-    opacity: 0;
-    width: 1.5em;
-    height: 1.5em;
-    background: gray;
-    color: white;
-    font-style: normal;
-    transition: opacity .2s, background-color .2s, color .2s;
-}
-dfn:hover > a.self-link {
-    opacity: 1;
-}
-dfn > a.self-link:hover {
-    color: black;
-}
+            .heading, .issue, .note, .example, li, dt {
+                position: relative;
+            }
+            a.self-link {
+                position: absolute;
+                top: 0;
+                left: calc(-1 * (3.5rem - 26px));
+                width: calc(3.5rem - 26px);
+                height: 2em;
+                text-align: center;
+                border: none;
+                transition: opacity .2s;
+                opacity: .5;
+            }
+            a.self-link:hover {
+                opacity: 1;
+            }
+            .heading > a.self-link {
+                font-size: 83%;
+            }
+            li > a.self-link {
+                left: calc(-1 * (3.5rem - 26px) - 2em);
+            }
+            dfn > a.self-link {
+                top: auto;
+                left: auto;
+                opacity: 0;
+                width: 1.5em;
+                height: 1.5em;
+                background: gray;
+                color: white;
+                font-style: normal;
+                transition: opacity .2s, background-color .2s, color .2s;
+            }
+            dfn:hover > a.self-link {
+                opacity: 1;
+            }
+            dfn > a.self-link:hover {
+                color: black;
+            }
 
-a.self-link::before            { content: "¶"; }
-.heading > a.self-link::before { content: "§"; }
-dfn > a.self-link::before      { content: "#"; }</style>
+            a.self-link::before            { content: "¶"; }
+            .heading > a.self-link::before { content: "§"; }
+            dfn > a.self-link::before      { content: "#"; }</style>
 <style>/* style-counters */
 
-body {
-    counter-reset: example figure issue;
-}
-.issue {
-    counter-increment: issue;
-}
-.issue:not(.no-marker)::before {
-    content: "Issue " counter(issue);
-}
+            body {
+                counter-reset: example figure issue;
+            }
+            .issue {
+                counter-increment: issue;
+            }
+            .issue:not(.no-marker)::before {
+                content: "Issue " counter(issue);
+            }
 
-.example {
-    counter-increment: example;
-}
-.example:not(.no-marker)::before {
-    content: "Example " counter(example);
-}
-.invalid.example:not(.no-marker)::before,
-.illegal.example:not(.no-marker)::before {
-    content: "Invalid Example" counter(example);
-}
+            .example {
+                counter-increment: example;
+            }
+            .example:not(.no-marker)::before {
+                content: "Example " counter(example);
+            }
+            .invalid.example:not(.no-marker)::before,
+            .illegal.example:not(.no-marker)::before {
+                content: "Invalid Example" counter(example);
+            }
 
-figcaption {
-    counter-increment: figure;
-}
-figcaption:not(.no-marker)::before {
-    content: "Figure " counter(figure) " ";
-}</style>
+            figcaption {
+                counter-increment: figure;
+            }
+            figcaption:not(.no-marker)::before {
+                content: "Figure " counter(figure) " ";
+            }</style>
 <style>/* style-autolinks */
 
-.css.css, .property.property, .descriptor.descriptor {
-    color: #005a9c;
-    font-size: inherit;
-    font-family: inherit;
-}
-.css::before, .property::before, .descriptor::before {
-    content: "‘";
-}
-.css::after, .property::after, .descriptor::after {
-    content: "’";
-}
-.property, .descriptor {
-    /* Don't wrap property and descriptor names */
-    white-space: nowrap;
-}
-.type { /* CSS value <type> */
-    font-style: italic;
-}
-pre .property::before, pre .property::after {
-    content: "";
-}
-[data-link-type="property"]::before,
-[data-link-type="propdesc"]::before,
-[data-link-type="descriptor"]::before,
-[data-link-type="value"]::before,
-[data-link-type="function"]::before,
-[data-link-type="at-rule"]::before,
-[data-link-type="selector"]::before,
-[data-link-type="maybe"]::before {
-    content: "‘";
-}
-[data-link-type="property"]::after,
-[data-link-type="propdesc"]::after,
-[data-link-type="descriptor"]::after,
-[data-link-type="value"]::after,
-[data-link-type="function"]::after,
-[data-link-type="at-rule"]::after,
-[data-link-type="selector"]::after,
-[data-link-type="maybe"]::after {
-    content: "’";
-}
+            .css.css, .property.property, .descriptor.descriptor {
+                color: #005a9c;
+                font-size: inherit;
+                font-family: inherit;
+            }
+            .css::before, .property::before, .descriptor::before {
+                content: "‘";
+            }
+            .css::after, .property::after, .descriptor::after {
+                content: "’";
+            }
+            .property, .descriptor {
+                /* Don't wrap property and descriptor names */
+                white-space: nowrap;
+            }
+            .type { /* CSS value <type> */
+                font-style: italic;
+            }
+            pre .property::before, pre .property::after {
+                content: "";
+            }
+            [data-link-type="property"]::before,
+            [data-link-type="propdesc"]::before,
+            [data-link-type="descriptor"]::before,
+            [data-link-type="value"]::before,
+            [data-link-type="function"]::before,
+            [data-link-type="at-rule"]::before,
+            [data-link-type="selector"]::before,
+            [data-link-type="maybe"]::before {
+                content: "‘";
+            }
+            [data-link-type="property"]::after,
+            [data-link-type="propdesc"]::after,
+            [data-link-type="descriptor"]::after,
+            [data-link-type="value"]::after,
+            [data-link-type="function"]::after,
+            [data-link-type="at-rule"]::after,
+            [data-link-type="selector"]::after,
+            [data-link-type="maybe"]::after {
+                content: "’";
+            }
 
-[data-link-type].production::before,
-[data-link-type].production::after,
-.prod [data-link-type]::before,
-.prod [data-link-type]::after {
-    content: "";
-}
+            [data-link-type].production::before,
+            [data-link-type].production::after,
+            .prod [data-link-type]::before,
+            .prod [data-link-type]::after {
+                content: "";
+            }
 
-[data-link-type=element],
-[data-link-type=element-attr] {
-    font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
-    font-size: .9em;
-}
-[data-link-type=element]::before { content: "<" }
-[data-link-type=element]::after  { content: ">" }
+            [data-link-type=element],
+            [data-link-type=element-attr] {
+                font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
+                font-size: .9em;
+            }
+            [data-link-type=element]::before { content: "<" }
+            [data-link-type=element]::after  { content: ">" }
 
-[data-link-type=biblio] {
-    white-space: pre;
-}</style>
+            [data-link-type=biblio] {
+                white-space: pre;
+            }</style>
 <style>/* style-dfn-panel */
 
         .dfn-panel {
@@ -1444,7 +1443,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">WebVTT: The Web Video Text Tracks Format</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-10-01">1 October 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-11-11">11 November 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1461,10 +1460,10 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:philipj@opera.com">Philip Jägenstedt</a> (<a class="p-org org" href="http://www.opera.com/">Opera Software ASA</a>)
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:ian@hixie.ch">Ian Hickson</a> (<a class="p-org org" href="http://www.google.com/">Google</a>)
      <dt>Participate:
-     <dd><a href="https://github.com/w3c/webvtt">GitHub w3c/webvtt</a> (<a href="https://github.com/w3c/webvtt/issues/new">new issue</a>, <a href="https://github.com/w3c/webvtt/issues">open issues</a>, <a href="https://www.w3.org/Bugs/Public/buglist.cgi?product=TextTracks%20CG&amp;component=WebVTT&amp;resolution=---">legacy open bugs</a>)
+     <dd><span><a href="https://github.com/w3c/webvtt">GitHub w3c/webvtt</a> (<a href="https://github.com/w3c/webvtt/issues/new">new issue</a>, <a href="https://github.com/w3c/webvtt/issues">open issues</a>, <a href="https://www.w3.org/Bugs/Public/buglist.cgi?product=TextTracks%20CG&amp;component=WebVTT&amp;resolution=---">legacy open bugs</a>)</span>
      <dt>Commits:
-     <dd><a href="https://github.com/w3c/webvtt/commits">GitHub w3c/webvtt/commits</a>
-     <dd><a href="https://twitter.com/webvtt">@webvtt</a>
+     <dd><span><a href="https://github.com/w3c/webvtt/commits">GitHub w3c/webvtt/commits</a></span>
+     <dd><span><a href="https://twitter.com/webvtt">@webvtt</a></span>
     </dl>
    </div>
    <div data-fill-with="warning"></div>
@@ -1765,13 +1764,13 @@ NOTE end of file
    </div>
    <h3 class="heading settled" data-level="1.3" id="styling"><span class="secno">1.3. </span><span class="content">Styling</span><a class="self-link" href="#styling"></a></h3>
    <p><i>This section is non-normative.</i></p>
-   <p>CSS style sheets that apply to an HTML page that contains a <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/media.html#video" id="ref-for-video">video</a> element can
+   <p>CSS style sheets that apply to an HTML page that contains a <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/media.html#video">video</a> element can
 target WebVTT cues and regions in the video using the <span class="css">::cue</span>, <span class="css">::cue()</span>, <span class="css">::cue-region</span> and <span class="css">::cue-region()</span> pseudo-elements.</p>
    <div class="example" id="example-6a17c0df">
     <a class="self-link" href="#example-6a17c0df"></a> 
-    <p>In this example, an HTML page has a CSS style sheet in a <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element" id="ref-for-the-style-element">style</a> element that
+    <p>In this example, an HTML page has a CSS style sheet in a <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element">style</a> element that
  styles all cues in the video with a gradient background and a text color, as well as changing the
- text color for all <a data-link-type="dfn" href="#webvtt-bold-object" id="ref-for-webvtt-bold-object">WebVTT Bold Objects</a> in cues in the video.</p>
+ text color for all <a data-link-type="dfn" href="#webvtt-bold-object" id="ref-for-webvtt-bold-object-1">WebVTT Bold Objects</a> in cues in the video.</p>
 <pre>&lt;!doctype html>
 &lt;html>
  &lt;head>
@@ -1925,14 +1924,14 @@ What are you waiting for?
  "position" setting applies, in a way which is agnostic regarding the horizontal or vertical
  direction of the cue. It does not affect or relate to the direction or position of the text itself
  within the box.</p>
-    <p>The cues cover only 35% of the video viewport’s width - that’s the <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box">cue
+    <p>The cues cover only 35% of the video viewport’s width - that’s the <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box-1">cue
  box</a>’s "size" for all three cues.</p>
-    <p>The first cue has its <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box①">cue box</a> positioned at the 10% mark. The
- "line-left" and "line-right" within the "position" setting indicates which side of the <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box②">cue box</a> the position refers to. Since in this case the text is horizontal,
+    <p>The first cue has its <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box-2">cue box</a> positioned at the 10% mark. The
+ "line-left" and "line-right" within the "position" setting indicates which side of the <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box-3">cue box</a> the position refers to. Since in this case the text is horizontal,
  "line-left" refers to the left side of the box, and the cue box is thus positioned between the 10%
  and the 45% mark of the video viewport’s width, probably underneath a speaker on the left of the
  video image. If the cue was vertical, "line-left" positioning would be from the top of the video
- viewport’s height and the <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box③">cue box</a> would cover 35% of the video
+ viewport’s height and the <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box-4">cue box</a> would cover 35% of the video
  viewport’s height.</p>
     <p>The text within the first cue’s cue box is aligned using the "align" cue setting. For
  left-to-right rendered text, "start" alignment is the left of that box, for right-to-left rendered
@@ -1940,7 +1939,7 @@ What are you waiting for?
  underneath that speaker. Note that "center" position alignment of the cue box is the default for
  start aligned text, in order to avoid having the box move when the base direction of the text
  changes (from left-to-right to right-to-left or vice versa) as a result of translation.</p>
-    <p>The second cue has its <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box④">cue box</a> right aligned at the 90% mark of the
+    <p>The second cue has its <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box-5">cue box</a> right aligned at the 90% mark of the
  video viewport width ("right" aligned text right aligns the box). The same effect can be achieved
  with "position:55%,line-left", which explicitly positions the cue box. The third cue has center
  aligned text within the same positioned cue box as the first cue.</p>
@@ -2005,10 +2004,10 @@ manner, so long as the end result is equivalent. (In particular, the algorithms 
 specification are intended to be easy to follow, and not intended to be performant.)</p>
    <h3 class="heading settled" data-level="2.1" id="conformance-classes"><span class="secno">2.1. </span><span class="content">Conformance classes</span><a class="self-link" href="#conformance-classes"></a></h3>
    <p>This specification describes the conformance criteria for user agents (relevant to implementors)
-and <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file">WebVTT files</a> (relevant to authors and authoring tool implementors).</p>
-   <p class="note" role="note"><a href="#syntax">§4 Syntax</a> defines what consists of a valid <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file①">WebVTT file</a>. Authors need to
-follow the requirements therein, and are encouraged to use a conformance checker. <a href="#parsing">§5 Parsing</a> defines how user agents are to interpret a file labelled as <a data-link-type="dfn" href="#text-vtt" id="ref-for-text-vtt">text/vtt</a>, for both valid and
-invalid <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file②">WebVTT files</a>. The parsing rules are more tolerant to author errors than the syntax
+and <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file-1">WebVTT files</a> (relevant to authors and authoring tool implementors).</p>
+   <p class="note" role="note"><a href="#syntax">§4 Syntax</a> defines what consists of a valid <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file-2">WebVTT file</a>. Authors need to
+follow the requirements therein, and are encouraged to use a conformance checker. <a href="#parsing">§5 Parsing</a> defines how user agents are to interpret a file labelled as <a data-link-type="dfn" href="#text-vtt" id="ref-for-text-vtt-1">text/vtt</a>, for both valid and
+invalid <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file-3">WebVTT files</a>. The parsing rules are more tolerant to author errors than the syntax
 allows, in order to provide for extensibility and to still render cues that have some syntax
 errors.</p>
    <p class="example" id="example-a403a5ba"><a class="self-link" href="#example-a403a5ba"></a>For example, the parser will create two cues even if the blank line between them is
@@ -2027,20 +2026,20 @@ requirements.</p>
      <p>All processing requirements in this specification apply, except those in <a href="#api">§8 API</a>.</p>
     <dt>User agents that do not support CSS
     <dd>
-     <p>All processing requirements in this specification apply, except those in <a href="#rendering">§6 Rendering</a> and
- in <a href="#css-extensions">§7 CSS extensions</a>. The user agent must instead implement equivalent visual rendering to what a
- CSS based rendering produces. <a href="#applying-css-properties">§6.1.1 Applying CSS properties to WebVTT Node Objects</a> lists the default styling properties in
- CSS speak that will also define the default styling in such user agents.</p>
+     <p>All processing requirements in this specification apply, except those in <a href="#css-extensions">§7 CSS extensions</a>. The user agent must instead implement equivalent visual rendering to what a
+ CSS based renderer produces according to <a href="#rendering">§6 Rendering</a>. <a href="#applying-css-properties">§6.1.1 Applying CSS properties to WebVTT Node Objects</a> lists the
+ default styling properties in CSS speak that will also define the default styling in such user
+ agents.</p>
     <dt>Conformance checkers
     <dd>
-     <p>Conformance checkers must verify that a <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file③">WebVTT file</a> conforms to the applicable
+     <p>Conformance checkers must verify that a <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file-4">WebVTT file</a> conforms to the applicable
  conformance criteria described in this specification. The term "validator" is equivalent to
  conformance checker for the purpose of this specification.</p>
     <dt>Authoring tools
     <dd>
-     <p>Authoring tools must generate conforming <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file④">WebVTT files</a>. Tools that convert other formats
-  to <a data-link-type="dfn" href="#webvtt" id="ref-for-webvtt">WebVTT</a> are also considered to be authoring tools.</p>
-     <p>When an authoring tool is used to edit a non-conforming <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file⑤">WebVTT file</a>, it may preserve the
+     <p>Authoring tools must generate conforming <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file-5">WebVTT files</a>. Tools that convert other formats
+  to <a data-link-type="dfn" href="#webvtt" id="ref-for-webvtt-1">WebVTT</a> are also considered to be authoring tools.</p>
+     <p>When an authoring tool is used to edit a non-conforming <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file-6">WebVTT file</a>, it may preserve the
   conformance errors in sections of the file that were not edited during the editing session (i.e.
   an editing tool is allowed to round-trip erroneous content). However, an authoring tool must not
   claim that the output is conformant if errors have been so preserved.</p>
@@ -2054,7 +2053,7 @@ cue with an ID consisting of the character U+00C5 LATIN CAPITAL LETTER A WITH RI
 precomposed character).</p>
    <h2 class="heading settled" data-level="3" id="data-model"><span class="secno">3. </span><span class="content">Data model</span><a class="self-link" href="#data-model"></a></h2>
    <h3 class="heading settled" data-level="3.1" id="cues"><span class="secno">3.1. </span><span class="content">WebVTT cues</span><a class="self-link" href="#cues"></a></h3>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue">WebVTT cue</dfn> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue" id="ref-for-text-track-cue">text track cue</a> that additionally consist of the following: <a data-link-type="biblio" href="#biblio-html">[HTML]</a></p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue">WebVTT cue</dfn> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue">text track cue</a> that additionally consist of the following: <a data-link-type="biblio" href="#biblio-html">[HTML]</a></p>
    <dl>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="text track cue text" data-noexport="" id="text-track-cue-text">A cue text</dfn>
     <dd>
@@ -2062,12 +2061,12 @@ precomposed character).</p>
   converted to a DOM fragment.</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT cue box" data-noexport="" id="webvtt-cue-box">A cue box</dfn>
     <dd>
-     <p>The cue box of a <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue">WebVTT cue</a> is a box within which the text of all lines of the cue is to
+     <p>The cue box of a <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-1">WebVTT cue</a> is a box within which the text of all lines of the cue is to
   be rendered.</p>
-     <p class="note" role="note">The position of the <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box⑤">cue box</a> within the video viewport’s
-  dimensions depends on the value of the <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position">WebVTT cue position</a> and the <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line">WebVTT cue
+     <p class="note" role="note">The position of the <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box-6">cue box</a> within the video viewport’s
+  dimensions depends on the value of the <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position-1">WebVTT cue position</a> and the <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line-1">WebVTT cue
   line</a>.</p>
-     <p class="note" role="note">Lines are wrapped within the <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box⑥">cue box</a>’s <a data-link-type="dfn" href="#webvtt-cue-size" id="ref-for-webvtt-cue-size">size</a> if lines' lengths make this necessary.</p>
+     <p class="note" role="note">Lines are wrapped within the <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box-7">cue box</a>’s <a data-link-type="dfn" href="#webvtt-cue-size" id="ref-for-webvtt-cue-size-1">size</a> if lines' lengths make this necessary.</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT cue writing direction" data-noexport="" id="webvtt-cue-writing-direction">A writing direction</dfn>
     <dd>
      <p>A writing direction, either</p>
@@ -2082,64 +2081,64 @@ precomposed character).</p>
    line extends vertically and is offset horizontally from the video viewport’s left edge, with
    consecutive lines displayed to the right of each other).
      </ul>
-     <p class="note" role="note">The <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction">writing direction</a> affects the
-  interpretation of the <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line①">line</a>, <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position①">position</a>,
-  and <a data-link-type="dfn" href="#webvtt-cue-size" id="ref-for-webvtt-cue-size①">size</a> cue settings to be interpreted with respect to either the
+     <p class="note" role="note">The <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-1">writing direction</a> affects the
+  interpretation of the <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line-2">line</a>, <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position-2">position</a>,
+  and <a data-link-type="dfn" href="#webvtt-cue-size" id="ref-for-webvtt-cue-size-2">size</a> cue settings to be interpreted with respect to either the
   width or height of the video.</p>
-     <p>By default, the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction①">writing direction</a> is set to to <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction">horizontal</a>.</p>
-     <p class="note" role="note">The <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-left-writing-direction" id="ref-for-webvtt-cue-vertical-growing-left-writing-direction">vertical growing
-  left</a> writing direction could be used for vertical Chinese, Japanese, and Korean, and the <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-right-writing-direction" id="ref-for-webvtt-cue-vertical-growing-right-writing-direction">vertical growing right</a> writing
+     <p>By default, the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-2">writing direction</a> is set to to <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction-1">horizontal</a>.</p>
+     <p class="note" role="note">The <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-left-writing-direction" id="ref-for-webvtt-cue-vertical-growing-left-writing-direction-1">vertical growing
+  left</a> writing direction could be used for vertical Chinese, Japanese, and Korean, and the <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-right-writing-direction" id="ref-for-webvtt-cue-vertical-growing-right-writing-direction-1">vertical growing right</a> writing
   direction could be used for vertical Mongolian.</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT cue snap-to-lines flag" data-noexport="" id="webvtt-cue-snap-to-lines-flag">A snap-to-lines flag</dfn>
     <dd>
-     <p>A boolean indicating whether the <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line②">line</a> is an integer number of lines
+     <p>A boolean indicating whether the <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line-3">line</a> is an integer number of lines
   (using the line dimensions of the first line of the cue), or whether it is a percentage of the
   dimension of the video. The flag is set to true when lines are counted, and false otherwise.</p>
-     <p>Cues whose <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag">WebVTT cue snap-to-lines flag</a> is true will be placed within the title-safe
+     <p>Cues whose <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag-1">WebVTT cue snap-to-lines flag</a> is true will be placed within the title-safe
   area on user agents that use overscan. Cues where the flag is false will be offset as requested
   (modulo overlap avoidance if multiple cues are in the same place).</p>
-     <p>By default, the <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag①">snap-to-lines flag</a> is set to
+     <p>By default, the <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag-2">snap-to-lines flag</a> is set to
   true.</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT cue line" data-noexport="" id="webvtt-cue-line">A line</dfn>
     <dd>
-     <p>The <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line③">line</a> defines positioning of the <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box⑦">cue
+     <p>The <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line-4">line</a> defines positioning of the <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box-8">cue
   box</a>.</p>
-     <p>The <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line④">line</a> offsets the <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box⑧">cue box</a> from the
-  top, the right or left of the video viewport as defined by the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction②">writing direction</a>, the <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag②">snap-to-lines
+     <p>The <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line-5">line</a> offsets the <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box-9">cue box</a> from the
+  top, the right or left of the video viewport as defined by the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-3">writing direction</a>, the <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag-3">snap-to-lines
   flag</a>, or the lines occupied by any other showing tracks.</p>
-     <p>The <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line⑤">line</a> is set either as a number of lines, a percentage of the
+     <p>The <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line-6">line</a> is set either as a number of lines, a percentage of the
   video viewport height or width, or as the special value <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT cue line
   automatic" data-noexport="" id="webvtt-cue-line-automatic">auto</dfn>, which means the offset is to depend on the other showing tracks.</p>
-     <p>By default, the <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line⑥">line</a> is set to <a data-link-type="dfn" href="#webvtt-cue-line-automatic" id="ref-for-webvtt-cue-line-automatic">auto</a>.</p>
-     <p>If the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction③">writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction①">horizontal</a>, then the <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line⑦">line</a> percentages are relative to the height of the video, otherwise to the width of the video.</p>
-     <p>A <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue①">WebVTT cue</a> has a <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="cue computed line" data-noexport="" id="cue-computed-line">computed line</dfn> whose value is that
+     <p>By default, the <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line-7">line</a> is set to <a data-link-type="dfn" href="#webvtt-cue-line-automatic" id="ref-for-webvtt-cue-line-automatic-1">auto</a>.</p>
+     <p>If the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-4">writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction-2">horizontal</a>, then the <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line-8">line</a> percentages are relative to the height of the video, otherwise to the width of the video.</p>
+     <p>A <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-2">WebVTT cue</a> has a <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="cue computed line" data-noexport="" id="cue-computed-line">computed line</dfn> whose value is that
   returned by the following algorithm, which is defined in terms of the other aspects of the
   cue:</p>
      <ol class="algorithm" data-algorithm="computed line">
       <li>
-       <p>If the <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line⑧">line</a> is numeric, the <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag③">WebVTT cue snap-to-lines flag</a> of the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue②">WebVTT cue</a> is false, and the <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line⑨">line</a> is negative or
+       <p>If the <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line-9">line</a> is numeric, the <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag-4">WebVTT cue snap-to-lines flag</a> of the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-3">WebVTT cue</a> is false, and the <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line-10">line</a> is negative or
     greater than 100, then return 100 and abort these steps.</p>
-       <p class="note" role="note">Although the <a data-link-type="dfn" href="#webvtt-parser" id="ref-for-webvtt-parser">WebVTT parser</a> will not set the <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line①⓪">line</a> to a number outside the range 0..100 and also set the <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag④">WebVTT cue snap-to-lines
-    flag</a> to false, this can happen when using the DOM API’s <code class="idl"><a data-link-type="idl" href="#dom-vttcue-snaptolines" id="ref-for-dom-vttcue-snaptolines">snapToLines</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-vttcue-line" id="ref-for-dom-vttcue-line">line</a></code> attributes.</p>
+       <p class="note" role="note">Although the <a data-link-type="dfn" href="#webvtt-parser" id="ref-for-webvtt-parser-1">WebVTT parser</a> will not set the <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line-11">line</a> to a number outside the range 0..100 and also set the <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag-5">WebVTT cue snap-to-lines
+    flag</a> to false, this can happen when using the DOM API’s <code class="idl"><a data-link-type="idl" href="#dom-vttcue-snaptolines" id="ref-for-dom-vttcue-snaptolines-1">snapToLines</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-vttcue-line" id="ref-for-dom-vttcue-line-1">line</a></code> attributes.</p>
       <li>
-       <p>If the <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line①①">line</a> is numeric, return the value of the <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line①②">WebVTT cue
-   line</a> and abort these steps. (Either the <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag⑤">WebVTT cue snap-to-lines flag</a> is true, so any
+       <p>If the <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line-12">line</a> is numeric, return the value of the <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line-13">WebVTT cue
+   line</a> and abort these steps. (Either the <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag-6">WebVTT cue snap-to-lines flag</a> is true, so any
    value, not just those in the range 0..100, is valid, or the value is in the range 0..100 and is
    thus valid regardless of the value of that flag.)</p>
       <li>
-       <p>If the <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag⑥">WebVTT cue snap-to-lines flag</a> of the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue③">WebVTT cue</a> is false, return the
-   value 100 and abort these steps. (The <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line①③">line</a> is the special value <a data-link-type="dfn" href="#webvtt-cue-line-automatic" id="ref-for-webvtt-cue-line-automatic①">auto</a>.)</p>
+       <p>If the <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag-7">WebVTT cue snap-to-lines flag</a> of the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-4">WebVTT cue</a> is false, return the
+   value 100 and abort these steps. (The <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line-14">line</a> is the special value <a data-link-type="dfn" href="#webvtt-cue-line-automatic" id="ref-for-webvtt-cue-line-automatic-2">auto</a>.)</p>
       <li>
-       <p>Let <var>cue</var> be the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue④">WebVTT cue</a>.</p>
+       <p>Let <var>cue</var> be the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-5">WebVTT cue</a>.</p>
       <li>
-       <p>If <var>cue</var> is not in a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-list-of-cues" id="ref-for-text-track-list-of-cues">list of cues</a> of a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track" id="ref-for-text-track">text
-   track</a>, or if that <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track" id="ref-for-text-track①">text track</a> is not in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#list-of-text-tracks" id="ref-for-list-of-text-tracks">list of text tracks</a> of a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element" id="ref-for-media-element">media
+       <p>If <var>cue</var> is not in a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-list-of-cues">list of cues</a> of a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track">text
+   track</a>, or if that <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track">text track</a> is not in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#list-of-text-tracks">list of text tracks</a> of a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media
    element</a>, return −1 and abort these steps.</p>
       <li>
-       <p>Let <var>track</var> be the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track" id="ref-for-text-track②">text track</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-list-of-cues" id="ref-for-text-track-list-of-cues①">list of
+       <p>Let <var>track</var> be the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track">text track</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-list-of-cues">list of
    cues</a> the <var>cue</var> is in.</p>
       <li>
-       <p>Let <var>n</var> be the number of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track" id="ref-for-text-track③">text tracks</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-mode" id="ref-for-text-track-mode">text track mode</a> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-showing" id="ref-for-text-track-showing">showing</a> and that are in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element" id="ref-for-media-element①">media element</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#list-of-text-tracks" id="ref-for-list-of-text-tracks①">list of text tracks</a> before <var>track</var>.</p>
+       <p>Let <var>n</var> be the number of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track">text tracks</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-mode">text track mode</a> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-showing">showing</a> and that are in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media element</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#list-of-text-tracks">list of text tracks</a> before <var>track</var>.</p>
       <li>
        <p>Increment <var>n</var> by one.</p>
       <li>
@@ -2147,122 +2146,122 @@ precomposed character).</p>
       <li>
        <p>Return <var>n</var>.</p>
      </ol>
-     <p class="example" id="example-d1c46c31"><a class="self-link" href="#example-d1c46c31"></a>For example, if two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track" id="ref-for-text-track④">text tracks</a> are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-showing" id="ref-for-text-track-showing①">showing</a> at the same time in one <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element" id="ref-for-media-element②">media element</a>, and each <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track" id="ref-for-text-track⑤">text track</a> currently has an active <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue⑤">WebVTT cue</a> whose <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line①④">line</a> are both <a data-link-type="dfn" href="#webvtt-cue-line-automatic" id="ref-for-webvtt-cue-line-automatic②">auto</a>, then the first <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track" id="ref-for-text-track⑥">text track</a>’s cue’s <a data-link-type="dfn" href="#cue-computed-line" id="ref-for-cue-computed-line">computed line</a> will be −1 and the second will be −2.</p>
+     <p class="example" id="example-d1c46c31"><a class="self-link" href="#example-d1c46c31"></a>For example, if two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track">text tracks</a> are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-showing">showing</a> at the same time in one <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media element</a>, and each <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track">text track</a> currently has an active <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-6">WebVTT cue</a> whose <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line-15">line</a> are both <a data-link-type="dfn" href="#webvtt-cue-line-automatic" id="ref-for-webvtt-cue-line-automatic-3">auto</a>, then the first <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track">text track</a>’s cue’s <a data-link-type="dfn" href="#cue-computed-line" id="ref-for-cue-computed-line-1">computed line</a> will be −1 and the second will be −2.</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT cue line alignment" data-noexport="" id="webvtt-cue-line-alignment">A line alignment</dfn>
     <dd>
-     <p>An alignment for the <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box⑨">cue box</a>’s <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line①⑤">line</a>, one
+     <p>An alignment for the <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box-10">cue box</a>’s <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line-16">line</a>, one
   of:</p>
      <dl>
       <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT cue line start alignment" data-noexport="" id="webvtt-cue-line-start-alignment">Start alignment</dfn>
-      <dd>The <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box①⓪">cue box</a>’s top side (for <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction②">horizontal</a> cues), left side (for <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-right-writing-direction" id="ref-for-webvtt-cue-vertical-growing-right-writing-direction①">vertical growing right</a>), or right side (for <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-left-writing-direction" id="ref-for-webvtt-cue-vertical-growing-left-writing-direction①">vertical growing left</a>) is aligned at the <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line①⑥">line</a>.
+      <dd>The <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box-11">cue box</a>’s top side (for <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction-3">horizontal</a> cues), left side (for <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-right-writing-direction" id="ref-for-webvtt-cue-vertical-growing-right-writing-direction-2">vertical growing right</a>), or right side (for <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-left-writing-direction" id="ref-for-webvtt-cue-vertical-growing-left-writing-direction-2">vertical growing left</a>) is aligned at the <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line-17">line</a>.
       <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT cue line center alignment" data-noexport="" id="webvtt-cue-line-center-alignment">Center alignment</dfn>
-      <dd>The <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box①①">cue box</a> is centered at the <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line①⑦">line</a>.
+      <dd>The <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box-12">cue box</a> is centered at the <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line-18">line</a>.
       <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT cue line end alignment" data-noexport="" id="webvtt-cue-line-end-alignment">End alignment</dfn>
-      <dd>The <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box①②">cue box</a>’s bottom side (for <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction③">horizontal</a> cues), right side (for <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-right-writing-direction" id="ref-for-webvtt-cue-vertical-growing-right-writing-direction②">vertical growing right</a>), or left side (for <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-left-writing-direction" id="ref-for-webvtt-cue-vertical-growing-left-writing-direction②">vertical growing left</a>) is aligned at the <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line①⑧">line</a>.
+      <dd>The <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box-13">cue box</a>’s bottom side (for <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction-4">horizontal</a> cues), right side (for <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-right-writing-direction" id="ref-for-webvtt-cue-vertical-growing-right-writing-direction-3">vertical growing right</a>), or left side (for <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-left-writing-direction" id="ref-for-webvtt-cue-vertical-growing-left-writing-direction-3">vertical growing left</a>) is aligned at the <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line-19">line</a>.
      </dl>
-     <p>By default, the <a data-link-type="dfn" href="#webvtt-cue-line-alignment" id="ref-for-webvtt-cue-line-alignment">line alignment</a> is set to <a data-link-type="dfn" href="#webvtt-cue-line-start-alignment" id="ref-for-webvtt-cue-line-start-alignment">start</a>.</p>
-     <p class="note" role="note">The <a data-link-type="dfn" href="#webvtt-cue-line-alignment" id="ref-for-webvtt-cue-line-alignment①">line alignment</a> is separate from the <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment">text alignment</a> — right-to-left vs. left-to-right cue text
-  does not affect the <a data-link-type="dfn" href="#webvtt-cue-line-alignment" id="ref-for-webvtt-cue-line-alignment②">line alignment</a>.</p>
+     <p>By default, the <a data-link-type="dfn" href="#webvtt-cue-line-alignment" id="ref-for-webvtt-cue-line-alignment-1">line alignment</a> is set to <a data-link-type="dfn" href="#webvtt-cue-line-start-alignment" id="ref-for-webvtt-cue-line-start-alignment-1">start</a>.</p>
+     <p class="note" role="note">The <a data-link-type="dfn" href="#webvtt-cue-line-alignment" id="ref-for-webvtt-cue-line-alignment-2">line alignment</a> is separate from the <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment-1">text alignment</a> — right-to-left vs. left-to-right cue text
+  does not affect the <a data-link-type="dfn" href="#webvtt-cue-line-alignment" id="ref-for-webvtt-cue-line-alignment-3">line alignment</a>.</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT cue position" data-noexport="" id="webvtt-cue-position">A position</dfn>
     <dd>
-     <p>The <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position②">position</a> defines the indent of the <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box①③">cue box</a> in the direction defined by the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction④">writing
+     <p>The <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position-3">position</a> defines the indent of the <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box-14">cue box</a> in the direction defined by the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-5">writing
   direction</a>.</p>
-     <p>The <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position③">position</a> is either a number giving the position of the <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box①④">cue box</a> as a percentage value or the special value <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT cue
-  automatic position" data-noexport="" id="webvtt-cue-automatic-position">auto</dfn>, which means the position is to depend on the <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment①">text alignment</a> of the cue.</p>
-     <p>If the cue is not within a <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region">region</a>, the percentage value is to be
+     <p>The <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position-4">position</a> is either a number giving the position of the <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box-15">cue box</a> as a percentage value or the special value <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT cue
+  automatic position" data-noexport="" id="webvtt-cue-automatic-position">auto</dfn>, which means the position is to depend on the <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment-2">text alignment</a> of the cue.</p>
+     <p>If the cue is not within a <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region-1">region</a>, the percentage value is to be
   interpreted as a percentage of the video dimensions, otherwise as a percentage of the region
   dimensions.</p>
-     <p>By default, the <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position④">position</a> is set to <a data-link-type="dfn" href="#webvtt-cue-automatic-position" id="ref-for-webvtt-cue-automatic-position">auto</a>.</p>
-     <p>If the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction⑤">writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction④">horizontal</a>, then the <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position⑤">position</a> percentages are relative to the width of the video, otherwise to the height of the video.</p>
-     <p>A <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue⑥">WebVTT cue</a> has a <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="cue computed position" data-noexport="" id="cue-computed-position">computed position</dfn> whose value
+     <p>By default, the <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position-5">position</a> is set to <a data-link-type="dfn" href="#webvtt-cue-automatic-position" id="ref-for-webvtt-cue-automatic-position-1">auto</a>.</p>
+     <p>If the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-6">writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction-5">horizontal</a>, then the <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position-6">position</a> percentages are relative to the width of the video, otherwise to the height of the video.</p>
+     <p>A <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-7">WebVTT cue</a> has a <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="cue computed position" data-noexport="" id="cue-computed-position">computed position</dfn> whose value
   is that returned by the following algorithm, which is defined in terms of the other aspects of the
   cue:</p>
      <ol class="algorithm" data-algorithm="computed position">
       <li>
-       <p>If the <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position⑥">position</a> is numeric, then return the value of the <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position⑦">position</a> and abort these steps. (Otherwise, the <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position⑧">position</a> is the special value <a data-link-type="dfn" href="#webvtt-cue-automatic-position" id="ref-for-webvtt-cue-automatic-position①">auto</a>.)</p>
+       <p>If the <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position-7">position</a> is numeric, then return the value of the <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position-8">position</a> and abort these steps. (Otherwise, the <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position-9">position</a> is the special value <a data-link-type="dfn" href="#webvtt-cue-automatic-position" id="ref-for-webvtt-cue-automatic-position-2">auto</a>.)</p>
       <li>
-       <p>If the <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment②">cue text alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-left-alignment" id="ref-for-webvtt-cue-left-alignment">left</a>, return 0 and abort these steps.</p>
+       <p>If the <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment-3">cue text alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-left-alignment" id="ref-for-webvtt-cue-left-alignment-1">left</a>, return 0 and abort these steps.</p>
       <li>
-       <p>If the <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment③">cue text alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-right-alignment" id="ref-for-webvtt-cue-right-alignment">right</a>, return 100 and abort these steps.</p>
+       <p>If the <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment-4">cue text alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-right-alignment" id="ref-for-webvtt-cue-right-alignment-1">right</a>, return 100 and abort these steps.</p>
       <li>
        <p>Otherwise, return 50 and abort these steps.</p>
      </ol>
-     <p class="note" role="note">Since the default value of the <a data-link-type="dfn" href="#webvtt-cue-position-alignment" id="ref-for-webvtt-cue-position-alignment">WebVTT cue position alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-center-alignment" id="ref-for-webvtt-cue-center-alignment">center</a>, if there is no <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment④">WebVTT cue text alignment</a> setting for a cue, the <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position⑨">WebVTT cue position</a> defaults to 50%.</p>
-     <p class="note" role="note">Even for <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction⑤">horizontal</a> cues with
-  right-to-left cue text, the <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box①⑤">cue box</a> is positioned from the left edge of
+     <p class="note" role="note">Since the default value of the <a data-link-type="dfn" href="#webvtt-cue-position-alignment" id="ref-for-webvtt-cue-position-alignment-1">WebVTT cue position alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-center-alignment" id="ref-for-webvtt-cue-center-alignment-1">center</a>, if there is no <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment-5">WebVTT cue text alignment</a> setting for a cue, the <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position-10">WebVTT cue position</a> defaults to 50%.</p>
+     <p class="note" role="note">Even for <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction-6">horizontal</a> cues with
+  right-to-left cue text, the <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box-16">cue box</a> is positioned from the left edge of
   the video viewport. This allows defining a rendering space template which can be filled with
   either left-to-right or right-to-left cue text, or both.</p>
-     <p>For <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue⑦">WebVTT cues</a> that have a <a data-link-type="dfn" href="#webvtt-cue-size" id="ref-for-webvtt-cue-size②">size</a> other than 100%, and a <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment⑤">text alignment</a> of <a data-link-type="dfn" href="#webvtt-cue-start-alignment" id="ref-for-webvtt-cue-start-alignment">start</a> or <a data-link-type="dfn" href="#webvtt-cue-end-alignment" id="ref-for-webvtt-cue-end-alignment">end</a>, authors must not use the default <a data-link-type="dfn" href="#webvtt-cue-automatic-position" id="ref-for-webvtt-cue-automatic-position②">auto</a> <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position①⓪">position</a>.</p>
-     <p class="note" role="note">When the <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment⑥">text alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-start-alignment" id="ref-for-webvtt-cue-start-alignment①">start</a> or <a data-link-type="dfn" href="#webvtt-cue-end-alignment" id="ref-for-webvtt-cue-end-alignment①">end</a>, the <a data-link-type="dfn" href="#webvtt-cue-automatic-position" id="ref-for-webvtt-cue-automatic-position③">auto</a> <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position①①">position</a> is 50%. This is different
-  from <a data-link-type="dfn" href="#webvtt-cue-left-alignment" id="ref-for-webvtt-cue-left-alignment①">left</a> and <a data-link-type="dfn" href="#webvtt-cue-right-alignment" id="ref-for-webvtt-cue-right-alignment①">right</a> aligned text, where the <a data-link-type="dfn" href="#webvtt-cue-automatic-position" id="ref-for-webvtt-cue-automatic-position④">auto</a> <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position①②">position</a> is 0% and 100%, respectively. The above requirement is present because it
-  can be surprising that automatic positioning doesn’t work for <a data-link-type="dfn" href="#webvtt-cue-start-alignment" id="ref-for-webvtt-cue-start-alignment②">start</a> or <a data-link-type="dfn" href="#webvtt-cue-end-alignment" id="ref-for-webvtt-cue-end-alignment②">end</a> aligned text. Since <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text">cue text</a> can consist of text with left-to-right base direction, or right-to-left
+     <p>For <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-8">WebVTT cues</a> that have a <a data-link-type="dfn" href="#webvtt-cue-size" id="ref-for-webvtt-cue-size-3">size</a> other than 100%, and a <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment-6">text alignment</a> of <a data-link-type="dfn" href="#webvtt-cue-start-alignment" id="ref-for-webvtt-cue-start-alignment-1">start</a> or <a data-link-type="dfn" href="#webvtt-cue-end-alignment" id="ref-for-webvtt-cue-end-alignment-1">end</a>, authors must not use the default <a data-link-type="dfn" href="#webvtt-cue-automatic-position" id="ref-for-webvtt-cue-automatic-position-3">auto</a> <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position-11">position</a>.</p>
+     <p class="note" role="note">When the <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment-7">text alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-start-alignment" id="ref-for-webvtt-cue-start-alignment-2">start</a> or <a data-link-type="dfn" href="#webvtt-cue-end-alignment" id="ref-for-webvtt-cue-end-alignment-2">end</a>, the <a data-link-type="dfn" href="#webvtt-cue-automatic-position" id="ref-for-webvtt-cue-automatic-position-4">auto</a> <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position-12">position</a> is 50%. This is different
+  from <a data-link-type="dfn" href="#webvtt-cue-left-alignment" id="ref-for-webvtt-cue-left-alignment-2">left</a> and <a data-link-type="dfn" href="#webvtt-cue-right-alignment" id="ref-for-webvtt-cue-right-alignment-2">right</a> aligned text, where the <a data-link-type="dfn" href="#webvtt-cue-automatic-position" id="ref-for-webvtt-cue-automatic-position-5">auto</a> <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position-13">position</a> is 0% and 100%, respectively. The above requirement is present because it
+  can be surprising that automatic positioning doesn’t work for <a data-link-type="dfn" href="#webvtt-cue-start-alignment" id="ref-for-webvtt-cue-start-alignment-3">start</a> or <a data-link-type="dfn" href="#webvtt-cue-end-alignment" id="ref-for-webvtt-cue-end-alignment-3">end</a> aligned text. Since <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-1">cue text</a> can consist of text with left-to-right base direction, or right-to-left
   base direction, or both (on different lines), such automatic positioning would have unexpected
   results.</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT cue position alignment" data-noexport="" id="webvtt-cue-position-alignment">A position alignment</dfn>
     <dd>
-     <p>An alignment for the <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box①⑥">cue box</a> in the dimension of the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction⑥">writing direction</a>, describing what the <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position①③">position</a> is anchored to, one of:</p>
+     <p>An alignment for the <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box-17">cue box</a> in the dimension of the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-7">writing direction</a>, describing what the <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position-14">position</a> is anchored to, one of:</p>
      <dl>
       <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT cue position line-left alignment" data-noexport="" id="webvtt-cue-position-line-left-alignment">Line-left alignment</dfn>
-      <dd>The <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box①⑦">cue box</a>’s left side (for <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction⑥">horizontal</a> cues) or top side (otherwise) is aligned at the <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position①④">position</a>.
+      <dd>The <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box-18">cue box</a>’s left side (for <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction-7">horizontal</a> cues) or top side (otherwise) is aligned at the <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position-15">position</a>.
       <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT cue position center alignment" data-noexport="" id="webvtt-cue-position-center-alignment">Center alignment</dfn>
-      <dd>The <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box①⑧">cue box</a> is centered at the <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position①⑤">position</a>.
+      <dd>The <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box-19">cue box</a> is centered at the <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position-16">position</a>.
       <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT cue position line-right alignment" data-noexport="" id="webvtt-cue-position-line-right-alignment">Line-right alignment</dfn>
-      <dd>The <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box①⑨">cue box</a>’s right side (for <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction⑦">horizontal</a> cues) or bottom side (otherwise) is aligned at the <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position①⑥">position</a>.
+      <dd>The <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box-20">cue box</a>’s right side (for <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction-8">horizontal</a> cues) or bottom side (otherwise) is aligned at the <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position-17">position</a>.
       <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT cue position automatic alignment" data-noexport="" id="webvtt-cue-position-automatic-alignment">Auto alignment</dfn>
-      <dd>The <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box②⓪">cue box</a>’s alignment depends on the value of the <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment⑦">text alignment</a> of the cue.
+      <dd>The <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box-21">cue box</a>’s alignment depends on the value of the <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment-8">text alignment</a> of the cue.
      </dl>
-     <p>By default, the <a data-link-type="dfn" href="#webvtt-cue-position-alignment" id="ref-for-webvtt-cue-position-alignment①">position alignment</a> is set to <a data-link-type="dfn" href="#webvtt-cue-position-automatic-alignment" id="ref-for-webvtt-cue-position-automatic-alignment">auto</a>.</p>
-     <p>A <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue⑧">WebVTT cue</a> has a <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="cue computed position alignment" data-noexport="" id="cue-computed-position-alignment">computed position
+     <p>By default, the <a data-link-type="dfn" href="#webvtt-cue-position-alignment" id="ref-for-webvtt-cue-position-alignment-2">position alignment</a> is set to <a data-link-type="dfn" href="#webvtt-cue-position-automatic-alignment" id="ref-for-webvtt-cue-position-automatic-alignment-1">auto</a>.</p>
+     <p>A <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-9">WebVTT cue</a> has a <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="cue computed position alignment" data-noexport="" id="cue-computed-position-alignment">computed position
   alignment</dfn> whose value is that returned by the following algorithm, which is defined in terms
   of other aspects of the cue:</p>
      <ol class="algorithm" data-algorithm="computed position alignment">
       <li>
-       <p>If the <a data-link-type="dfn" href="#webvtt-cue-position-alignment" id="ref-for-webvtt-cue-position-alignment②">WebVTT cue position alignment</a> is not <a data-link-type="dfn" href="#webvtt-cue-position-automatic-alignment" id="ref-for-webvtt-cue-position-automatic-alignment①">auto</a>, then return the value of the <a data-link-type="dfn" href="#webvtt-cue-position-alignment" id="ref-for-webvtt-cue-position-alignment③">WebVTT cue position alignment</a> and abort
+       <p>If the <a data-link-type="dfn" href="#webvtt-cue-position-alignment" id="ref-for-webvtt-cue-position-alignment-3">WebVTT cue position alignment</a> is not <a data-link-type="dfn" href="#webvtt-cue-position-automatic-alignment" id="ref-for-webvtt-cue-position-automatic-alignment-2">auto</a>, then return the value of the <a data-link-type="dfn" href="#webvtt-cue-position-alignment" id="ref-for-webvtt-cue-position-alignment-4">WebVTT cue position alignment</a> and abort
    these steps.</p>
       <li>
-       <p>If the <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment⑧">WebVTT cue text alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-left-alignment" id="ref-for-webvtt-cue-left-alignment②">left</a>,
-   return <a data-link-type="dfn" href="#webvtt-cue-position-line-left-alignment" id="ref-for-webvtt-cue-position-line-left-alignment">line-left</a> and abort these
+       <p>If the <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment-9">WebVTT cue text alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-left-alignment" id="ref-for-webvtt-cue-left-alignment-3">left</a>,
+   return <a data-link-type="dfn" href="#webvtt-cue-position-line-left-alignment" id="ref-for-webvtt-cue-position-line-left-alignment-1">line-left</a> and abort these
    steps.</p>
       <li>
-       <p>If the <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment⑨">WebVTT cue text alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-right-alignment" id="ref-for-webvtt-cue-right-alignment②">right</a>,
-   return <a data-link-type="dfn" href="#webvtt-cue-position-line-right-alignment" id="ref-for-webvtt-cue-position-line-right-alignment">line-right</a> and abort these
+       <p>If the <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment-10">WebVTT cue text alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-right-alignment" id="ref-for-webvtt-cue-right-alignment-3">right</a>,
+   return <a data-link-type="dfn" href="#webvtt-cue-position-line-right-alignment" id="ref-for-webvtt-cue-position-line-right-alignment-1">line-right</a> and abort these
    steps.</p>
       <li>
-       <p>Otherwise, return <a data-link-type="dfn" href="#webvtt-cue-center-alignment" id="ref-for-webvtt-cue-center-alignment①">center</a>.</p>
+       <p>Otherwise, return <a data-link-type="dfn" href="#webvtt-cue-center-alignment" id="ref-for-webvtt-cue-center-alignment-2">center</a>.</p>
      </ol>
-     <p class="note" role="note">Since the <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position①⑦">position</a> always measures from the left
-  of the video (for <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction⑧">horizontal</a> cues) or the top
-  (otherwise), the <a data-link-type="dfn" href="#webvtt-cue-position-alignment" id="ref-for-webvtt-cue-position-alignment④">WebVTT cue position alignment</a> <a data-link-type="dfn" href="#webvtt-cue-position-line-left-alignment" id="ref-for-webvtt-cue-position-line-left-alignment①">line-left</a> value varies between left and top for horizontal and vertical cues.</p>
+     <p class="note" role="note">Since the <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position-18">position</a> always measures from the left
+  of the video (for <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction-9">horizontal</a> cues) or the top
+  (otherwise), the <a data-link-type="dfn" href="#webvtt-cue-position-alignment" id="ref-for-webvtt-cue-position-alignment-5">WebVTT cue position alignment</a> <a data-link-type="dfn" href="#webvtt-cue-position-line-left-alignment" id="ref-for-webvtt-cue-position-line-left-alignment-2">line-left</a> value varies between left and top for horizontal and vertical cues.</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT cue size" data-noexport="" id="webvtt-cue-size">A size</dfn>
     <dd>
-     <p>A number giving the size of the <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box②①">cue box</a>, to be interpreted as a
-  percentage of the video, as defined by the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction⑦">writing
+     <p>A number giving the size of the <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box-22">cue box</a>, to be interpreted as a
+  percentage of the video, as defined by the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-8">writing
   direction</a>.</p>
-     <p>By default, the <a data-link-type="dfn" href="#webvtt-cue-size" id="ref-for-webvtt-cue-size③">WebVTT cue size</a> is set to 100%.</p>
-     <p>If the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction⑧">writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction⑨">horizontal</a>, then the <a data-link-type="dfn" href="#webvtt-cue-size" id="ref-for-webvtt-cue-size④">size</a> percentages are relative to the width of the video, otherwise to the height of the video.</p>
+     <p>By default, the <a data-link-type="dfn" href="#webvtt-cue-size" id="ref-for-webvtt-cue-size-4">WebVTT cue size</a> is set to 100%.</p>
+     <p>If the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-9">writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction-10">horizontal</a>, then the <a data-link-type="dfn" href="#webvtt-cue-size" id="ref-for-webvtt-cue-size-5">size</a> percentages are relative to the width of the video, otherwise to the height of the video.</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT cue text alignment" data-noexport="" id="webvtt-cue-text-alignment">A text alignment</dfn>
     <dd>
-     <p>An alignment for all lines of text within the <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box②②">cue box</a>, in the
-  dimension of the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction⑨">writing direction</a>, one of:</p>
+     <p>An alignment for all lines of text within the <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box-23">cue box</a>, in the
+  dimension of the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-10">writing direction</a>, one of:</p>
      <dl>
       <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT cue start alignment" data-noexport="" id="webvtt-cue-start-alignment">Start alignment</dfn>
       <dd>The text of each line is individually aligned towards the start side of the box, where the
-   start side for that line is determined by using the CSS rules for <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-writing-modes-4/#valdef-unicode-bidi-plaintext" id="ref-for-valdef-unicode-bidi-plaintext">plaintext</a> value of the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi" id="ref-for-propdef-unicode-bidi">unicode-bidi</a> property. <a data-link-type="biblio" href="#biblio-css-writing-modes-3">[CSS-WRITING-MODES-3]</a>
+   start side for that line is determined by using the CSS rules for <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-writing-modes-4/#valdef-unicode-bidi-plaintext">plaintext</a> value of the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi">unicode-bidi</a> property. <a data-link-type="biblio" href="#biblio-css-writing-modes-3">[CSS-WRITING-MODES-3]</a>
       <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT cue center alignment" data-noexport="" id="webvtt-cue-center-alignment">Center alignment</dfn>
       <dd>The text is aligned centered between the box’s start and end sides.
       <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT cue end alignment" data-noexport="" id="webvtt-cue-end-alignment">End alignment</dfn>
       <dd>The text of each line is individually aligned towards the end side of the box, where the end
-   side for that line is determined by using the CSS rules for <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-writing-modes-4/#valdef-unicode-bidi-plaintext" id="ref-for-valdef-unicode-bidi-plaintext①">plaintext</a> value of
-   the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi" id="ref-for-propdef-unicode-bidi①">unicode-bidi</a> property. <a data-link-type="biblio" href="#biblio-css-writing-modes-3">[CSS-WRITING-MODES-3]</a>
+   side for that line is determined by using the CSS rules for <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-writing-modes-4/#valdef-unicode-bidi-plaintext">plaintext</a> value of
+   the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi">unicode-bidi</a> property. <a data-link-type="biblio" href="#biblio-css-writing-modes-3">[CSS-WRITING-MODES-3]</a>
       <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT cue left alignment" data-noexport="" id="webvtt-cue-left-alignment">Left alignment</dfn>
-      <dd>The text is aligned to the box’s left side (for <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction①⓪">horizontal</a> cues) or top side (otherwise).
+      <dd>The text is aligned to the box’s left side (for <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction-11">horizontal</a> cues) or top side (otherwise).
       <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT cue right alignment" data-noexport="" id="webvtt-cue-right-alignment">Right alignment</dfn>
-      <dd>The text is aligned to the box’s right side (for <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction①①">horizontal</a> cues) or bottom side (otherwise).
+      <dd>The text is aligned to the box’s right side (for <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction-12">horizontal</a> cues) or bottom side (otherwise).
      </dl>
-     <p>By default, the <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment①⓪">text alignment</a> is set to <a data-link-type="dfn" href="#webvtt-cue-center-alignment" id="ref-for-webvtt-cue-center-alignment②">center</a>.</p>
+     <p>By default, the <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment-11">text alignment</a> is set to <a data-link-type="dfn" href="#webvtt-cue-center-alignment" id="ref-for-webvtt-cue-center-alignment-3">center</a>.</p>
      <p class="note" role="note">The base direction of each line in a cue (which is used by the Unicode Bidirectional
   Algorithm to determine the order in which to display the characters in the line) is determined by
-  looking up the first strong directional character in each line, using the CSS <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-writing-modes-4/#valdef-unicode-bidi-plaintext" id="ref-for-valdef-unicode-bidi-plaintext②">plaintext</a> algorithm. In the occasional cases where the first strong character on
+  looking up the first strong directional character in each line, using the CSS <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-writing-modes-4/#valdef-unicode-bidi-plaintext">plaintext</a> algorithm. In the occasional cases where the first strong character on
   a line would produce the wrong base direction for that line, the author can use an U+200E
   LEFT-TO-RIGHT MARK or U+200F RIGHT-TO-LEFT MARK character at the start of the line to correct it. <a data-link-type="biblio" href="#biblio-bidi">[BIDI]</a></p>
      <div class="example" id="example-4a66a3ef">
@@ -2302,13 +2301,13 @@ What was his name again?
    (Those characters can be escaped as "<code>&amp;#x2068;</code>" and "<code>&amp;#x2069;</code>",
    respectively.)</p>
      </div>
-     <p class="note" role="note">The default text alignment is <a data-link-type="dfn" href="#webvtt-cue-center-alignment" id="ref-for-webvtt-cue-center-alignment③">center
+     <p class="note" role="note">The default text alignment is <a data-link-type="dfn" href="#webvtt-cue-center-alignment" id="ref-for-webvtt-cue-center-alignment-4">center
   alignment</a> regardless of the base direction of the cue text. To make the text alignment of each
-  line match the base direction of the line (e.g. left for English, right for Hebrew), use <a data-link-type="dfn" href="#webvtt-cue-start-alignment" id="ref-for-webvtt-cue-start-alignment③">start alignment</a>, or <a data-link-type="dfn" href="#webvtt-cue-end-alignment" id="ref-for-webvtt-cue-end-alignment③">end
+  line match the base direction of the line (e.g. left for English, right for Hebrew), use <a data-link-type="dfn" href="#webvtt-cue-start-alignment" id="ref-for-webvtt-cue-start-alignment-4">start alignment</a>, or <a data-link-type="dfn" href="#webvtt-cue-end-alignment" id="ref-for-webvtt-cue-end-alignment-4">end
   alignment</a> for the opposite alignment.</p>
      <div class="example" id="example-73203b99">
       <a class="self-link" href="#example-73203b99"></a> 
-      <p>In this example, <a data-link-type="dfn" href="#webvtt-cue-start-alignment" id="ref-for-webvtt-cue-start-alignment④">start alignment</a> is used. The first
+      <p>In this example, <a data-link-type="dfn" href="#webvtt-cue-start-alignment" id="ref-for-webvtt-cue-start-alignment-5">start alignment</a> is used. The first
    line is left-aligned because the base direction is left-to-right, and the second line is
    right-aligned because the base direction is right-to-left.</p>
 <pre>WEBVTT
@@ -2322,24 +2321,24 @@ Hello!
                                             <samp><bdo dir="ltr">!םולש</bdo></samp>
 </pre>
      </div>
-     <p class="note" role="note">The <a data-link-type="dfn" href="#webvtt-cue-left-alignment" id="ref-for-webvtt-cue-left-alignment③">left alignment</a> and <a data-link-type="dfn" href="#webvtt-cue-right-alignment" id="ref-for-webvtt-cue-right-alignment③">right alignment</a> can be used to left-align or right-align the cue text regardless of
+     <p class="note" role="note">The <a data-link-type="dfn" href="#webvtt-cue-left-alignment" id="ref-for-webvtt-cue-left-alignment-4">left alignment</a> and <a data-link-type="dfn" href="#webvtt-cue-right-alignment" id="ref-for-webvtt-cue-right-alignment-4">right alignment</a> can be used to left-align or right-align the cue text regardless of
   its lines' base direction.</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT cue region" data-noexport="" id="webvtt-cue-region">A region</dfn>
     <dd>
-     <p>An optional <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region①">WebVTT region</a> to which a cue belongs.</p>
-     <p>By default, the <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region②">region</a> is set to null.</p>
+     <p>An optional <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region-2">WebVTT region</a> to which a cue belongs.</p>
+     <p>By default, the <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region-3">region</a> is set to null.</p>
    </dl>
-   <p>The associated <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#rules-for-updating-the-text-track-rendering" id="ref-for-rules-for-updating-the-text-track-rendering">rules for updating the text track rendering</a> of <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue⑨">WebVTT
-cues</a> are the <a data-link-type="dfn" href="#rules-for-updating-the-display-of-webvtt-text-tracks" id="ref-for-rules-for-updating-the-display-of-webvtt-text-tracks">rules for updating the display of WebVTT text tracks</a>.</p>
+   <p>The associated <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#rules-for-updating-the-text-track-rendering">rules for updating the text track rendering</a> of <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-10">WebVTT
+cues</a> are the <a data-link-type="dfn" href="#rules-for-updating-the-display-of-webvtt-text-tracks" id="ref-for-rules-for-updating-the-display-of-webvtt-text-tracks-1">rules for updating the display of WebVTT text tracks</a>.</p>
    <div class="impl">
-    <p>When a <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue①⓪">WebVTT cue</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-active-flag" id="ref-for-text-track-cue-active-flag">active flag</a> is set has its <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction①⓪">writing direction</a>, <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag⑦">snap-to-lines flag</a>, <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line①⑨">line</a>, <a data-link-type="dfn" href="#webvtt-cue-line-alignment" id="ref-for-webvtt-cue-line-alignment③">line alignment</a>, <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position①⑧">position</a>, <a data-link-type="dfn" href="#webvtt-cue-position-alignment" id="ref-for-webvtt-cue-position-alignment⑤">position alignment</a>, <a data-link-type="dfn" href="#webvtt-cue-size" id="ref-for-webvtt-cue-size⑤">size</a>, <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment①①">text alignment</a>, <a data-link-type="dfn" href="#webvtt-cue-region" id="ref-for-webvtt-cue-region">region</a>, or <a data-link-type="dfn" href="#text-track-cue-text" id="ref-for-text-track-cue-text">text</a> change value, then the user agent must empty the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-display-state" id="ref-for-text-track-cue-display-state">text track cue display
- state</a>, and then immediately run the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track" id="ref-for-text-track⑦">text track</a>’s <a data-link-type="dfn" href="#rules-for-updating-the-display-of-webvtt-text-tracks" id="ref-for-rules-for-updating-the-display-of-webvtt-text-tracks①">rules for updating the display of
+    <p>When a <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-11">WebVTT cue</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-active-flag">active flag</a> is set has its <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-11">writing direction</a>, <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag-8">snap-to-lines flag</a>, <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line-20">line</a>, <a data-link-type="dfn" href="#webvtt-cue-line-alignment" id="ref-for-webvtt-cue-line-alignment-4">line alignment</a>, <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position-19">position</a>, <a data-link-type="dfn" href="#webvtt-cue-position-alignment" id="ref-for-webvtt-cue-position-alignment-6">position alignment</a>, <a data-link-type="dfn" href="#webvtt-cue-size" id="ref-for-webvtt-cue-size-6">size</a>, <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment-12">text alignment</a>, <a data-link-type="dfn" href="#webvtt-cue-region" id="ref-for-webvtt-cue-region-1">region</a>, or <a data-link-type="dfn" href="#text-track-cue-text" id="ref-for-text-track-cue-text-1">text</a> change value, then the user agent must empty the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-display-state">text track cue display
+ state</a>, and then immediately run the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track">text track</a>’s <a data-link-type="dfn" href="#rules-for-updating-the-display-of-webvtt-text-tracks" id="ref-for-rules-for-updating-the-display-of-webvtt-text-tracks-2">rules for updating the display of
  WebVTT text tracks</a>.</p>
    </div>
    <h3 class="heading settled" data-level="3.2" id="regions"><span class="secno">3.2. </span><span class="content">WebVTT regions</span><a class="self-link" href="#regions"></a></h3>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-region">WebVTT region</dfn> represents a subpart of the video viewport and provides a rendering
-area for <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue①①">WebVTT cues</a>.</p>
-   <p>Each <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region③">WebVTT region</a> consists of:</p>
+area for <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-12">WebVTT cues</a>.</p>
+   <p>Each <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region-4">WebVTT region</a> consists of:</p>
    <dl>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT region identifier" data-noexport="" id="webvtt-region-identifier">An identifier</dfn>
     <dd>
@@ -2392,12 +2391,12 @@ area for <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue①①
    <dl>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="text track list of regions" data-noexport="" id="text-track-list-of-regions">A text track list of regions</dfn>
     <dd>
-     <p>A list of zero or more <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region④">WebVTT regions</a>.</p>
+     <p>A list of zero or more <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region-5">WebVTT regions</a>.</p>
    </dl>
    <h2 class="heading settled" data-level="4" id="syntax"><span class="secno">4. </span><span class="content">Syntax</span><a class="self-link" href="#syntax"></a></h2>
    <h3 class="heading settled" data-level="4.1" id="file-structure"><span class="secno">4.1. </span><span class="content">WebVTT file structure</span><a class="self-link" href="#file-structure"></a></h3>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-file">WebVTT file</dfn> must consist of a <a data-link-type="dfn" href="#webvtt-file-body" id="ref-for-webvtt-file-body">WebVTT file body</a> encoded as UTF-8 and labeled
-with the <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#mime-type" id="ref-for-mime-type">MIME type</a> <code>text/vtt</code>. <a data-link-type="biblio" href="#biblio-rfc3629">[RFC3629]</a></p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-file">WebVTT file</dfn> must consist of a <a data-link-type="dfn" href="#webvtt-file-body" id="ref-for-webvtt-file-body-1">WebVTT file body</a> encoded as UTF-8 and labeled
+with the <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#mime-type">MIME type</a> <code>text/vtt</code>. <a data-link-type="biblio" href="#biblio-rfc3629">[RFC3629]</a></p>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-file-body">WebVTT file body</dfn> consists of the following components, in the following order:</p>
    <ol class="algorithm">
     <li>An optional U+FEFF BYTE ORDER MARK (BOM) character.
@@ -2405,14 +2404,14 @@ with the <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#mime-t
     <li>Optionally, either a U+0020 SPACE character or a U+0009 CHARACTER TABULATION (tab) character
  followed by any number of characters that are not U+000A LINE FEED (LF) or U+000D CARRIAGE RETURN
  (CR) characters.
-    <li>Two or more <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator">WebVTT line terminators</a> to terminate the line
+    <li>Two or more <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator-1">WebVTT line terminators</a> to terminate the line
  with the file magic and separate it from the rest of the body.
-    <li>Zero or more <a data-link-type="dfn" href="#webvtt-region-definition-block" id="ref-for-webvtt-region-definition-block">WebVTT region definition blocks</a>, <a data-link-type="dfn" href="#webvtt-style-block" id="ref-for-webvtt-style-block">WebVTT style blocks</a> and <a data-link-type="dfn" href="#webvtt-comment-block" id="ref-for-webvtt-comment-block">WebVTT comment
- blocks</a> separated from each other by one or more <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator①">WebVTT line
+    <li>Zero or more <a data-link-type="dfn" href="#webvtt-region-definition-block" id="ref-for-webvtt-region-definition-block-1">WebVTT region definition blocks</a>, <a data-link-type="dfn" href="#webvtt-style-block" id="ref-for-webvtt-style-block-1">WebVTT style blocks</a> and <a data-link-type="dfn" href="#webvtt-comment-block" id="ref-for-webvtt-comment-block-1">WebVTT comment
+ blocks</a> separated from each other by one or more <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator-2">WebVTT line
  terminators</a>.
-    <li>Zero or more <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator②">WebVTT line terminators</a>.
-    <li>Zero or more <a data-link-type="dfn" href="#webvtt-cue-block" id="ref-for-webvtt-cue-block">WebVTT cue blocks</a> and <a data-link-type="dfn" href="#webvtt-comment-block" id="ref-for-webvtt-comment-block①">WebVTT comment blocks</a> separated from each other by one or more <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator③">WebVTT line terminators</a>.
-    <li>Zero or more <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator④">WebVTT line terminators</a>.
+    <li>Zero or more <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator-3">WebVTT line terminators</a>.
+    <li>Zero or more <a data-link-type="dfn" href="#webvtt-cue-block" id="ref-for-webvtt-cue-block-1">WebVTT cue blocks</a> and <a data-link-type="dfn" href="#webvtt-comment-block" id="ref-for-webvtt-comment-block-2">WebVTT comment blocks</a> separated from each other by one or more <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator-4">WebVTT line terminators</a>.
+    <li>Zero or more <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator-5">WebVTT line terminators</a>.
    </ol>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-line-terminator">WebVTT line terminator</dfn> consists of one of the following:</p>
    <ul class="brief">
@@ -2427,86 +2426,86 @@ order:</p>
  U+0047 LATIN CAPITAL LETTER G, U+0049 LATIN CAPITAL LETTER I, U+004F LATIN CAPITAL LETTER O, U+004E
  LATIN CAPITAL LETTER N).
     <li>Zero or more U+0020 SPACE characters or U+0009 CHARACTER TABULATION (tab) characters.
-    <li>A <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator⑤">WebVTT line terminator</a>.
-    <li>A <a data-link-type="dfn" href="#webvtt-region-settings-list" id="ref-for-webvtt-region-settings-list">WebVTT region settings list</a>.
-    <li>A <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator⑥">WebVTT line terminator</a>.
+    <li>A <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator-6">WebVTT line terminator</a>.
+    <li>A <a data-link-type="dfn" href="#webvtt-region-settings-list" id="ref-for-webvtt-region-settings-list-1">WebVTT region settings list</a>.
+    <li>A <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator-7">WebVTT line terminator</a>.
    </ol>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-style-block">WebVTT style block</dfn> consists of the following components, in the given order:</p>
    <ol>
     <li>The string "<code>STYLE</code>" (U+0053 LATIN CAPITAL LETTER S, U+0054 LATIN CAPITAL LETTER T,
  U+0059 LATIN CAPITAL LETTER Y, U+004C LATIN CAPITAL LETTER L, U+0045 LATIN CAPITAL LETTER E).
     <li>Zero or more U+0020 SPACE characters or U+0009 CHARACTER TABULATION (tab) characters.
-    <li>A <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator⑦">WebVTT line terminator</a>.
+    <li>A <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator-8">WebVTT line terminator</a>.
     <li>Any sequence of zero or more characters other than U+000A LINE FEED (LF) characters and U+000D
- CARRIAGE RETURN (CR) characters, each optionally separated from the next by a <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator⑧">WebVTT line
+ CARRIAGE RETURN (CR) characters, each optionally separated from the next by a <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator-9">WebVTT line
  terminator</a>, except that the entire resulting string must not contain the substring
  "<code>--></code>" (U+002D HYPHEN-MINUS, U+002D HYPHEN-MINUS, U+003E GREATER-THAN SIGN). The string
  represents a CSS style sheet; the requirements given in the relevant CSS specifications apply. <a data-link-type="biblio" href="#biblio-css22">[CSS22]</a>
-    <li>A <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator⑨">WebVTT line terminator</a>.
+    <li>A <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator-10">WebVTT line terminator</a>.
    </ol>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue-block">WebVTT cue block</dfn> consists of the following components, in the given order:</p>
    <ol>
-    <li>Optionally, a <a data-link-type="dfn" href="#webvtt-cue-identifier" id="ref-for-webvtt-cue-identifier">WebVTT cue identifier</a> followed by a <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator①⓪">WebVTT line terminator</a>.
-    <li><a data-link-type="dfn" href="#webvtt-cue-timings" id="ref-for-webvtt-cue-timings">WebVTT cue timings</a>.
+    <li>Optionally, a <a data-link-type="dfn" href="#webvtt-cue-identifier" id="ref-for-webvtt-cue-identifier-1">WebVTT cue identifier</a> followed by a <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator-11">WebVTT line terminator</a>.
+    <li><a data-link-type="dfn" href="#webvtt-cue-timings" id="ref-for-webvtt-cue-timings-1">WebVTT cue timings</a>.
     <li>Optionally, one or more U+0020 SPACE characters or U+0009 CHARACTER TABULATION (tab) characters
- followed by a <a data-link-type="dfn" href="#webvtt-cue-settings-list" id="ref-for-webvtt-cue-settings-list">WebVTT cue settings list</a>.
-    <li>A <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator①①">WebVTT line terminator</a>.
-    <li>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="cue-payload">cue payload</dfn>: either <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text①">WebVTT cue text</a>, <a data-link-type="dfn" href="#webvtt-chapter-title-text" id="ref-for-webvtt-chapter-title-text">WebVTT chapter title text</a>, or <a data-link-type="dfn" href="#webvtt-metadata-text" id="ref-for-webvtt-metadata-text">WebVTT metadata text</a>, but it must not contain the substring "<code>--></code>" (U+002D
+ followed by a <a data-link-type="dfn" href="#webvtt-cue-settings-list" id="ref-for-webvtt-cue-settings-list-1">WebVTT cue settings list</a>.
+    <li>A <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator-12">WebVTT line terminator</a>.
+    <li>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="cue-payload">cue payload</dfn>: either <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-2">WebVTT cue text</a>, <a data-link-type="dfn" href="#webvtt-chapter-title-text" id="ref-for-webvtt-chapter-title-text-1">WebVTT chapter title text</a>, or <a data-link-type="dfn" href="#webvtt-metadata-text" id="ref-for-webvtt-metadata-text-1">WebVTT metadata text</a>, but it must not contain the substring "<code>--></code>" (U+002D
  HYPHEN-MINUS, U+002D HYPHEN-MINUS, U+003E GREATER-THAN SIGN).
-    <li>A <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator①②">WebVTT line terminator</a>.
+    <li>A <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator-13">WebVTT line terminator</a>.
    </ol>
-   <p class="note" role="note">A <a data-link-type="dfn" href="#webvtt-cue-block" id="ref-for-webvtt-cue-block①">WebVTT cue block</a> corresponds to one piece of time-aligned text or data in
-the <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file⑥">WebVTT file</a>, for example one subtitle. The <a data-link-type="dfn" href="#cue-payload" id="ref-for-cue-payload">cue payload</a> is the text or data
+   <p class="note" role="note">A <a data-link-type="dfn" href="#webvtt-cue-block" id="ref-for-webvtt-cue-block-2">WebVTT cue block</a> corresponds to one piece of time-aligned text or data in
+the <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file-7">WebVTT file</a>, for example one subtitle. The <a data-link-type="dfn" href="#cue-payload" id="ref-for-cue-payload-1">cue payload</a> is the text or data
 associated with the cue.</p>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue-identifier">WebVTT cue identifier</dfn> is any sequence of one or more characters not containing the
 substring "<code>--></code>" (U+002D HYPHEN-MINUS, U+002D HYPHEN-MINUS, U+003E GREATER-THAN SIGN),
 nor containing any U+000A LINE FEED (LF) characters or U+000D CARRIAGE RETURN (CR) characters.</p>
-   <p>A <a data-link-type="dfn" href="#webvtt-cue-identifier" id="ref-for-webvtt-cue-identifier①">WebVTT cue identifier</a> must be unique amongst all the <a data-link-type="dfn" href="#webvtt-cue-identifier" id="ref-for-webvtt-cue-identifier②">WebVTT cue identifiers</a> of all <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue①②">WebVTT cues</a> of a <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file⑦">WebVTT
+   <p>A <a data-link-type="dfn" href="#webvtt-cue-identifier" id="ref-for-webvtt-cue-identifier-2">WebVTT cue identifier</a> must be unique amongst all the <a data-link-type="dfn" href="#webvtt-cue-identifier" id="ref-for-webvtt-cue-identifier-3">WebVTT cue identifiers</a> of all <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-13">WebVTT cues</a> of a <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file-8">WebVTT
 file</a>.</p>
-   <p class="note" role="note">A <a data-link-type="dfn" href="#webvtt-cue-identifier" id="ref-for-webvtt-cue-identifier③">WebVTT cue identifier</a> can be used to reference a specific cue, for example
+   <p class="note" role="note">A <a data-link-type="dfn" href="#webvtt-cue-identifier" id="ref-for-webvtt-cue-identifier-4">WebVTT cue identifier</a> can be used to reference a specific cue, for example
 from script or CSS.</p>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue-timings">WebVTT cue timings</dfn> part of a <a data-link-type="dfn" href="#webvtt-cue-block" id="ref-for-webvtt-cue-block②">WebVTT cue block</a> consists of the following
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue-timings">WebVTT cue timings</dfn> part of a <a data-link-type="dfn" href="#webvtt-cue-block" id="ref-for-webvtt-cue-block-3">WebVTT cue block</a> consists of the following
 components, in the given order:</p>
    <ol>
-    <li>A <a data-link-type="dfn" href="#webvtt-timestamp" id="ref-for-webvtt-timestamp">WebVTT timestamp</a> representing the start time offset of the cue. The time represented
- by this <a data-link-type="dfn" href="#webvtt-timestamp" id="ref-for-webvtt-timestamp①">WebVTT timestamp</a> must be greater than or equal to the start time offsets of all
+    <li>A <a data-link-type="dfn" href="#webvtt-timestamp" id="ref-for-webvtt-timestamp-1">WebVTT timestamp</a> representing the start time offset of the cue. The time represented
+ by this <a data-link-type="dfn" href="#webvtt-timestamp" id="ref-for-webvtt-timestamp-2">WebVTT timestamp</a> must be greater than or equal to the start time offsets of all
  previous cues in the file.
     <li>One or more U+0020 SPACE characters or U+0009 CHARACTER TABULATION (tab) characters.
     <li>The string "<code>--></code>" (U+002D HYPHEN-MINUS, U+002D HYPHEN-MINUS, U+003E GREATER-THAN
  SIGN).
     <li>One or more U+0020 SPACE characters or U+0009 CHARACTER TABULATION (tab) characters.
-    <li>A <a data-link-type="dfn" href="#webvtt-timestamp" id="ref-for-webvtt-timestamp②">WebVTT timestamp</a> representing the end time offset of the cue. The time represented by
- this <a data-link-type="dfn" href="#webvtt-timestamp" id="ref-for-webvtt-timestamp③">WebVTT timestamp</a> must be greater than the start time offset of the cue.
+    <li>A <a data-link-type="dfn" href="#webvtt-timestamp" id="ref-for-webvtt-timestamp-3">WebVTT timestamp</a> representing the end time offset of the cue. The time represented by
+ this <a data-link-type="dfn" href="#webvtt-timestamp" id="ref-for-webvtt-timestamp-4">WebVTT timestamp</a> must be greater than the start time offset of the cue.
    </ol>
-   <p class="note" role="note">The <a data-link-type="dfn" href="#webvtt-cue-timings" id="ref-for-webvtt-cue-timings①">WebVTT cue timings</a> give the start and end offsets of the <a data-link-type="dfn" href="#webvtt-cue-block" id="ref-for-webvtt-cue-block③">WebVTT cue
+   <p class="note" role="note">The <a data-link-type="dfn" href="#webvtt-cue-timings" id="ref-for-webvtt-cue-timings-2">WebVTT cue timings</a> give the start and end offsets of the <a data-link-type="dfn" href="#webvtt-cue-block" id="ref-for-webvtt-cue-block-4">WebVTT cue
 block</a>. Different cues can overlap. Cues are always listed ordered by their start time.</p>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-timestamp">WebVTT timestamp</dfn> consists of the following components, in the given order:</p>
    <ol>
     <li>
       Optionally (required if <var>hours</var> is non-zero): 
      <ol>
-      <li>Two or more <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits" id="ref-for-ascii-digits">ASCII digits</a>, representing the <var>hours</var> as a base ten integer.
+      <li>Two or more <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits">ASCII digits</a>, representing the <var>hours</var> as a base ten integer.
       <li>A U+003A COLON character (:)
      </ol>
-    <li>Two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits" id="ref-for-ascii-digits①">ASCII digits</a>, representing the <var>minutes</var> as a base ten integer in the range
+    <li>Two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits">ASCII digits</a>, representing the <var>minutes</var> as a base ten integer in the range
  0 ≤ <var>minutes</var> ≤ 59.
     <li>A U+003A COLON character (:)
-    <li>Two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits" id="ref-for-ascii-digits②">ASCII digits</a>, representing the <var>seconds</var> as a base ten integer in the range
+    <li>Two <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits">ASCII digits</a>, representing the <var>seconds</var> as a base ten integer in the range
  0 ≤ <var>seconds</var> ≤ 59.
     <li>A U+002E FULL STOP character (.).
-    <li>Three <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits" id="ref-for-ascii-digits③">ASCII digits</a>, representing the thousandths of a second <var>seconds-frac</var> as a base
+    <li>Three <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits">ASCII digits</a>, representing the thousandths of a second <var>seconds-frac</var> as a base
  ten integer.
    </ol>
-   <p class="note" role="note">A <a data-link-type="dfn" href="#webvtt-timestamp" id="ref-for-webvtt-timestamp④">WebVTT timestamp</a> is always interpreted relative to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#current-playback-position" id="ref-for-current-playback-position">current playback
+   <p class="note" role="note">A <a data-link-type="dfn" href="#webvtt-timestamp" id="ref-for-webvtt-timestamp-5">WebVTT timestamp</a> is always interpreted relative to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#current-playback-position">current playback
 position</a> of the media data that the WebVTT file is to be synchronized with.</p>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue-settings-list">WebVTT cue settings list</dfn> consist of a sequence of zero or more <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT cue
 setting" data-noexport="" id="webvtt-cue-setting">WebVTT cue settings</dfn> in any order, separated from each other by one or more U+0020
 SPACE characters or U+0009 CHARACTER TABULATION (tab) characters. Each setting consists of the
 following components, in the order given:</p>
    <ol>
-    <li>A <a data-link-type="dfn" href="#webvtt-cue-setting-name" id="ref-for-webvtt-cue-setting-name">WebVTT cue setting name</a>.
+    <li>A <a data-link-type="dfn" href="#webvtt-cue-setting-name" id="ref-for-webvtt-cue-setting-name-1">WebVTT cue setting name</a>.
     <li>An optional U+003A COLON (colon) character.
-    <li>An optional <a data-link-type="dfn" href="#webvtt-cue-setting-value" id="ref-for-webvtt-cue-setting-value">WebVTT cue setting value</a>.
+    <li>An optional <a data-link-type="dfn" href="#webvtt-cue-setting-value" id="ref-for-webvtt-cue-setting-value-1">WebVTT cue setting value</a>.
    </ol>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue-setting-name">WebVTT cue setting name</dfn> and a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue-setting-value">WebVTT cue setting value</dfn> each consist of
 any sequence of one or more characters other than U+000A LINE FEED (LF) characters and - U+000D
@@ -2515,16 +2514,16 @@ substring "<code>--></code>" (U+002D HYPHEN-MINUS, U+002D HYPHEN-MINUS, U+003E G
 SIGN).</p>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-percentage">WebVTT percentage</dfn> consists of the following components:</p>
    <ol>
-    <li>One or more <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits" id="ref-for-ascii-digits④">ASCII digits</a>.
+    <li>One or more <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits">ASCII digits</a>.
     <li>
       Optionally: 
      <ol>
       <li>A U+002E DOT character (.).
-      <li>One or more <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits" id="ref-for-ascii-digits⑤">ASCII digits</a>.
+      <li>One or more <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits">ASCII digits</a>.
      </ol>
     <li>A U+0025 PERCENT SIGN character (%).
    </ol>
-   <p>When interpreted as a number, a <a data-link-type="dfn" href="#webvtt-percentage" id="ref-for-webvtt-percentage">WebVTT percentage</a> must be in the range 0..100.</p>
+   <p>When interpreted as a number, a <a data-link-type="dfn" href="#webvtt-percentage" id="ref-for-webvtt-percentage-1">WebVTT percentage</a> must be in the range 0..100.</p>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-comment-block">WebVTT comment block</dfn> consists of the following components, in the given order:</p>
    <ol>
     <li>The string "<code>NOTE</code>".
@@ -2535,71 +2534,71 @@ SIGN).</p>
         Either: 
        <ul>
         <li>A U+0020 SPACE character or U+0009 CHARACTER TABULATION (tab) character.
-        <li>A <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator①③">WebVTT line terminator</a>.
+        <li>A <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator-14">WebVTT line terminator</a>.
        </ul>
       <li>Any sequence of zero or more characters other than U+000A LINE FEED (LF) characters and
-   U+000D CARRIAGE RETURN (CR) characters, each optionally separated from the next by a <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator①④">WebVTT
+   U+000D CARRIAGE RETURN (CR) characters, each optionally separated from the next by a <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator-15">WebVTT
    line terminator</a>, except that the entire resulting string must not contain the substring
    "<code>--></code>" (U+002D HYPHEN-MINUS, U+002D HYPHEN-MINUS, U+003E GREATER-THAN SIGN).
      </ol>
-    <li>A <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator①⑤">WebVTT line terminator</a>.
+    <li>A <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator-16">WebVTT line terminator</a>.
    </ol>
-   <p class="note" role="note">A <a data-link-type="dfn" href="#webvtt-comment-block" id="ref-for-webvtt-comment-block②">WebVTT comment block</a> is ignored by the parser.</p>
+   <p class="note" role="note">A <a data-link-type="dfn" href="#webvtt-comment-block" id="ref-for-webvtt-comment-block-3">WebVTT comment block</a> is ignored by the parser.</p>
    <h3 class="heading settled" data-level="4.2" id="types-of-webvtt-cue-payload"><span class="secno">4.2. </span><span class="content">Types of WebVTT cue payload</span><a class="self-link" href="#types-of-webvtt-cue-payload"></a></h3>
    <h4 class="heading settled" data-level="4.2.1" id="metadata-text"><span class="secno">4.2.1. </span><span class="content">WebVTT metadata text</span><a class="self-link" href="#metadata-text"></a></h4>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-metadata-text">WebVTT metadata text</dfn> consists of any sequence of zero or more characters other than
 U+000A LINE FEED (LF) characters and U+000D CARRIAGE RETURN (CR) characters, each optionally
-separated from the next by a <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator①⑥">WebVTT line terminator</a>. (In other words, any text that does not
-have two consecutive <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator①⑦">WebVTT line terminators</a> and does not start
-or end with a <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator①⑧">WebVTT line terminator</a>.)</p>
-   <p><a data-link-type="dfn" href="#webvtt-metadata-text" id="ref-for-webvtt-metadata-text①">WebVTT metadata text</a> cues are only useful for scripted applications (using the <code>metadata</code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-kind" id="ref-for-text-track-kind">text track kind</a>).</p>
+separated from the next by a <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator-17">WebVTT line terminator</a>. (In other words, any text that does not
+have two consecutive <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator-18">WebVTT line terminators</a> and does not start
+or end with a <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator-19">WebVTT line terminator</a>.)</p>
+   <p><a data-link-type="dfn" href="#webvtt-metadata-text" id="ref-for-webvtt-metadata-text-2">WebVTT metadata text</a> cues are only useful for scripted applications (using the <code>metadata</code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-kind">text track kind</a>).</p>
    <h4 class="heading settled" data-level="4.2.2" id="cue-text"><span class="secno">4.2.2. </span><span class="content">WebVTT cue text</span><a class="self-link" href="#cue-text"></a></h4>
-   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue-text">WebVTT cue text</dfn> is <a data-link-type="dfn" href="#cue-payload" id="ref-for-cue-payload①">cue payload</a> that consists of zero or more <a data-link-type="dfn" href="#webvtt-cue-components" id="ref-for-webvtt-cue-components">WebVTT cue
-components</a>, in any order, each optionally separated from the next by a <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator①⑨">WebVTT line
+   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue-text">WebVTT cue text</dfn> is <a data-link-type="dfn" href="#cue-payload" id="ref-for-cue-payload-2">cue payload</a> that consists of zero or more <a data-link-type="dfn" href="#webvtt-cue-components" id="ref-for-webvtt-cue-components-1">WebVTT cue
+components</a>, in any order, each optionally separated from the next by a <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator-20">WebVTT line
 terminator</a>.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue-components">WebVTT cue components</dfn> are:</p>
    <ul>
-    <li>A <a data-link-type="dfn" href="#webvtt-cue-class-span" id="ref-for-webvtt-cue-class-span">WebVTT cue class span</a>.
-    <li>A <a data-link-type="dfn" href="#webvtt-cue-italics-span" id="ref-for-webvtt-cue-italics-span">WebVTT cue italics span</a>.
-    <li>A <a data-link-type="dfn" href="#webvtt-cue-bold-span" id="ref-for-webvtt-cue-bold-span">WebVTT cue bold span</a>.
-    <li>A <a data-link-type="dfn" href="#webvtt-cue-underline-span" id="ref-for-webvtt-cue-underline-span">WebVTT cue underline span</a>.
-    <li>A <a data-link-type="dfn" href="#webvtt-cue-ruby-span" id="ref-for-webvtt-cue-ruby-span">WebVTT cue ruby span</a>.
-    <li>A <a data-link-type="dfn" href="#webvtt-cue-voice-span" id="ref-for-webvtt-cue-voice-span">WebVTT cue voice span</a>.
-    <li>A <a data-link-type="dfn" href="#webvtt-cue-language-span" id="ref-for-webvtt-cue-language-span">WebVTT cue language span</a>.
-    <li>A <a data-link-type="dfn" href="#webvtt-cue-timestamp" id="ref-for-webvtt-cue-timestamp">WebVTT cue timestamp</a>.
-    <li>A <a data-link-type="dfn" href="#webvtt-cue-text-span" id="ref-for-webvtt-cue-text-span">WebVTT cue text span</a>, representing the text of the cue.
-    <li>An <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/syntax.html#syntax-charref" id="ref-for-syntax-charref">HTML character reference</a>, representing one or two Unicode
+    <li>A <a data-link-type="dfn" href="#webvtt-cue-class-span" id="ref-for-webvtt-cue-class-span-1">WebVTT cue class span</a>.
+    <li>A <a data-link-type="dfn" href="#webvtt-cue-italics-span" id="ref-for-webvtt-cue-italics-span-1">WebVTT cue italics span</a>.
+    <li>A <a data-link-type="dfn" href="#webvtt-cue-bold-span" id="ref-for-webvtt-cue-bold-span-1">WebVTT cue bold span</a>.
+    <li>A <a data-link-type="dfn" href="#webvtt-cue-underline-span" id="ref-for-webvtt-cue-underline-span-1">WebVTT cue underline span</a>.
+    <li>A <a data-link-type="dfn" href="#webvtt-cue-ruby-span" id="ref-for-webvtt-cue-ruby-span-1">WebVTT cue ruby span</a>.
+    <li>A <a data-link-type="dfn" href="#webvtt-cue-voice-span" id="ref-for-webvtt-cue-voice-span-1">WebVTT cue voice span</a>.
+    <li>A <a data-link-type="dfn" href="#webvtt-cue-language-span" id="ref-for-webvtt-cue-language-span-1">WebVTT cue language span</a>.
+    <li>A <a data-link-type="dfn" href="#webvtt-cue-timestamp" id="ref-for-webvtt-cue-timestamp-1">WebVTT cue timestamp</a>.
+    <li>A <a data-link-type="dfn" href="#webvtt-cue-text-span" id="ref-for-webvtt-cue-text-span-1">WebVTT cue text span</a>, representing the text of the cue.
+    <li>An <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/syntax.html#syntax-charref">HTML character reference</a>, representing one or two Unicode
  code points, as defined in HTML, in the text of the cue. <a data-link-type="biblio" href="#biblio-html">[HTML]</a>
    </ul>
-   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue-internal-text">WebVTT cue internal text</dfn> consists of an optional <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator②⓪">WebVTT line terminator</a>,
-followed by zero or more <a data-link-type="dfn" href="#webvtt-cue-components" id="ref-for-webvtt-cue-components①">WebVTT cue components</a>, in any order, each optionally followed by a <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator②①">WebVTT line terminator</a>.</p>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue-class-span">WebVTT cue class span</dfn> consists of a <a data-link-type="dfn" href="#webvtt-cue-span-start-tag" id="ref-for-webvtt-cue-span-start-tag">WebVTT cue span start tag</a> "<code>c</code>" that disallows an annotation, <a data-link-type="dfn" href="#webvtt-cue-internal-text" id="ref-for-webvtt-cue-internal-text">WebVTT cue internal text</a> representing cue
-text, and a <a data-link-type="dfn" href="#webvtt-cue-span-end-tag" id="ref-for-webvtt-cue-span-end-tag">WebVTT cue span end tag</a> "<code>c</code>".</p>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue-italics-span">WebVTT cue italics span</dfn> consists of a <a data-link-type="dfn" href="#webvtt-cue-span-start-tag" id="ref-for-webvtt-cue-span-start-tag①">WebVTT cue span start tag</a> "<code>i</code>" that disallows an annotation, <a data-link-type="dfn" href="#webvtt-cue-internal-text" id="ref-for-webvtt-cue-internal-text①">WebVTT cue internal text</a> representing the
-italicized text, and a <a data-link-type="dfn" href="#webvtt-cue-span-end-tag" id="ref-for-webvtt-cue-span-end-tag①">WebVTT cue span end tag</a> "<code>i</code>".</p>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue-bold-span">WebVTT cue bold span</dfn> consists of a <a data-link-type="dfn" href="#webvtt-cue-span-start-tag" id="ref-for-webvtt-cue-span-start-tag②">WebVTT cue span start tag</a> "<code>b</code>"
-that disallows an annotation, <a data-link-type="dfn" href="#webvtt-cue-internal-text" id="ref-for-webvtt-cue-internal-text②">WebVTT cue internal text</a> representing the boldened text, and a <a data-link-type="dfn" href="#webvtt-cue-span-end-tag" id="ref-for-webvtt-cue-span-end-tag②">WebVTT cue span end tag</a> "<code>b</code>".</p>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue-underline-span">WebVTT cue underline span</dfn> consists of a <a data-link-type="dfn" href="#webvtt-cue-span-start-tag" id="ref-for-webvtt-cue-span-start-tag③">WebVTT cue span start tag</a> "<code>u</code>" that disallows an annotation, <a data-link-type="dfn" href="#webvtt-cue-internal-text" id="ref-for-webvtt-cue-internal-text③">WebVTT cue internal text</a> representing the
-underlined text, and a <a data-link-type="dfn" href="#webvtt-cue-span-end-tag" id="ref-for-webvtt-cue-span-end-tag③">WebVTT cue span end tag</a> "<code>u</code>".</p>
+   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue-internal-text">WebVTT cue internal text</dfn> consists of an optional <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator-21">WebVTT line terminator</a>,
+followed by zero or more <a data-link-type="dfn" href="#webvtt-cue-components" id="ref-for-webvtt-cue-components-2">WebVTT cue components</a>, in any order, each optionally followed by a <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator-22">WebVTT line terminator</a>.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue-class-span">WebVTT cue class span</dfn> consists of a <a data-link-type="dfn" href="#webvtt-cue-span-start-tag" id="ref-for-webvtt-cue-span-start-tag-1">WebVTT cue span start tag</a> "<code>c</code>" that disallows an annotation, <a data-link-type="dfn" href="#webvtt-cue-internal-text" id="ref-for-webvtt-cue-internal-text-1">WebVTT cue internal text</a> representing cue
+text, and a <a data-link-type="dfn" href="#webvtt-cue-span-end-tag" id="ref-for-webvtt-cue-span-end-tag-1">WebVTT cue span end tag</a> "<code>c</code>".</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue-italics-span">WebVTT cue italics span</dfn> consists of a <a data-link-type="dfn" href="#webvtt-cue-span-start-tag" id="ref-for-webvtt-cue-span-start-tag-2">WebVTT cue span start tag</a> "<code>i</code>" that disallows an annotation, <a data-link-type="dfn" href="#webvtt-cue-internal-text" id="ref-for-webvtt-cue-internal-text-2">WebVTT cue internal text</a> representing the
+italicized text, and a <a data-link-type="dfn" href="#webvtt-cue-span-end-tag" id="ref-for-webvtt-cue-span-end-tag-2">WebVTT cue span end tag</a> "<code>i</code>".</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue-bold-span">WebVTT cue bold span</dfn> consists of a <a data-link-type="dfn" href="#webvtt-cue-span-start-tag" id="ref-for-webvtt-cue-span-start-tag-3">WebVTT cue span start tag</a> "<code>b</code>"
+that disallows an annotation, <a data-link-type="dfn" href="#webvtt-cue-internal-text" id="ref-for-webvtt-cue-internal-text-3">WebVTT cue internal text</a> representing the boldened text, and a <a data-link-type="dfn" href="#webvtt-cue-span-end-tag" id="ref-for-webvtt-cue-span-end-tag-3">WebVTT cue span end tag</a> "<code>b</code>".</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue-underline-span">WebVTT cue underline span</dfn> consists of a <a data-link-type="dfn" href="#webvtt-cue-span-start-tag" id="ref-for-webvtt-cue-span-start-tag-4">WebVTT cue span start tag</a> "<code>u</code>" that disallows an annotation, <a data-link-type="dfn" href="#webvtt-cue-internal-text" id="ref-for-webvtt-cue-internal-text-4">WebVTT cue internal text</a> representing the
+underlined text, and a <a data-link-type="dfn" href="#webvtt-cue-span-end-tag" id="ref-for-webvtt-cue-span-end-tag-4">WebVTT cue span end tag</a> "<code>u</code>".</p>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue-ruby-span">WebVTT cue ruby span</dfn> consists of the following components, in the order given:</p>
    <ol>
-    <li>A <a data-link-type="dfn" href="#webvtt-cue-span-start-tag" id="ref-for-webvtt-cue-span-start-tag④">WebVTT cue span start tag</a> "<code>ruby</code>" that disallows an annotation.
+    <li>A <a data-link-type="dfn" href="#webvtt-cue-span-start-tag" id="ref-for-webvtt-cue-span-start-tag-5">WebVTT cue span start tag</a> "<code>ruby</code>" that disallows an annotation.
     <li>
       One or more occurrences of the following group of components, in the order given: 
      <ol>
-      <li><a data-link-type="dfn" href="#webvtt-cue-internal-text" id="ref-for-webvtt-cue-internal-text④">WebVTT cue internal text</a>, representing the ruby base.
-      <li>A <a data-link-type="dfn" href="#webvtt-cue-span-start-tag" id="ref-for-webvtt-cue-span-start-tag⑤">WebVTT cue span start tag</a> "<code>rt</code>" that disallows an annotation.
-      <li>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue-ruby-text-span">WebVTT cue ruby text span</dfn>: <a data-link-type="dfn" href="#webvtt-cue-internal-text" id="ref-for-webvtt-cue-internal-text⑤">WebVTT cue internal text</a>, representing the
+      <li><a data-link-type="dfn" href="#webvtt-cue-internal-text" id="ref-for-webvtt-cue-internal-text-5">WebVTT cue internal text</a>, representing the ruby base.
+      <li>A <a data-link-type="dfn" href="#webvtt-cue-span-start-tag" id="ref-for-webvtt-cue-span-start-tag-6">WebVTT cue span start tag</a> "<code>rt</code>" that disallows an annotation.
+      <li>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue-ruby-text-span">WebVTT cue ruby text span</dfn>: <a data-link-type="dfn" href="#webvtt-cue-internal-text" id="ref-for-webvtt-cue-internal-text-6">WebVTT cue internal text</a>, representing the
    ruby text component of the ruby annotation.
-      <li>A <a data-link-type="dfn" href="#webvtt-cue-span-end-tag" id="ref-for-webvtt-cue-span-end-tag④">WebVTT cue span end tag</a> "<code>rt</code>". If this is the last occurrence of this
-   group of components in the <a data-link-type="dfn" href="#webvtt-cue-ruby-span" id="ref-for-webvtt-cue-ruby-span①">WebVTT cue ruby span</a>, then this last end tag string may be
+      <li>A <a data-link-type="dfn" href="#webvtt-cue-span-end-tag" id="ref-for-webvtt-cue-span-end-tag-5">WebVTT cue span end tag</a> "<code>rt</code>". If this is the last occurrence of this
+   group of components in the <a data-link-type="dfn" href="#webvtt-cue-ruby-span" id="ref-for-webvtt-cue-ruby-span-2">WebVTT cue ruby span</a>, then this last end tag string may be
    omitted.
      </ol>
-    <li>If the last end tag string was not omitted: Optionally, a <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator②②">WebVTT line terminator</a>.
+    <li>If the last end tag string was not omitted: Optionally, a <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator-23">WebVTT line terminator</a>.
     <li>If the last end tag string was not omitted: Zero or more U+0020 SPACE characters or U+0009
- CHARACTER TABULATION (tab) characters, each optionally followed by a <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator②③">WebVTT line
+ CHARACTER TABULATION (tab) characters, each optionally followed by a <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator-24">WebVTT line
  terminator</a>.
-    <li>A <a data-link-type="dfn" href="#webvtt-cue-span-end-tag" id="ref-for-webvtt-cue-span-end-tag⑤">WebVTT cue span end tag</a> "<code>ruby</code>".
+    <li>A <a data-link-type="dfn" href="#webvtt-cue-span-end-tag" id="ref-for-webvtt-cue-span-end-tag-6">WebVTT cue span end tag</a> "<code>ruby</code>".
    </ol>
    <p class="note" role="note">Cue positioning controls the positioning of the baseline text, not the ruby
 text.</p>
@@ -2608,21 +2607,21 @@ the future to also support an object for ruby base text as well as complex ruby,
 are more mature in HTML and CSS. <a data-link-type="biblio" href="#biblio-html">[HTML]</a> <a data-link-type="biblio" href="#biblio-css3-ruby">[CSS3-RUBY]</a></p>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue-voice-span">WebVTT cue voice span</dfn> consists of the following components, in the order given:</p>
    <ol>
-    <li>A <a data-link-type="dfn" href="#webvtt-cue-span-start-tag" id="ref-for-webvtt-cue-span-start-tag⑥">WebVTT cue span start tag</a> "<code>v</code>" that requires an annotation; the annotation
+    <li>A <a data-link-type="dfn" href="#webvtt-cue-span-start-tag" id="ref-for-webvtt-cue-span-start-tag-7">WebVTT cue span start tag</a> "<code>v</code>" that requires an annotation; the annotation
  represents the name of the voice.
-    <li><a data-link-type="dfn" href="#webvtt-cue-internal-text" id="ref-for-webvtt-cue-internal-text⑥">WebVTT cue internal text</a>.
-    <li>A <a data-link-type="dfn" href="#webvtt-cue-span-end-tag" id="ref-for-webvtt-cue-span-end-tag⑥">WebVTT cue span end tag</a> "<code>v</code>". If this <a data-link-type="dfn" href="#webvtt-cue-voice-span" id="ref-for-webvtt-cue-voice-span①">WebVTT cue voice span</a> is the
- only <a data-link-type="dfn" href="#webvtt-cue-components" id="ref-for-webvtt-cue-components②">component</a> of its <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text②">WebVTT cue text</a> sequence, then the
+    <li><a data-link-type="dfn" href="#webvtt-cue-internal-text" id="ref-for-webvtt-cue-internal-text-7">WebVTT cue internal text</a>.
+    <li>A <a data-link-type="dfn" href="#webvtt-cue-span-end-tag" id="ref-for-webvtt-cue-span-end-tag-7">WebVTT cue span end tag</a> "<code>v</code>". If this <a data-link-type="dfn" href="#webvtt-cue-voice-span" id="ref-for-webvtt-cue-voice-span-2">WebVTT cue voice span</a> is the
+ only <a data-link-type="dfn" href="#webvtt-cue-components" id="ref-for-webvtt-cue-components-3">component</a> of its <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-3">WebVTT cue text</a> sequence, then the
  end tag may be omitted for brevity.
    </ol>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue-language-span">WebVTT cue language span</dfn> consists of the following components, in the order
 given:</p>
    <ol>
-    <li>A <a data-link-type="dfn" href="#webvtt-cue-span-start-tag" id="ref-for-webvtt-cue-span-start-tag⑦">WebVTT cue span start tag</a> "<code>lang</code>" that requires an annotation; the
+    <li>A <a data-link-type="dfn" href="#webvtt-cue-span-start-tag" id="ref-for-webvtt-cue-span-start-tag-8">WebVTT cue span start tag</a> "<code>lang</code>" that requires an annotation; the
  annotation represents the language of the following component, and must be a valid BCP 47 language
  tag. <a data-link-type="biblio" href="#biblio-bcp47">[BCP47]</a>
-    <li><a data-link-type="dfn" href="#webvtt-cue-internal-text" id="ref-for-webvtt-cue-internal-text⑦">WebVTT cue internal text</a>.
-    <li>A <a data-link-type="dfn" href="#webvtt-cue-span-end-tag" id="ref-for-webvtt-cue-span-end-tag⑦">WebVTT cue span end tag</a> "<code>lang</code>".
+    <li><a data-link-type="dfn" href="#webvtt-cue-internal-text" id="ref-for-webvtt-cue-internal-text-8">WebVTT cue internal text</a>.
+    <li>A <a data-link-type="dfn" href="#webvtt-cue-span-end-tag" id="ref-for-webvtt-cue-span-end-tag-8">WebVTT cue span end tag</a> "<code>lang</code>".
    </ol>
    <p class="note" role="note">The requirement above regarding valid BCP 47 language tag is an authoring requirement,
 so a conformance checker will do validity checking of the language tag, but other user agents will
@@ -2649,9 +2648,9 @@ given:</p>
   of their representations having a value that contains at least one character other than U+0020
   SPACE and U+0009 CHARACTER TABULATION (tab) characters:</p>
      <ul>
-      <li><a data-link-type="dfn" href="#webvtt-cue-span-start-tag-annotation-text" id="ref-for-webvtt-cue-span-start-tag-annotation-text">WebVTT cue span start tag annotation text</a>, representing the text of the
+      <li><a data-link-type="dfn" href="#webvtt-cue-span-start-tag-annotation-text" id="ref-for-webvtt-cue-span-start-tag-annotation-text-1">WebVTT cue span start tag annotation text</a>, representing the text of the
    annotation.
-      <li>An <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/syntax.html#syntax-charref" id="ref-for-syntax-charref①">HTML character reference</a>, representing one or two Unicode
+      <li>An <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/syntax.html#syntax-charref">HTML character reference</a>, representing one or two Unicode
    code points, as defined in HTML, in the text of the annotation. <a data-link-type="biblio" href="#biblio-html">[HTML]</a>
      </ul>
     <li>A U+003E GREATER-THAN SIGN character (>).
@@ -2665,9 +2664,9 @@ in the order given:</p>
     <li>A U+003E GREATER-THAN SIGN character (>).
    </ol>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue-timestamp">WebVTT cue timestamp</dfn> consists of a U+003C LESS-THAN SIGN character (&lt;), followed
-by a <a data-link-type="dfn" href="#webvtt-timestamp" id="ref-for-webvtt-timestamp⑤">WebVTT timestamp</a> representing the time that the given point in the cue becomes active,
-followed by a U+003E GREATER-THAN SIGN character (>). The time represented by the <a data-link-type="dfn" href="#webvtt-timestamp" id="ref-for-webvtt-timestamp⑥">WebVTT
-timestamp</a> must be greater than the times represented by any previous <a data-link-type="dfn" href="#webvtt-cue-timestamp" id="ref-for-webvtt-cue-timestamp①">WebVTT cue timestamps</a> in the cue, as well as greater than the cue’s start time
+by a <a data-link-type="dfn" href="#webvtt-timestamp" id="ref-for-webvtt-timestamp-6">WebVTT timestamp</a> representing the time that the given point in the cue becomes active,
+followed by a U+003E GREATER-THAN SIGN character (>). The time represented by the <a data-link-type="dfn" href="#webvtt-timestamp" id="ref-for-webvtt-timestamp-7">WebVTT
+timestamp</a> must be greater than the times represented by any previous <a data-link-type="dfn" href="#webvtt-cue-timestamp" id="ref-for-webvtt-cue-timestamp-2">WebVTT cue timestamps</a> in the cue, as well as greater than the cue’s start time
 offset, and less than the cue’s end time offset.</p>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue-text-span">WebVTT cue text span</dfn> consists of one or more characters other than U+000A LINE FEED
 (LF) characters, U+000D CARRIAGE RETURN (CR) characters, U+0026 AMPERSAND characters (&amp;), and
@@ -2676,30 +2675,30 @@ U+003C LESS-THAN SIGN characters (&lt;).</p>
 than U+000A LINE FEED (LF) characters, U+000D CARRIAGE RETURN (CR) characters, U+0026 AMPERSAND
 characters (&amp;), and U+003E GREATER-THAN SIGN characters (>).</p>
    <h4 class="heading settled" data-level="4.2.3" id="chapter-title-text"><span class="secno">4.2.3. </span><span class="content">WebVTT chapter title text</span><a class="self-link" href="#chapter-title-text"></a></h4>
-   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-chapter-title-text">WebVTT chapter title text</dfn> is <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text③">WebVTT cue text</a> that makes use only of zero or
-more of the following components, each optionally separated from the next by a <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator②④">WebVTT line
+   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-chapter-title-text">WebVTT chapter title text</dfn> is <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-4">WebVTT cue text</a> that makes use of zero or more of
+the following components, each optionally separated from the next by a <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator-25">WebVTT line
 terminator</a>:</p>
    <ul>
-    <li><a data-link-type="dfn" href="#webvtt-cue-text-span" id="ref-for-webvtt-cue-text-span①">WebVTT cue text span</a>
-    <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/syntax.html#syntax-charref" id="ref-for-syntax-charref②">HTML character reference</a> <a data-link-type="biblio" href="#biblio-html">[HTML]</a>
+    <li><a data-link-type="dfn" href="#webvtt-cue-text-span" id="ref-for-webvtt-cue-text-span-2">WebVTT cue text span</a>
+    <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/syntax.html#syntax-charref">HTML character reference</a> <a data-link-type="biblio" href="#biblio-html">[HTML]</a>
    </ul>
    <h3 class="heading settled" data-level="4.3" id="region-settings"><span class="secno">4.3. </span><span class="content">WebVTT region settings</span><a class="self-link" href="#region-settings"></a></h3>
-   <p>A <a data-link-type="dfn" href="#webvtt-cue-settings-list" id="ref-for-webvtt-cue-settings-list①">WebVTT cue settings list</a> can contain a reference to a <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region⑤">WebVTT region</a>. To define a
-region, a <a data-link-type="dfn" href="#webvtt-region-definition-block" id="ref-for-webvtt-region-definition-block①">WebVTT region definition block</a> is specified.</p>
+   <p>A <a data-link-type="dfn" href="#webvtt-cue-settings-list" id="ref-for-webvtt-cue-settings-list-2">WebVTT cue settings list</a> can contain a reference to a <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region-6">WebVTT region</a>. To define a
+region, a <a data-link-type="dfn" href="#webvtt-region-definition-block" id="ref-for-webvtt-region-definition-block-2">WebVTT region definition block</a> is specified.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-region-settings-list">WebVTT region settings list</dfn> consists of zero or more of the following components,
 in any order, separated from each other by one or more U+0020 SPACE characters, U+0009 CHARACTER
-TABULATION (tab) characters, or <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator②⑤">WebVTT line terminators</a>, except that the string must not
-contain two consecutive <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator②⑥">WebVTT line terminators</a>. Each component must not be included more
-than once per <a data-link-type="dfn" href="#webvtt-region-settings-list" id="ref-for-webvtt-region-settings-list①">WebVTT region settings list</a> string.</p>
+TABULATION (tab) characters, or <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator-26">WebVTT line terminators</a>, except that the string must not
+contain two consecutive <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator-27">WebVTT line terminators</a>. Each component must not be included more
+than once per <a data-link-type="dfn" href="#webvtt-region-settings-list" id="ref-for-webvtt-region-settings-list-2">WebVTT region settings list</a> string.</p>
    <ul>
-    <li>A <a data-link-type="dfn" href="#webvtt-region-identifier-setting" id="ref-for-webvtt-region-identifier-setting">WebVTT region identifier setting</a>.
-    <li>A <a data-link-type="dfn" href="#webvtt-region-width-setting" id="ref-for-webvtt-region-width-setting">WebVTT region width setting</a>.
-    <li>A <a data-link-type="dfn" href="#webvtt-region-lines-setting" id="ref-for-webvtt-region-lines-setting">WebVTT region lines setting</a>.
-    <li>A <a data-link-type="dfn" href="#webvtt-region-anchor-setting" id="ref-for-webvtt-region-anchor-setting">WebVTT region anchor setting</a>.
-    <li>A <a data-link-type="dfn" href="#webvtt-region-viewport-anchor-setting" id="ref-for-webvtt-region-viewport-anchor-setting">WebVTT region viewport anchor setting</a>.
-    <li>A <a data-link-type="dfn" href="#webvtt-region-scroll-setting" id="ref-for-webvtt-region-scroll-setting">WebVTT region scroll setting</a>.
+    <li>A <a data-link-type="dfn" href="#webvtt-region-identifier-setting" id="ref-for-webvtt-region-identifier-setting-1">WebVTT region identifier setting</a>.
+    <li>A <a data-link-type="dfn" href="#webvtt-region-width-setting" id="ref-for-webvtt-region-width-setting-1">WebVTT region width setting</a>.
+    <li>A <a data-link-type="dfn" href="#webvtt-region-lines-setting" id="ref-for-webvtt-region-lines-setting-1">WebVTT region lines setting</a>.
+    <li>A <a data-link-type="dfn" href="#webvtt-region-anchor-setting" id="ref-for-webvtt-region-anchor-setting-1">WebVTT region anchor setting</a>.
+    <li>A <a data-link-type="dfn" href="#webvtt-region-viewport-anchor-setting" id="ref-for-webvtt-region-viewport-anchor-setting-1">WebVTT region viewport anchor setting</a>.
+    <li>A <a data-link-type="dfn" href="#webvtt-region-scroll-setting" id="ref-for-webvtt-region-scroll-setting-1">WebVTT region scroll setting</a>.
    </ul>
-   <p class="note" role="note">The <a data-link-type="dfn" href="#webvtt-region-settings-list" id="ref-for-webvtt-region-settings-list②">WebVTT region settings list</a> gives configuration options regarding the
+   <p class="note" role="note">The <a data-link-type="dfn" href="#webvtt-region-settings-list" id="ref-for-webvtt-region-settings-list-3">WebVTT region settings list</a> gives configuration options regarding the
 dimensions, positioning and anchoring of the region. For example, it allows a group of cues within a
 region to be anchored in the center of the region and the center of the video viewport. In this
 example, when the font size grows, the region grows uniformly in all directions from the center.</p>
@@ -2711,15 +2710,15 @@ given:</p>
     <li>
      <p>A U+003A COLON character (:).</p>
     <li>
-     <p>An arbitrary string of one or more characters other than <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-whitespace" id="ref-for-ascii-whitespace">ASCII whitespace</a>. The string
+     <p>An arbitrary string of one or more characters other than <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-whitespace">ASCII whitespace</a>. The string
  must not contain the substring "<code>--></code>" (U+002D HYPHEN-MINUS, U+002D HYPHEN-MINUS, U+003E
  GREATER-THAN SIGN).</p>
    </ol>
-   <p>A <a data-link-type="dfn" href="#webvtt-region-identifier-setting" id="ref-for-webvtt-region-identifier-setting①">WebVTT region identifier setting</a> must be unique amongst all the <a data-link-type="dfn" href="#webvtt-region-identifier-setting" id="ref-for-webvtt-region-identifier-setting②">WebVTT region identifier settings</a> of all <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region⑥">WebVTT
-regions</a> of a <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file⑧">WebVTT file</a>.</p>
-   <p>A <a data-link-type="dfn" href="#webvtt-region-identifier-setting" id="ref-for-webvtt-region-identifier-setting③">WebVTT region identifier setting</a> must be present in each <a data-link-type="dfn" href="#webvtt-cue-settings-list" id="ref-for-webvtt-cue-settings-list②">WebVTT cue settings
-list</a>. Without an identifier, it is not possible to associate a <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue①③">WebVTT cue</a> with a <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region⑦">WebVTT region</a> in the syntax.</p>
-   <p class="note" role="note">The <a data-link-type="dfn" href="#webvtt-region-identifier-setting" id="ref-for-webvtt-region-identifier-setting④">WebVTT region identifier setting</a> gives a name to the region so it can be
+   <p>A <a data-link-type="dfn" href="#webvtt-region-identifier-setting" id="ref-for-webvtt-region-identifier-setting-2">WebVTT region identifier setting</a> must be unique amongst all the <a data-link-type="dfn" href="#webvtt-region-identifier-setting" id="ref-for-webvtt-region-identifier-setting-3">WebVTT region identifier settings</a> of all <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region-7">WebVTT
+regions</a> of a <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file-9">WebVTT file</a>.</p>
+   <p>A <a data-link-type="dfn" href="#webvtt-region-identifier-setting" id="ref-for-webvtt-region-identifier-setting-4">WebVTT region identifier setting</a> must be present in each <a data-link-type="dfn" href="#webvtt-cue-settings-list" id="ref-for-webvtt-cue-settings-list-3">WebVTT cue settings
+list</a>. Without an identifier, it is not possible to associate a <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-14">WebVTT cue</a> with a <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region-8">WebVTT region</a> in the syntax.</p>
+   <p class="note" role="note">The <a data-link-type="dfn" href="#webvtt-region-identifier-setting" id="ref-for-webvtt-region-identifier-setting-5">WebVTT region identifier setting</a> gives a name to the region so it can be
 referenced by the cues that belong to the region.</p>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-region-width-setting">WebVTT region width setting</dfn> consists of the following components, in the order
 given:</p>
@@ -2729,9 +2728,9 @@ given:</p>
     <li>
      <p>A U+003A COLON character (:).</p>
     <li>
-     <p>A <a data-link-type="dfn" href="#webvtt-percentage" id="ref-for-webvtt-percentage①">WebVTT percentage</a>.</p>
+     <p>A <a data-link-type="dfn" href="#webvtt-percentage" id="ref-for-webvtt-percentage-2">WebVTT percentage</a>.</p>
    </ol>
-   <p class="note" role="note">The <a data-link-type="dfn" href="#webvtt-region-width-setting" id="ref-for-webvtt-region-width-setting①">WebVTT region width setting</a> provides a fixed width as a percentage of the
+   <p class="note" role="note">The <a data-link-type="dfn" href="#webvtt-region-width-setting" id="ref-for-webvtt-region-width-setting-2">WebVTT region width setting</a> provides a fixed width as a percentage of the
 video width for the region into which cues are rendered and based on which alignment is
 calculated.</p>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-region-lines-setting">WebVTT region lines setting</dfn> consists of the following components, in the order
@@ -2742,9 +2741,9 @@ given:</p>
     <li>
      <p>A U+003A COLON character (:).</p>
     <li>
-     <p>One or more <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits" id="ref-for-ascii-digits⑥">ASCII digits</a>.</p>
+     <p>One or more <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits">ASCII digits</a>.</p>
    </ol>
-   <p class="note" role="note">The <a data-link-type="dfn" href="#webvtt-region-lines-setting" id="ref-for-webvtt-region-lines-setting①">WebVTT region lines setting</a> provides a fixed height as a number of lines
+   <p class="note" role="note">The <a data-link-type="dfn" href="#webvtt-region-lines-setting" id="ref-for-webvtt-region-lines-setting-2">WebVTT region lines setting</a> provides a fixed height as a number of lines
 for the region into which cues are rendered. As such, it defines the height of the roll-up region if
 it is a scroll region.</p>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-region-anchor-setting">WebVTT region anchor setting</dfn> consists of the following components, in the order
@@ -2755,15 +2754,15 @@ given:</p>
     <li>
      <p>A U+003A COLON character (:).</p>
     <li>
-     <p>A <a data-link-type="dfn" href="#webvtt-percentage" id="ref-for-webvtt-percentage②">WebVTT percentage</a>.</p>
+     <p>A <a data-link-type="dfn" href="#webvtt-percentage" id="ref-for-webvtt-percentage-3">WebVTT percentage</a>.</p>
     <li>
      <p>A U+002C COMMA character (,).</p>
     <li>
-     <p>A <a data-link-type="dfn" href="#webvtt-percentage" id="ref-for-webvtt-percentage③">WebVTT percentage</a>.</p>
+     <p>A <a data-link-type="dfn" href="#webvtt-percentage" id="ref-for-webvtt-percentage-4">WebVTT percentage</a>.</p>
    </ol>
-   <p class="note" role="note">The <a data-link-type="dfn" href="#webvtt-region-anchor-setting" id="ref-for-webvtt-region-anchor-setting①">WebVTT region anchor setting</a> provides a tuple of two percentages that
+   <p class="note" role="note">The <a data-link-type="dfn" href="#webvtt-region-anchor-setting" id="ref-for-webvtt-region-anchor-setting-2">WebVTT region anchor setting</a> provides a tuple of two percentages that
 specify the point within the region box that is fixed in location. The first percentage measures the
-x-dimension and the second percentage y-dimension from the top left corner of the region box. If no <a data-link-type="dfn" href="#webvtt-region-anchor-setting" id="ref-for-webvtt-region-anchor-setting②">WebVTT region anchor setting</a> is given, the anchor defaults to 0%, 100% (i.e. the bottom left
+x-dimension and the second percentage y-dimension from the top left corner of the region box. If no <a data-link-type="dfn" href="#webvtt-region-anchor-setting" id="ref-for-webvtt-region-anchor-setting-3">WebVTT region anchor setting</a> is given, the anchor defaults to 0%, 100% (i.e. the bottom left
 corner).</p>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-region-viewport-anchor-setting">WebVTT region viewport anchor setting</dfn> consists of the following components, in the
 order given:</p>
@@ -2773,13 +2772,13 @@ order given:</p>
     <li>
      <p>A U+003A COLON character (:).</p>
     <li>
-     <p>A <a data-link-type="dfn" href="#webvtt-percentage" id="ref-for-webvtt-percentage④">WebVTT percentage</a>.</p>
+     <p>A <a data-link-type="dfn" href="#webvtt-percentage" id="ref-for-webvtt-percentage-5">WebVTT percentage</a>.</p>
     <li>
      <p>A U+002C COMMA character (,).</p>
     <li>
-     <p>A <a data-link-type="dfn" href="#webvtt-percentage" id="ref-for-webvtt-percentage⑤">WebVTT percentage</a>.</p>
+     <p>A <a data-link-type="dfn" href="#webvtt-percentage" id="ref-for-webvtt-percentage-6">WebVTT percentage</a>.</p>
    </ol>
-   <p class="note" role="note">The <a data-link-type="dfn" href="#webvtt-region-viewport-anchor-setting" id="ref-for-webvtt-region-viewport-anchor-setting①">WebVTT region viewport anchor setting</a> provides a tuple of two percentages
+   <p class="note" role="note">The <a data-link-type="dfn" href="#webvtt-region-viewport-anchor-setting" id="ref-for-webvtt-region-viewport-anchor-setting-2">WebVTT region viewport anchor setting</a> provides a tuple of two percentages
 that specify the point within the video viewport that the region anchor point is anchored to. The
 first percentage measures the x-dimension and the second percentage measures the y-dimension from
 the top left corner of the video viewport box. If no viewport anchor is given, it defaults to 0%,
@@ -2797,7 +2796,7 @@ given:</p>
     <li>
      <p>The string "<code>up</code>".</p>
    </ol>
-   <p class="note" role="note">The <a data-link-type="dfn" href="#webvtt-region-scroll-setting" id="ref-for-webvtt-region-scroll-setting①">WebVTT region scroll setting</a> specifies whether cues rendered into the
+   <p class="note" role="note">The <a data-link-type="dfn" href="#webvtt-region-scroll-setting" id="ref-for-webvtt-region-scroll-setting-2">WebVTT region scroll setting</a> specifies whether cues rendered into the
 region are allowed to move out of their initial rendering place and roll up, i.e. move towards the
 top of the video viewport. If the scroll setting is omitted, cues do not move from their rendered
 position.</p>
@@ -2811,56 +2810,56 @@ cue line and allows it to be added.</p>
 the line in the bottom of the region. If no empty line is available, the oldest line is
 replaced.</p>
    <h3 class="heading settled" data-level="4.4" id="cue-settings"><span class="secno">4.4. </span><span class="content">WebVTT cue settings</span><a class="self-link" href="#cue-settings"></a></h3>
-   <p>A <a data-link-type="dfn" href="#webvtt-cue-setting" id="ref-for-webvtt-cue-setting">WebVTT cue setting</a> is part of a <a data-link-type="dfn" href="#webvtt-cue-settings-list" id="ref-for-webvtt-cue-settings-list③">WebVTT cue settings list</a> and provides
+   <p>A <a data-link-type="dfn" href="#webvtt-cue-setting" id="ref-for-webvtt-cue-setting-1">WebVTT cue setting</a> is part of a <a data-link-type="dfn" href="#webvtt-cue-settings-list" id="ref-for-webvtt-cue-settings-list-4">WebVTT cue settings list</a> and provides
 configuration options regarding the position and alignment of the cue box and the cue text
 within.</p>
    <p class="note" role="note">For example, a set of WebVTT cue settings may allow a cue box to be aligned to the
 left or positioned at the top right with the cue text within center aligned.</p>
-   <p>The current available <a data-link-type="dfn" href="#webvtt-cue-setting" id="ref-for-webvtt-cue-setting①">WebVTT cue settings</a> that may appear in a <a data-link-type="dfn" href="#webvtt-cue-settings-list" id="ref-for-webvtt-cue-settings-list④">WebVTT cue settings
+   <p>The current available <a data-link-type="dfn" href="#webvtt-cue-setting" id="ref-for-webvtt-cue-setting-2">WebVTT cue settings</a> that may appear in a <a data-link-type="dfn" href="#webvtt-cue-settings-list" id="ref-for-webvtt-cue-settings-list-5">WebVTT cue settings
 list</a> are:</p>
    <ul class="brief">
-    <li>A <a data-link-type="dfn" href="#webvtt-vertical-text-cue-setting" id="ref-for-webvtt-vertical-text-cue-setting">WebVTT vertical text cue setting</a>.
-    <li>A <a data-link-type="dfn" href="#webvtt-line-cue-setting" id="ref-for-webvtt-line-cue-setting">WebVTT line cue setting</a>.
-    <li>A <a data-link-type="dfn" href="#webvtt-position-cue-setting" id="ref-for-webvtt-position-cue-setting">WebVTT position cue setting</a>.
-    <li>A <a data-link-type="dfn" href="#webvtt-size-cue-setting" id="ref-for-webvtt-size-cue-setting">WebVTT size cue setting</a>.
-    <li>A <a data-link-type="dfn" href="#webvtt-alignment-cue-setting" id="ref-for-webvtt-alignment-cue-setting">WebVTT alignment cue setting</a>.
-    <li>A <a data-link-type="dfn" href="#webvtt-region-cue-setting" id="ref-for-webvtt-region-cue-setting">WebVTT region cue setting</a>.
+    <li>A <a data-link-type="dfn" href="#webvtt-vertical-text-cue-setting" id="ref-for-webvtt-vertical-text-cue-setting-1">WebVTT vertical text cue setting</a>.
+    <li>A <a data-link-type="dfn" href="#webvtt-line-cue-setting" id="ref-for-webvtt-line-cue-setting-1">WebVTT line cue setting</a>.
+    <li>A <a data-link-type="dfn" href="#webvtt-position-cue-setting" id="ref-for-webvtt-position-cue-setting-1">WebVTT position cue setting</a>.
+    <li>A <a data-link-type="dfn" href="#webvtt-size-cue-setting" id="ref-for-webvtt-size-cue-setting-1">WebVTT size cue setting</a>.
+    <li>A <a data-link-type="dfn" href="#webvtt-alignment-cue-setting" id="ref-for-webvtt-alignment-cue-setting-1">WebVTT alignment cue setting</a>.
+    <li>A <a data-link-type="dfn" href="#webvtt-region-cue-setting" id="ref-for-webvtt-region-cue-setting-1">WebVTT region cue setting</a>.
    </ul>
-   <p>Each of these setting must not be included more than once per <a data-link-type="dfn" href="#webvtt-cue-settings-list" id="ref-for-webvtt-cue-settings-list⑤">WebVTT cue settings
+   <p>Each of these setting must not be included more than once per <a data-link-type="dfn" href="#webvtt-cue-settings-list" id="ref-for-webvtt-cue-settings-list-6">WebVTT cue settings
 list</a>.</p>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-vertical-text-cue-setting">WebVTT vertical text cue setting</dfn> is a <a data-link-type="dfn" href="#webvtt-cue-setting" id="ref-for-webvtt-cue-setting②">WebVTT cue setting</a> that consists of the
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-vertical-text-cue-setting">WebVTT vertical text cue setting</dfn> is a <a data-link-type="dfn" href="#webvtt-cue-setting" id="ref-for-webvtt-cue-setting-3">WebVTT cue setting</a> that consists of the
 following components, in the order given:</p>
    <ol>
-    <li>The string "<code>vertical</code>" as the <a data-link-type="dfn" href="#webvtt-cue-setting-name" id="ref-for-webvtt-cue-setting-name①">WebVTT cue setting name</a>.
+    <li>The string "<code>vertical</code>" as the <a data-link-type="dfn" href="#webvtt-cue-setting-name" id="ref-for-webvtt-cue-setting-name-2">WebVTT cue setting name</a>.
     <li>
      <p>A U+003A COLON character (:).</p>
-    <li>One of the following strings as the <a data-link-type="dfn" href="#webvtt-cue-setting-value" id="ref-for-webvtt-cue-setting-value①">WebVTT cue setting value</a>: "<code>rl</code>",
+    <li>One of the following strings as the <a data-link-type="dfn" href="#webvtt-cue-setting-value" id="ref-for-webvtt-cue-setting-value-2">WebVTT cue setting value</a>: "<code>rl</code>",
  "<code>lr</code>".
    </ol>
-   <p class="note" role="note">A <a data-link-type="dfn" href="#webvtt-vertical-text-cue-setting" id="ref-for-webvtt-vertical-text-cue-setting①">WebVTT vertical text cue setting</a> configures the cue to use vertical text
+   <p class="note" role="note">A <a data-link-type="dfn" href="#webvtt-vertical-text-cue-setting" id="ref-for-webvtt-vertical-text-cue-setting-2">WebVTT vertical text cue setting</a> configures the cue to use vertical text
 layout rather than horizontal text layout. Vertical text layout is sometimes used in Japanese, for
 example. The default is horizontal layout.</p>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-line-cue-setting">WebVTT line cue setting</dfn> consists of the following components, in the order
 given:</p>
    <ol>
     <li>
-     <p>The string "<code>line</code>" as the <a data-link-type="dfn" href="#webvtt-cue-setting-name" id="ref-for-webvtt-cue-setting-name②">WebVTT cue setting name</a>.</p>
+     <p>The string "<code>line</code>" as the <a data-link-type="dfn" href="#webvtt-cue-setting-name" id="ref-for-webvtt-cue-setting-name-3">WebVTT cue setting name</a>.</p>
     <li>
      <p>A U+003A COLON character (:).</p>
     <li>
-      As the <a data-link-type="dfn" href="#webvtt-cue-setting-value" id="ref-for-webvtt-cue-setting-value②">WebVTT cue setting value</a>: 
+      As the <a data-link-type="dfn" href="#webvtt-cue-setting-value" id="ref-for-webvtt-cue-setting-value-3">WebVTT cue setting value</a>: 
      <ol>
       <li>
         an offset value, either: 
        <dl>
         <dt>To represent a specific offset relative to the video viewport
         <dd>
-         <p>A <a data-link-type="dfn" href="#webvtt-percentage" id="ref-for-webvtt-percentage⑥">WebVTT percentage</a>.</p>
+         <p>A <a data-link-type="dfn" href="#webvtt-percentage" id="ref-for-webvtt-percentage-7">WebVTT percentage</a>.</p>
         <dt>Or to represent a line number
         <dd>
          <ol>
           <li>Optionally a U+002D HYPHEN-MINUS character (-).
-          <li>One or more <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits" id="ref-for-ascii-digits⑦">ASCII digits</a>.
+          <li>One or more <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits">ASCII digits</a>.
          </ol>
        </dl>
       <li>
@@ -2872,11 +2871,11 @@ given:</p>
        </ol>
      </ol>
    </ol>
-   <p class="note" role="note">A <a data-link-type="dfn" href="#webvtt-line-cue-setting" id="ref-for-webvtt-line-cue-setting①">WebVTT line cue setting</a> configures the offset of the cue box from the video
-viewport’s edge in the direction opposite to the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction①①">writing
+   <p class="note" role="note">A <a data-link-type="dfn" href="#webvtt-line-cue-setting" id="ref-for-webvtt-line-cue-setting-2">WebVTT line cue setting</a> configures the offset of the cue box from the video
+viewport’s edge in the direction opposite to the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-12">writing
 direction</a>. For horizontal cues, this is the vertical offset from the top of the video viewport.
-The offset is for the <a data-link-type="dfn" href="#webvtt-cue-line-start-alignment" id="ref-for-webvtt-cue-line-start-alignment①">start</a>, <a data-link-type="dfn" href="#webvtt-cue-line-center-alignment" id="ref-for-webvtt-cue-line-center-alignment">center</a>, or <a data-link-type="dfn" href="#webvtt-cue-line-end-alignment" id="ref-for-webvtt-cue-line-end-alignment">end</a> of the cue box,
-depending on the <a data-link-type="dfn" href="#webvtt-cue-line-alignment" id="ref-for-webvtt-cue-line-alignment④">WebVTT cue line alignment</a> value - <a data-link-type="dfn" href="#webvtt-cue-line-start-alignment" id="ref-for-webvtt-cue-line-start-alignment②">start</a> by default. The offset can be given either as a percentage of the video
+The offset is for the <a data-link-type="dfn" href="#webvtt-cue-line-start-alignment" id="ref-for-webvtt-cue-line-start-alignment-2">start</a>, <a data-link-type="dfn" href="#webvtt-cue-line-center-alignment" id="ref-for-webvtt-cue-line-center-alignment-1">center</a>, or <a data-link-type="dfn" href="#webvtt-cue-line-end-alignment" id="ref-for-webvtt-cue-line-end-alignment-1">end</a> of the cue box,
+depending on the <a data-link-type="dfn" href="#webvtt-cue-line-alignment" id="ref-for-webvtt-cue-line-alignment-5">WebVTT cue line alignment</a> value - <a data-link-type="dfn" href="#webvtt-cue-line-start-alignment" id="ref-for-webvtt-cue-line-start-alignment-3">start</a> by default. The offset can be given either as a percentage of the video
 dimension or as a line number. Line numbers are based on the size of the first line of the cue.
 Positive line numbers count from the start of the video viewport (the first line is numbered 0),
 negative line numbers from the end of the viewport (the last line is numbered −1).</p>
@@ -2884,13 +2883,13 @@ negative line numbers from the end of the viewport (the last line is numbered �
 given:</p>
    <ol>
     <li>
-     <p>The string "<code>position</code>" as the <a data-link-type="dfn" href="#webvtt-cue-setting-name" id="ref-for-webvtt-cue-setting-name③">WebVTT cue setting name</a>.</p>
+     <p>The string "<code>position</code>" as the <a data-link-type="dfn" href="#webvtt-cue-setting-name" id="ref-for-webvtt-cue-setting-name-4">WebVTT cue setting name</a>.</p>
     <li>
      <p>A U+003A COLON character (:).</p>
     <li>
-      As the <a data-link-type="dfn" href="#webvtt-cue-setting-value" id="ref-for-webvtt-cue-setting-value③">WebVTT cue setting value</a>: 
+      As the <a data-link-type="dfn" href="#webvtt-cue-setting-value" id="ref-for-webvtt-cue-setting-value-4">WebVTT cue setting value</a>: 
      <ol>
-      <li>a position value consisting of: a <a data-link-type="dfn" href="#webvtt-percentage" id="ref-for-webvtt-percentage⑦">WebVTT percentage</a>.
+      <li>a position value consisting of: a <a data-link-type="dfn" href="#webvtt-percentage" id="ref-for-webvtt-percentage-8">WebVTT percentage</a>.
       <li>
         an optional alignment value consisting of: 
        <ol>
@@ -2900,52 +2899,52 @@ given:</p>
        </ol>
      </ol>
    </ol>
-   <p class="note" role="note">A <a data-link-type="dfn" href="#webvtt-position-cue-setting" id="ref-for-webvtt-position-cue-setting①">WebVTT position cue setting</a> configures the indent position of the <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box②③">cue box</a> in the direction orthogonal to the <a data-link-type="dfn" href="#webvtt-line-cue-setting" id="ref-for-webvtt-line-cue-setting②">WebVTT line cue setting</a>.
+   <p class="note" role="note">A <a data-link-type="dfn" href="#webvtt-position-cue-setting" id="ref-for-webvtt-position-cue-setting-2">WebVTT position cue setting</a> configures the indent position of the <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box-24">cue box</a> in the direction orthogonal to the <a data-link-type="dfn" href="#webvtt-line-cue-setting" id="ref-for-webvtt-line-cue-setting-3">WebVTT line cue setting</a>.
 For horizontal cues, this is the horizontal position. The cue position is given as a percentage of
-the video viewport. The positioning is for the <a data-link-type="dfn" href="#webvtt-cue-position-line-left-alignment" id="ref-for-webvtt-cue-position-line-left-alignment②">line-left</a>, <a data-link-type="dfn" href="#webvtt-cue-position-center-alignment" id="ref-for-webvtt-cue-position-center-alignment">center</a>, or <a data-link-type="dfn" href="#webvtt-cue-position-line-right-alignment" id="ref-for-webvtt-cue-position-line-right-alignment①">line-right</a> of the cue box, depending on the cue’s <a data-link-type="dfn" href="#cue-computed-position-alignment" id="ref-for-cue-computed-position-alignment">computed position alignment</a>, which is overridden by the <a data-link-type="dfn" href="#webvtt-position-cue-setting" id="ref-for-webvtt-position-cue-setting②">WebVTT
+the video viewport. The positioning is for the <a data-link-type="dfn" href="#webvtt-cue-position-line-left-alignment" id="ref-for-webvtt-cue-position-line-left-alignment-3">line-left</a>, <a data-link-type="dfn" href="#webvtt-cue-position-center-alignment" id="ref-for-webvtt-cue-position-center-alignment-1">center</a>, or <a data-link-type="dfn" href="#webvtt-cue-position-line-right-alignment" id="ref-for-webvtt-cue-position-line-right-alignment-2">line-right</a> of the cue box, depending on the cue’s <a data-link-type="dfn" href="#cue-computed-position-alignment" id="ref-for-cue-computed-position-alignment-1">computed position alignment</a>, which is overridden by the <a data-link-type="dfn" href="#webvtt-position-cue-setting" id="ref-for-webvtt-position-cue-setting-3">WebVTT
 position cue setting</a>.</p>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-size-cue-setting">WebVTT size cue setting</dfn> consists of the following components, in the order
 given:</p>
    <ol>
     <li>
-     <p>The string "<code>size</code>" as the <a data-link-type="dfn" href="#webvtt-cue-setting-name" id="ref-for-webvtt-cue-setting-name④">WebVTT cue setting name</a>.</p>
+     <p>The string "<code>size</code>" as the <a data-link-type="dfn" href="#webvtt-cue-setting-name" id="ref-for-webvtt-cue-setting-name-5">WebVTT cue setting name</a>.</p>
     <li>
      <p>A U+003A COLON character (:).</p>
     <li>
-     <p>As the <a data-link-type="dfn" href="#webvtt-cue-setting-value" id="ref-for-webvtt-cue-setting-value④">WebVTT cue setting value</a>: a <a data-link-type="dfn" href="#webvtt-percentage" id="ref-for-webvtt-percentage⑧">WebVTT percentage</a>.</p>
+     <p>As the <a data-link-type="dfn" href="#webvtt-cue-setting-value" id="ref-for-webvtt-cue-setting-value-5">WebVTT cue setting value</a>: a <a data-link-type="dfn" href="#webvtt-percentage" id="ref-for-webvtt-percentage-9">WebVTT percentage</a>.</p>
    </ol>
-   <p class="note" role="note">A <a data-link-type="dfn" href="#webvtt-size-cue-setting" id="ref-for-webvtt-size-cue-setting①">WebVTT size cue setting</a> configures the size of the <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box②④">cue box</a> in the same direction as the <a data-link-type="dfn" href="#webvtt-position-cue-setting" id="ref-for-webvtt-position-cue-setting③">WebVTT position cue setting</a>. For horizontal
-cues, this is the width of the <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box②⑤">cue box</a>. It is given as a percentage of
+   <p class="note" role="note">A <a data-link-type="dfn" href="#webvtt-size-cue-setting" id="ref-for-webvtt-size-cue-setting-2">WebVTT size cue setting</a> configures the size of the <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box-25">cue box</a> in the same direction as the <a data-link-type="dfn" href="#webvtt-position-cue-setting" id="ref-for-webvtt-position-cue-setting-4">WebVTT position cue setting</a>. For horizontal
+cues, this is the width of the <a data-link-type="dfn" href="#webvtt-cue-box" id="ref-for-webvtt-cue-box-26">cue box</a>. It is given as a percentage of
 the width of the viewport.</p>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-alignment-cue-setting">WebVTT alignment cue setting</dfn> consists of the following components, in the order
 given:</p>
    <ol>
     <li>
-     <p>The string "<code>align</code>" as the <a data-link-type="dfn" href="#webvtt-cue-setting-name" id="ref-for-webvtt-cue-setting-name⑤">WebVTT cue setting name</a>.</p>
+     <p>The string "<code>align</code>" as the <a data-link-type="dfn" href="#webvtt-cue-setting-name" id="ref-for-webvtt-cue-setting-name-6">WebVTT cue setting name</a>.</p>
     <li>
      <p>A U+003A COLON character (:).</p>
-    <li>One of the following strings as the <a data-link-type="dfn" href="#webvtt-cue-setting-value" id="ref-for-webvtt-cue-setting-value⑤">WebVTT cue setting value</a>: "<code>start</code>",
+    <li>One of the following strings as the <a data-link-type="dfn" href="#webvtt-cue-setting-value" id="ref-for-webvtt-cue-setting-value-6">WebVTT cue setting value</a>: "<code>start</code>",
  "<code>center</code>", "<code>end</code>", "<code>left</code>", "<code>right</code>"
    </ol>
-   <p class="note" role="note">A <a data-link-type="dfn" href="#webvtt-alignment-cue-setting" id="ref-for-webvtt-alignment-cue-setting①">WebVTT alignment cue setting</a> configures the alignment of the text within
+   <p class="note" role="note">A <a data-link-type="dfn" href="#webvtt-alignment-cue-setting" id="ref-for-webvtt-alignment-cue-setting-2">WebVTT alignment cue setting</a> configures the alignment of the text within
 the cue. The "<code>start</code>" and "<code>end</code>" keywords are relative to the cue text’s
 lines' base direction; for left-to-right English text, "<code>start</code>" means left-aligned.</p>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-region-cue-setting">WebVTT region cue setting</dfn> consists of the following components, in the order
 given:</p>
    <ol>
     <li>
-     <p>The string "<code>region</code>" as the <a data-link-type="dfn" href="#webvtt-cue-setting-name" id="ref-for-webvtt-cue-setting-name⑥">WebVTT cue setting name</a>.</p>
+     <p>The string "<code>region</code>" as the <a data-link-type="dfn" href="#webvtt-cue-setting-name" id="ref-for-webvtt-cue-setting-name-7">WebVTT cue setting name</a>.</p>
     <li>
      <p>A U+003A COLON character (:).</p>
     <li>
-     <p>As the <a data-link-type="dfn" href="#webvtt-cue-setting-value" id="ref-for-webvtt-cue-setting-value⑥">WebVTT cue setting value</a>: a <a data-link-type="dfn" href="#webvtt-region-identifier" id="ref-for-webvtt-region-identifier">WebVTT region identifier</a>.</p>
+     <p>As the <a data-link-type="dfn" href="#webvtt-cue-setting-value" id="ref-for-webvtt-cue-setting-value-7">WebVTT cue setting value</a>: a <a data-link-type="dfn" href="#webvtt-region-identifier" id="ref-for-webvtt-region-identifier-1">WebVTT region identifier</a>.</p>
    </ol>
-   <p class="note" role="note">A <a data-link-type="dfn" href="#webvtt-region-cue-setting" id="ref-for-webvtt-region-cue-setting①">WebVTT region cue setting</a> configures a cue to become part of a region by
-referencing the region’s identifier unless the cue has a <a data-link-type="dfn" href="#webvtt-vertical-text-cue-setting" id="ref-for-webvtt-vertical-text-cue-setting②">"vertical"</a>, <a data-link-type="dfn" href="#webvtt-line-cue-setting" id="ref-for-webvtt-line-cue-setting③">"line"</a> or <a data-link-type="dfn" href="#webvtt-size-cue-setting" id="ref-for-webvtt-size-cue-setting②">"size"</a> cue setting. If a cue is part of a region, its cue settings for <a data-link-type="dfn" href="#webvtt-position-cue-setting" id="ref-for-webvtt-position-cue-setting④">"position"</a> and <a data-link-type="dfn" href="#webvtt-alignment-cue-setting" id="ref-for-webvtt-alignment-cue-setting②">"align"</a> are
+   <p class="note" role="note">A <a data-link-type="dfn" href="#webvtt-region-cue-setting" id="ref-for-webvtt-region-cue-setting-2">WebVTT region cue setting</a> configures a cue to become part of a region by
+referencing the region’s identifier unless the cue has a <a data-link-type="dfn" href="#webvtt-vertical-text-cue-setting" id="ref-for-webvtt-vertical-text-cue-setting-3">"vertical"</a>, <a data-link-type="dfn" href="#webvtt-line-cue-setting" id="ref-for-webvtt-line-cue-setting-4">"line"</a> or <a data-link-type="dfn" href="#webvtt-size-cue-setting" id="ref-for-webvtt-size-cue-setting-3">"size"</a> cue setting. If a cue is part of a region, its cue settings for <a data-link-type="dfn" href="#webvtt-position-cue-setting" id="ref-for-webvtt-position-cue-setting-5">"position"</a> and <a data-link-type="dfn" href="#webvtt-alignment-cue-setting" id="ref-for-webvtt-alignment-cue-setting-3">"align"</a> are
 applied to the line boxes in the cue relative to the region box.</p>
    <h3 class="heading settled" data-level="4.5" id="properties-of-cue-sequences"><span class="secno">4.5. </span><span class="content">Properties of cue sequences</span><a class="self-link" href="#properties-of-cue-sequences"></a></h3>
    <h4 class="heading settled" data-level="4.5.1" id="file-using-only-nested-cues"><span class="secno">4.5.1. </span><span class="content">WebVTT file using only nested cues</span><a class="self-link" href="#file-using-only-nested-cues"></a></h4>
-   <p>A <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file⑨">WebVTT file</a> whose cues all follow the following rules is said to be a <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT file using only nested cues" data-noexport="" id="webvtt-file-using-only-nested-cues">WebVTT file
+   <p>A <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file-10">WebVTT file</a> whose cues all follow the following rules is said to be a <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT file using only nested cues" data-noexport="" id="webvtt-file-using-only-nested-cues">WebVTT file
 using only nested cues</dfn>:</p>
    <p>given any two cues <var>cue1</var> and <var>cue2</var> with start and end time offsets (<var>x1</var>, <var>y1</var>) and (<var>x2</var>, <var>y2</var>) respectively,</p>
    <ul>
@@ -2995,7 +2994,7 @@ Timeline Panel
       </ul>
     </ul>
     <p>If the file has cues that can’t be expressed in this fashion, then they don’t match the
- definition of a <a data-link-type="dfn" href="#webvtt-file-using-only-nested-cues" id="ref-for-webvtt-file-using-only-nested-cues">WebVTT file using only nested cues</a>. For example:</p>
+ definition of a <a data-link-type="dfn" href="#webvtt-file-using-only-nested-cues" id="ref-for-webvtt-file-using-only-nested-cues-1">WebVTT file using only nested cues</a>. For example:</p>
 <pre>WEBVTT
 
 00:00.000 --> 01:00.000
@@ -3005,30 +3004,30 @@ The First Minute
 The Final Minute
 </pre>
     <p>In this ninety-second example, the two cues partly overlap, with the first ending before the
- second ends and the second starting before the first ends. This therefore is not a <a data-link-type="dfn" href="#webvtt-file-using-only-nested-cues" id="ref-for-webvtt-file-using-only-nested-cues①">WebVTT file
+ second ends and the second starting before the first ends. This therefore is not a <a data-link-type="dfn" href="#webvtt-file-using-only-nested-cues" id="ref-for-webvtt-file-using-only-nested-cues-2">WebVTT file
  using only nested cues</a>.</p>
    </div>
    <h3 class="heading settled" data-level="4.6" id="types-of-webvtt-files"><span class="secno">4.6. </span><span class="content">Types of WebVTT files</span><a class="self-link" href="#types-of-webvtt-files"></a></h3>
    <p>The syntax definition of WebVTT files allows authoring of a wide variety of WebVTT files with a
 mix of cues. However, only a small subset of WebVTT file types are typically authored.</p>
-   <p>Conformance checkers, when validating <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file①⓪">WebVTT files</a>, may offer to restrict syntax checking
+   <p>Conformance checkers, when validating <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file-11">WebVTT files</a>, may offer to restrict syntax checking
 for validating these types.</p>
    <h4 class="heading settled" data-level="4.6.1" id="file-using-metadata-content"><span class="secno">4.6.1. </span><span class="content">WebVTT file using metadata content</span><a class="self-link" href="#file-using-metadata-content"></a></h4>
-   <p>A <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file①①">WebVTT file</a> whose cues all have a <a data-link-type="dfn" href="#cue-payload" id="ref-for-cue-payload②">cue payload</a> that is <a data-link-type="dfn" href="#webvtt-metadata-text" id="ref-for-webvtt-metadata-text②">WebVTT metadata text</a> is said to be a <dfn data-dfn-type="dfn" data-noexport="" id="webvtt-file-using-metadata-content">WebVTT file using metadata content<a class="self-link" href="#webvtt-file-using-metadata-content"></a></dfn>.</p>
+   <p>A <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file-12">WebVTT file</a> whose cues all have a <a data-link-type="dfn" href="#cue-payload" id="ref-for-cue-payload-3">cue payload</a> that is <a data-link-type="dfn" href="#webvtt-metadata-text" id="ref-for-webvtt-metadata-text-3">WebVTT metadata text</a> is said to be a <dfn data-dfn-type="dfn" data-noexport="" id="webvtt-file-using-metadata-content">WebVTT file using metadata content<a class="self-link" href="#webvtt-file-using-metadata-content"></a></dfn>.</p>
    <h4 class="heading settled" data-level="4.6.2" id="file-using-chapter-title-text"><span class="secno">4.6.2. </span><span class="content">WebVTT file using chapter title text</span><a class="self-link" href="#file-using-chapter-title-text"></a></h4>
-   <p>A <dfn data-dfn-type="dfn" data-noexport="" id="webvtt-file-using-chapter-title-text">WebVTT file using chapter title text<a class="self-link" href="#webvtt-file-using-chapter-title-text"></a></dfn> is a <a data-link-type="dfn" href="#webvtt-file-using-only-nested-cues" id="ref-for-webvtt-file-using-only-nested-cues②">WebVTT file using only nested cues</a> whose cues all have a <a data-link-type="dfn" href="#cue-payload" id="ref-for-cue-payload③">cue payload</a> that is <a data-link-type="dfn" href="#webvtt-chapter-title-text" id="ref-for-webvtt-chapter-title-text①">WebVTT chapter title text</a>.</p>
+   <p>A <dfn data-dfn-type="dfn" data-noexport="" id="webvtt-file-using-chapter-title-text">WebVTT file using chapter title text<a class="self-link" href="#webvtt-file-using-chapter-title-text"></a></dfn> is a <a data-link-type="dfn" href="#webvtt-file-using-only-nested-cues" id="ref-for-webvtt-file-using-only-nested-cues-3">WebVTT file using only nested cues</a> whose cues all have a <a data-link-type="dfn" href="#cue-payload" id="ref-for-cue-payload-4">cue payload</a> that is <a data-link-type="dfn" href="#webvtt-chapter-title-text" id="ref-for-webvtt-chapter-title-text-2">WebVTT chapter title text</a>.</p>
    <h4 class="heading settled" data-level="4.6.3" id="file-using-cue-text"><span class="secno">4.6.3. </span><span class="content">WebVTT file using cue text</span><a class="self-link" href="#file-using-cue-text"></a></h4>
-   <p>A <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file①②">WebVTT file</a> whose cues all have a <a data-link-type="dfn" href="#cue-payload" id="ref-for-cue-payload④">cue payload</a> that is <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text④">WebVTT cue text</a> is
+   <p>A <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file-13">WebVTT file</a> whose cues all have a <a data-link-type="dfn" href="#cue-payload" id="ref-for-cue-payload-5">cue payload</a> that is <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-5">WebVTT cue text</a> is
 said to be a <dfn data-dfn-type="dfn" data-noexport="" id="webvtt-file-using-cue-text">WebVTT file using cue text<a class="self-link" href="#webvtt-file-using-cue-text"></a></dfn>.</p>
    <h2 class="heading settled" data-level="5" id="parsing"><span class="secno">5. </span><span class="content">Parsing</span><a class="self-link" href="#parsing"></a></h2>
    <h3 class="heading settled algorithm" data-algorithm="WebVTT file parsing" data-level="5.1" id="file-parsing"><span class="secno">5.1. </span><span class="content">WebVTT file parsing</span><a class="self-link" href="#file-parsing"></a></h3>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-parser">WebVTT parser</dfn>, given an input byte stream, a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-list-of-cues" id="ref-for-text-track-list-of-cues②">text track list of cues</a> <var>output</var>, and a collection of <a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#css-style-sheet" id="ref-for-css-style-sheet">CSS style sheets</a> <var>stylesheets</var>, must decode the byte
-stream using the <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#utf-8-decode" id="ref-for-utf-8-decode">UTF-8 decode</a> algorithm, and then must parse the resulting
-string according to the <a data-link-type="dfn" href="#webvtt-parser-algorithm" id="ref-for-webvtt-parser-algorithm">WebVTT parser algorithm</a> below. This results in <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue①④">WebVTT cues</a> being added to <var>output</var>, and <a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#css-style-sheet" id="ref-for-css-style-sheet①">CSS style sheets</a> being added to <var>stylesheets</var>. <a data-link-type="biblio" href="#biblio-rfc3629">[RFC3629]</a></p>
-   <p>A <a data-link-type="dfn" href="#webvtt-parser" id="ref-for-webvtt-parser①">WebVTT parser</a>, specifically its conversion and parsing steps, is typically run
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-parser">WebVTT parser</dfn>, given an input byte stream, a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-list-of-cues">text track list of cues</a> <var>output</var>, and a collection of <a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#css-style-sheet">CSS style sheets</a> <var>stylesheets</var>, must decode the byte
+stream using the <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#utf-8-decode">UTF-8 decode</a> algorithm, and then must parse the resulting
+string according to the <a data-link-type="dfn" href="#webvtt-parser-algorithm" id="ref-for-webvtt-parser-algorithm-1">WebVTT parser algorithm</a> below. This results in <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-15">WebVTT cues</a> being added to <var>output</var>, and <a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#css-style-sheet">CSS style sheets</a> being added to <var>stylesheets</var>. <a data-link-type="biblio" href="#biblio-rfc3629">[RFC3629]</a></p>
+   <p>A <a data-link-type="dfn" href="#webvtt-parser" id="ref-for-webvtt-parser-2">WebVTT parser</a>, specifically its conversion and parsing steps, is typically run
 asynchronously, with the input byte stream being updated incrementally as the resource is
 downloaded; this is called an <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="incremental-webvtt-parser">incremental WebVTT parser</dfn>.</p>
-   <p>A <a data-link-type="dfn" href="#webvtt-parser" id="ref-for-webvtt-parser②">WebVTT parser</a> verifies a file signature before parsing the provided byte stream. If the
+   <p>A <a data-link-type="dfn" href="#webvtt-parser" id="ref-for-webvtt-parser-3">WebVTT parser</a> verifies a file signature before parsing the provided byte stream. If the
 stream lacks this WebVTT file signature, then the parser aborts.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-parser-algorithm">WebVTT parser algorithm</dfn> is as follows:</p>
    <ol class="algorithm">
@@ -3047,7 +3046,7 @@ stream lacks this WebVTT file signature, then the parser aborts.</p>
      </ul>
     <li>
      <p>Let <var>position</var> be a pointer into <var>input</var>, initially pointing at the start of the string. In
- an <a data-link-type="dfn" href="#incremental-webvtt-parser" id="ref-for-incremental-webvtt-parser">incremental WebVTT parser</a>, when this algorithm (or further algorithms that it uses) moves
+ an <a data-link-type="dfn" href="#incremental-webvtt-parser" id="ref-for-incremental-webvtt-parser-1">incremental WebVTT parser</a>, when this algorithm (or further algorithms that it uses) moves
  the <var>position</var> pointer, the user agent must wait until appropriate further characters from the byte
  stream have been added to <var>input</var> before moving the pointer, so that the algorithm never reads past
  the end of the <var>input</var> string. Once the byte stream has ended, and all characters have been added
@@ -3056,56 +3055,56 @@ stream lacks this WebVTT file signature, then the parser aborts.</p>
     <li>Let <var>seen cue</var> be false.
     <li>
      <p>If <var>input</var> is less than six characters long, then abort these steps. The file does not start
- with the correct <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file①③">WebVTT file</a> signature and was therefore not successfully
+ with the correct <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file-14">WebVTT file</a> signature and was therefore not successfully
  processed.</p>
     <li>
      <p>If <var>input</var> is exactly six characters long but does not exactly equal "<code>WEBVTT</code>",
- then abort these steps. The file does not start with the correct <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file①④">WebVTT file</a> signature and
+ then abort these steps. The file does not start with the correct <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file-15">WebVTT file</a> signature and
  was therefore not successfully processed.</p>
     <li>
      <p>If <var>input</var> is more than six characters long but the first six characters do not exactly
  equal "<code>WEBVTT</code>", or the seventh character is not a U+0020 SPACE character, a U+0009
  CHARACTER TABULATION (tab) character, or a U+000A LINE FEED (LF) character, then abort these steps.
- The file does not start with the correct <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file①⑤">WebVTT file</a> signature and was therefore not
+ The file does not start with the correct <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file-16">WebVTT file</a> signature and was therefore not
  successfully processed.</p>
     <li>
-     <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points" id="ref-for-collect-a-sequence-of-code-points">collect a sequence of code points</a> that are <em>not</em> U+000A LINE FEED (LF)
+     <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points">collect a sequence of code points</a> that are <em>not</em> U+000A LINE FEED (LF)
  characters.</p>
     <li>
      <p>If <var>position</var> is past the end of <var>input</var>, then abort these steps. The file was successfully
- processed, but it contains no useful data and so no <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue①⑤">WebVTT cues</a> were added
+ processed, but it contains no useful data and so no <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-16">WebVTT cues</a> were added
  to <var>output</var>.</p>
     <li>
      <p>The character indicated by <var>position</var> is a U+000A LINE FEED (LF) character. Advance <var>position</var> to the next character in <var>input</var>.</p>
     <li>
      <p>If <var>position</var> is past the end of <var>input</var>, then abort these steps. The file was successfully
- processed, but it contains no useful data and so no <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue①⑥">WebVTT cues</a> were added
+ processed, but it contains no useful data and so no <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-17">WebVTT cues</a> were added
  to <var>output</var>.</p>
     <li>
      <p><i>Header</i>: If the character indicated by <var>position</var> is not a U+000A LINE FEED (LF)
- character, then <a data-link-type="dfn" href="#collect-a-webvtt-block" id="ref-for-collect-a-webvtt-block">collect a WebVTT block</a> with the <i>in header</i> flag set. Otherwise,
+ character, then <a data-link-type="dfn" href="#collect-a-webvtt-block" id="ref-for-collect-a-webvtt-block-1">collect a WebVTT block</a> with the <i>in header</i> flag set. Otherwise,
  advance <var>position</var> to the next character in <var>input</var>.</p>
     <li>
-     <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points" id="ref-for-collect-a-sequence-of-code-points①">collect a sequence of code points</a> that are U+000A LINE FEED (LF) characters.</p>
+     <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points">collect a sequence of code points</a> that are U+000A LINE FEED (LF) characters.</p>
     <li>
-     <p>Let <var>regions</var> be an empty <a data-link-type="dfn" href="#text-track-list-of-regions" id="ref-for-text-track-list-of-regions">text track list of regions</a>.</p>
+     <p>Let <var>regions</var> be an empty <a data-link-type="dfn" href="#text-track-list-of-regions" id="ref-for-text-track-list-of-regions-1">text track list of regions</a>.</p>
     <li>
      <p><i>Block loop</i>: While <var>position</var> doesn’t point past the end of <var>input</var>:</p>
      <ol>
       <li>
-       <p><a data-link-type="dfn" href="#collect-a-webvtt-block" id="ref-for-collect-a-webvtt-block①">Collect a WebVTT block</a>, and let <var>block</var> be the returned value.</p>
+       <p><a data-link-type="dfn" href="#collect-a-webvtt-block" id="ref-for-collect-a-webvtt-block-2">Collect a WebVTT block</a>, and let <var>block</var> be the returned value.</p>
       <li>
-       <p>If <var>block</var> is a <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue①⑦">WebVTT cue</a>, add <var>block</var> to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-list-of-cues" id="ref-for-text-track-list-of-cues③">text track list of cues</a> <var>output</var>.</p>
+       <p>If <var>block</var> is a <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-18">WebVTT cue</a>, add <var>block</var> to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-list-of-cues">text track list of cues</a> <var>output</var>.</p>
       <li>
-       <p>Otherwise, if <var>block</var> is a <a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#css-style-sheet" id="ref-for-css-style-sheet②">CSS style sheet</a>, add <var>block</var> to <var>stylesheets</var>.</p>
+       <p>Otherwise, if <var>block</var> is a <a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#css-style-sheet">CSS style sheet</a>, add <var>block</var> to <var>stylesheets</var>.</p>
       <li>
-       <p>Otherwise, if <var>block</var> is a <a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object">WebVTT region object</a>, add <var>block</var> to <var>regions</var>.</p>
+       <p>Otherwise, if <var>block</var> is a <a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object-1">WebVTT region object</a>, add <var>block</var> to <var>regions</var>.</p>
       <li>
-       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points" id="ref-for-collect-a-sequence-of-code-points②">collect a sequence of code points</a> that are U+000A LINE FEED (LF)
+       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points">collect a sequence of code points</a> that are U+000A LINE FEED (LF)
    characters.</p>
      </ol>
     <li>
-     <p><i>End</i>: The file has ended. Abort these steps. The <a data-link-type="dfn" href="#webvtt-parser" id="ref-for-webvtt-parser③">WebVTT parser</a> has finished.
+     <p><i>End</i>: The file has ended. Abort these steps. The <a data-link-type="dfn" href="#webvtt-parser" id="ref-for-webvtt-parser-4">WebVTT parser</a> has finished.
  The file was successfully processed.</p>
    </ol>
    <p>When the algorithm above says to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="collect-a-webvtt-block">collect a WebVTT block</dfn>, optionally with a flag <i>in
@@ -3136,7 +3135,7 @@ header</i> set, the user agent must run the following steps:</p>
      <p><i>Loop</i>: Run these substeps in a loop:</p>
      <ol>
       <li>
-       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points" id="ref-for-collect-a-sequence-of-code-points③">collect a sequence of code points</a> that are <em>not</em> U+000A LINE FEED (LF)
+       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points">collect a sequence of code points</a> that are <em>not</em> U+000A LINE FEED (LF)
    characters. Let <var>line</var> be those characters, if any.</p>
       <li>
        <p>Increment <var>line count</var> by 1.</p>
@@ -3163,36 +3162,36 @@ header</i> set, the user agent must run the following steps:</p>
           <li>
            <p>Let <var>previous position</var> be <var>position</var>.</p>
           <li>
-           <p><i>Cue creation</i>: Let <var>cue</var> be a new <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue①⑧">WebVTT cue</a> and initialize it as
+           <p><i>Cue creation</i>: Let <var>cue</var> be a new <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-19">WebVTT cue</a> and initialize it as
         follows:</p>
            <ol>
             <li>
-             <p>Let <var>cue</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-identifier" id="ref-for-text-track-cue-identifier">text track cue identifier</a> be <var>buffer</var>.</p>
+             <p>Let <var>cue</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-identifier">text track cue identifier</a> be <var>buffer</var>.</p>
             <li>
-             <p>Let <var>cue</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-pause-on-exit-flag" id="ref-for-text-track-cue-pause-on-exit-flag">text track cue pause-on-exit flag</a> be false.</p>
+             <p>Let <var>cue</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-pause-on-exit-flag">text track cue pause-on-exit flag</a> be false.</p>
             <li>
-             <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-region" id="ref-for-webvtt-cue-region①">WebVTT cue region</a> be null.</p>
+             <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-region" id="ref-for-webvtt-cue-region-2">WebVTT cue region</a> be null.</p>
             <li>
-             <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction①②">WebVTT cue writing direction</a> be <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction①②">horizontal</a>.</p>
+             <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-13">WebVTT cue writing direction</a> be <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction-13">horizontal</a>.</p>
             <li>
-             <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag⑧">WebVTT cue snap-to-lines flag</a> be true.</p>
+             <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag-9">WebVTT cue snap-to-lines flag</a> be true.</p>
             <li>
-             <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line②⓪">WebVTT cue line</a> be <a data-link-type="dfn" href="#webvtt-cue-line-automatic" id="ref-for-webvtt-cue-line-automatic③">auto</a>.</p>
+             <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line-21">WebVTT cue line</a> be <a data-link-type="dfn" href="#webvtt-cue-line-automatic" id="ref-for-webvtt-cue-line-automatic-4">auto</a>.</p>
             <li>
-             <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-line-alignment" id="ref-for-webvtt-cue-line-alignment⑤">WebVTT cue line alignment</a> be <a data-link-type="dfn" href="#webvtt-cue-line-start-alignment" id="ref-for-webvtt-cue-line-start-alignment③">start alignment</a>.</p>
+             <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-line-alignment" id="ref-for-webvtt-cue-line-alignment-6">WebVTT cue line alignment</a> be <a data-link-type="dfn" href="#webvtt-cue-line-start-alignment" id="ref-for-webvtt-cue-line-start-alignment-4">start alignment</a>.</p>
             <li>
-             <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position①⑨">WebVTT cue position</a> be <a data-link-type="dfn" href="#webvtt-cue-automatic-position" id="ref-for-webvtt-cue-automatic-position⑤">auto</a>.</p>
+             <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position-20">WebVTT cue position</a> be <a data-link-type="dfn" href="#webvtt-cue-automatic-position" id="ref-for-webvtt-cue-automatic-position-6">auto</a>.</p>
             <li>
-             <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-position-alignment" id="ref-for-webvtt-cue-position-alignment⑥">WebVTT cue position alignment</a> be <a data-link-type="dfn" href="#webvtt-cue-position-automatic-alignment" id="ref-for-webvtt-cue-position-automatic-alignment②">auto</a>.</p>
+             <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-position-alignment" id="ref-for-webvtt-cue-position-alignment-7">WebVTT cue position alignment</a> be <a data-link-type="dfn" href="#webvtt-cue-position-automatic-alignment" id="ref-for-webvtt-cue-position-automatic-alignment-3">auto</a>.</p>
             <li>
-             <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-size" id="ref-for-webvtt-cue-size⑥">WebVTT cue size</a> be 100.</p>
+             <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-size" id="ref-for-webvtt-cue-size-7">WebVTT cue size</a> be 100.</p>
             <li>
-             <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment①②">WebVTT cue text alignment</a> be <a data-link-type="dfn" href="#webvtt-cue-center-alignment" id="ref-for-webvtt-cue-center-alignment④">center alignment</a>.</p>
+             <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment-13">WebVTT cue text alignment</a> be <a data-link-type="dfn" href="#webvtt-cue-center-alignment" id="ref-for-webvtt-cue-center-alignment-5">center alignment</a>.</p>
             <li>
-             <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#text-track-cue-text" id="ref-for-text-track-cue-text①">text track cue text</a> be the empty string.</p>
+             <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#text-track-cue-text" id="ref-for-text-track-cue-text-2">text track cue text</a> be the empty string.</p>
            </ol>
           <li>
-           <p><a data-link-type="dfn" href="#collect-webvtt-cue-timings-and-settings" id="ref-for-collect-webvtt-cue-timings-and-settings">Collect WebVTT cue timings and settings</a> from <var>line</var> using <var>regions</var> for <var>cue</var>.
+           <p><a data-link-type="dfn" href="#collect-webvtt-cue-timings-and-settings" id="ref-for-collect-webvtt-cue-timings-and-settings-1">Collect WebVTT cue timings and settings</a> from <var>line</var> using <var>regions</var> for <var>cue</var>.
        If that fails, let <var>cue</var> be null. Otherwise, let <var>buffer</var> be the empty string and let <var>seen
        cue</var> be true.</p>
          </ol>
@@ -3210,28 +3209,28 @@ header</i> set, the user agent must run the following steps:</p>
            <p>If <var>seen cue</var> is false and <var>buffer</var> starts with the substring "<code>STYLE</code>"
         (U+0053 LATIN CAPITAL LETTER S, U+0054 LATIN CAPITAL LETTER T, U+0059 LATIN CAPITAL LETTER
         Y, U+004C LATIN CAPITAL LETTER L, U+0045 LATIN CAPITAL LETTER E), and the remaining
-        characters in <var>buffer</var> (if any) are all <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-whitespace" id="ref-for-ascii-whitespace①">ASCII whitespace</a>, then run these
+        characters in <var>buffer</var> (if any) are all <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-whitespace">ASCII whitespace</a>, then run these
         substeps:</p>
            <ol>
             <li>
-             <p>Let <var>stylesheet</var> be the result of <a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#create-a-css-style-sheet" id="ref-for-create-a-css-style-sheet">creating
+             <p>Let <var>stylesheet</var> be the result of <a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#create-a-css-style-sheet">creating
           a CSS style sheet</a>, with the following properties: <a data-link-type="biblio" href="#biblio-cssom">[CSSOM]</a></p>
              <dl>
-              <dt><a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-location" id="ref-for-concept-css-style-sheet-location">location</a>
+              <dt><a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-location">location</a>
               <dd>null
-              <dt><a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-parent-css-style-sheet" id="ref-for-concept-css-style-sheet-parent-css-style-sheet">parent CSS style sheet</a>
+              <dt><a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-parent-css-style-sheet">parent CSS style sheet</a>
               <dd>null
-              <dt><a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-owner-node" id="ref-for-concept-css-style-sheet-owner-node">owner node</a>
+              <dt><a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-owner-node">owner node</a>
               <dd>null
-              <dt><a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-owner-css-rule" id="ref-for-concept-css-style-sheet-owner-css-rule">owner CSS rule</a>
+              <dt><a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-owner-css-rule">owner CSS rule</a>
               <dd>null
-              <dt><a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-media" id="ref-for-concept-css-style-sheet-media">media</a>
+              <dt><a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-media">media</a>
               <dd>The empty string.
-              <dt><a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-title" id="ref-for-concept-css-style-sheet-title">title</a>
+              <dt><a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-title">title</a>
               <dd>The empty string.
-              <dt><a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-alternate-flag" id="ref-for-concept-css-style-sheet-alternate-flag">alternate flag</a>
+              <dt><a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-alternate-flag">alternate flag</a>
               <dd>Unset.
-              <dt><a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-origin-clean-flag" id="ref-for-concept-css-style-sheet-origin-clean-flag">origin-clean flag</a>
+              <dt><a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-origin-clean-flag">origin-clean flag</a>
               <dd>Set.
              </dl>
             <li>
@@ -3241,25 +3240,25 @@ header</i> set, the user agent must run the following steps:</p>
            <p>Otherwise, if <var>seen cue</var> is false and <var>buffer</var> starts with the substring
         "<code>REGION</code>" (U+0052 LATIN CAPITAL LETTER R, U+0045 LATIN CAPITAL LETTER E, U+0047
         LATIN CAPITAL LETTER G, U+0049 LATIN CAPITAL LETTER I, U+004F LATIN CAPITAL LETTER O, U+004E
-        LATIN CAPITAL LETTER N), and the remaining characters in <var>buffer</var> (if any) are all <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-whitespace" id="ref-for-ascii-whitespace②">ASCII
+        LATIN CAPITAL LETTER N), and the remaining characters in <var>buffer</var> (if any) are all <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-whitespace">ASCII
         whitespace</a>, then run these substeps:</p>
            <ol>
             <li>
-             <p><i>Region creation</i>: Let <var>region</var> be a new <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region⑧">WebVTT region</a>.</p>
+             <p><i>Region creation</i>: Let <var>region</var> be a new <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region-9">WebVTT region</a>.</p>
             <li>
-             <p>Let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-identifier" id="ref-for-webvtt-region-identifier①">identifier</a> be the empty
+             <p>Let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-identifier" id="ref-for-webvtt-region-identifier-2">identifier</a> be the empty
          string.</p>
             <li>
-             <p>Let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-width" id="ref-for-webvtt-region-width">width</a> be 100.</p>
+             <p>Let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-width" id="ref-for-webvtt-region-width-1">width</a> be 100.</p>
             <li>
-             <p>Let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-lines" id="ref-for-webvtt-region-lines">lines</a> be 3.</p>
+             <p>Let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-lines" id="ref-for-webvtt-region-lines-1">lines</a> be 3.</p>
             <li>
-             <p>Let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-anchor" id="ref-for-webvtt-region-anchor">anchor point</a> be (0,100).</p>
+             <p>Let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-anchor" id="ref-for-webvtt-region-anchor-1">anchor point</a> be (0,100).</p>
             <li>
-             <p>Let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-viewport-anchor" id="ref-for-webvtt-region-viewport-anchor">viewport anchor point</a> be
+             <p>Let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-viewport-anchor" id="ref-for-webvtt-region-viewport-anchor-1">viewport anchor point</a> be
          (0,100).</p>
             <li>
-             <p>Let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-scroll" id="ref-for-webvtt-region-scroll">scroll value</a> be <a data-link-type="dfn" href="#webvtt-region-scroll-none" id="ref-for-webvtt-region-scroll-none">none</a>.</p>
+             <p>Let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-scroll" id="ref-for-webvtt-region-scroll-1">scroll value</a> be <a data-link-type="dfn" href="#webvtt-region-scroll-none" id="ref-for-webvtt-region-scroll-none-1">none</a>.</p>
             <li>
              <p>Let <var>buffer</var> be the empty string.</p>
            </ol>
@@ -3275,24 +3274,25 @@ header</i> set, the user agent must run the following steps:</p>
        <p>If <var>seen EOF</var> is true, break out of <i>loop</i>.</p>
      </ol>
     <li>
-     <p>If <var>cue</var> is not null, let the <a data-link-type="dfn" href="#text-track-cue-text" id="ref-for-text-track-cue-text②">text track cue text</a> of <var>cue</var> be <var>buffer</var>, and return <var>cue</var>.</p>
+     <p>If <var>cue</var> is not null, let the <a data-link-type="dfn" href="#text-track-cue-text" id="ref-for-text-track-cue-text-3">text track cue text</a> of <var>cue</var> be <var>buffer</var>, and return <var>cue</var>.</p>
     <li>
-     <p>Otherwise, if <var>stylesheet</var> is not null, then <a data-link-type="dfn" href="https://drafts.csswg.org/css-syntax-3/#parse-a-stylesheet" id="ref-for-parse-a-stylesheet">Parse a stylesheet</a> from <var>buffer</var>. If it returned a list of rules, assign the list as <var>stylesheet</var>’s <a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-css-rules" id="ref-for-concept-css-style-sheet-css-rules">CSS rules</a>; otherwise, set <var>stylesheet</var>’s <a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-css-rules" id="ref-for-concept-css-style-sheet-css-rules①">CSS
+     <p>Otherwise, if <var>stylesheet</var> is not null, then <a data-link-type="dfn" href="https://drafts.csswg.org/css-syntax-3/#parse-a-stylesheet">Parse a stylesheet</a> from <var>buffer</var>. If it returned a list of rules, assign the list as <var>stylesheet</var>’s <a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-css-rules">CSS rules</a>; otherwise, set <var>stylesheet</var>’s <a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-css-rules">CSS
  rules</a> to an empty list. <a data-link-type="biblio" href="#biblio-cssom">[CSSOM]</a> <a data-link-type="biblio" href="#biblio-css-syntax-3">[CSS-SYNTAX-3]</a> Finally, return <var>stylesheet</var>.</p>
     <li>
-     <p>Otherwise, if <var>region</var> is not null, then <a data-link-type="dfn" href="#collect-webvtt-region-settings" id="ref-for-collect-webvtt-region-settings">collect WebVTT region settings</a> from <var>buffer</var> using <var>region</var> for the results. Construct a <a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object①">WebVTT Region Object</a> from <var>region</var>, and return
+     <p>Otherwise, if <var>region</var> is not null, then <a data-link-type="dfn" href="#collect-webvtt-region-settings" id="ref-for-collect-webvtt-region-settings-1">collect WebVTT region settings</a> from <var>buffer</var> using <var>region</var> for the results. Construct a <a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object-2">WebVTT Region Object</a> from <var>region</var>, and return
  it.</p>
     <li>
      <p>Otherwise, return null.</p>
    </ol>
    <h3 class="heading settled algorithm" data-algorithm="WebVTT region settings parsing" data-level="5.2" id="region-settings-parsing"><span class="secno">5.2. </span><span class="content">WebVTT region settings parsing</span><a class="self-link" href="#region-settings-parsing"></a></h3>
-   <p>When the <a data-link-type="dfn" href="#webvtt-parser" id="ref-for-webvtt-parser④">WebVTT parser</a> says to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="collect-webvtt-region-settings">collect WebVTT region settings</dfn> from a string <var>input</var> for a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track" id="ref-for-text-track⑧">text track</a>, the user agent must run the following algorithm.</p>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-region-object">WebVTT region object</dfn> is a conceptual construct to represent a <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region⑨">WebVTT region</a> that is used as a root node for <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects">lists of WebVTT node
-objects</a>. This algorithm returns a list of <a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object②">WebVTT Region
+   <p>When the <a data-link-type="dfn" href="#webvtt-parser-algorithm" id="ref-for-webvtt-parser-algorithm-2">WebVTT parser algorithm</a> says to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="collect-webvtt-region-settings">collect WebVTT region settings</dfn> from a
+string <var>input</var> for a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track">text track</a>, the user agent must run the following algorithm.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-region-object">WebVTT region object</dfn> is a conceptual construct to represent a <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region-10">WebVTT region</a> that is used as a root node for <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-1">lists of WebVTT node
+objects</a>. This algorithm returns a list of <a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object-3">WebVTT Region
 Objects</a>.</p>
    <ol class="algorithm">
     <li>
-     <p>Let <var>settings</var> be the result of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#split-a-string-on-spaces" id="ref-for-split-a-string-on-spaces">splitting <var>input</var> on
+     <p>Let <var>settings</var> be the result of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#split-a-string-on-spaces">splitting <var>input</var> on
  spaces</a>.</p>
     <li>
       For each token <var>setting</var> in the list <var>settings</var>, run the following substeps: 
@@ -3311,25 +3311,25 @@ Objects</a>.</p>
        <p>Run the appropriate substeps that apply for the value of <var>name</var>, as follows:</p>
        <dl>
         <dt>
-         <p>If <var>name</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive">case-sensitive</a> match for "<code>id</code>"</p>
+         <p>If <var>name</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">case-sensitive</a> match for "<code>id</code>"</p>
         <dd>
-         <p>Let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-identifier" id="ref-for-webvtt-region-identifier②">identifier</a> be <var>value</var>.</p>
+         <p>Let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-identifier" id="ref-for-webvtt-region-identifier-3">identifier</a> be <var>value</var>.</p>
         <dt>
-         <p>Otherwise if <var>name</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive①">case-sensitive</a> match for "<code>width</code>"</p>
+         <p>Otherwise if <var>name</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">case-sensitive</a> match for "<code>width</code>"</p>
         <dd>
-         <p>If <a data-link-type="dfn" href="#parse-a-percentage-string" id="ref-for-parse-a-percentage-string">parse a percentage string</a> from <var>value</var> returns a <var>percentage</var>, let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-width" id="ref-for-webvtt-region-width①">WebVTT region width</a> be <var>percentage</var>.</p>
-        <dt>Otherwise if <var>name</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive②">case-sensitive</a> match for "<code>lines</code>"
+         <p>If <a data-link-type="dfn" href="#parse-a-percentage-string" id="ref-for-parse-a-percentage-string-1">parse a percentage string</a> from <var>value</var> returns a <var>percentage</var>, let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-width" id="ref-for-webvtt-region-width-2">WebVTT region width</a> be <var>percentage</var>.</p>
+        <dt>Otherwise if <var>name</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">case-sensitive</a> match for "<code>lines</code>"
         <dd>
          <ol>
           <li>
-           <p>If <var>value</var> contains any characters other than <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits" id="ref-for-ascii-digits⑧">ASCII digits</a>, then jump to the
+           <p>If <var>value</var> contains any characters other than <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits">ASCII digits</a>, then jump to the
        step labeled <i>next setting</i>.</p>
           <li>
            <p>Interpret <var>value</var> as an integer, and let <var>number</var> be that number.</p>
           <li>
-           <p>Let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-lines" id="ref-for-webvtt-region-lines①">WebVTT region lines</a> be <var>number</var>.</p>
+           <p>Let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-lines" id="ref-for-webvtt-region-lines-2">WebVTT region lines</a> be <var>number</var>.</p>
          </ol>
-        <dt>Otherwise if <var>name</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive③">case-sensitive</a> match for "<code>regionanchor</code>"
+        <dt>Otherwise if <var>name</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">case-sensitive</a> match for "<code>regionanchor</code>"
         <dd>
          <ol>
           <li>
@@ -3342,13 +3342,13 @@ Objects</a>.</p>
            <p>Let <var>anchorY</var> be the trailing substring of <var>value</var> starting from the character
        immediately after the first U+002C COMMA character (,) in that string.</p>
           <li>
-           <p>If <a data-link-type="dfn" href="#parse-a-percentage-string" id="ref-for-parse-a-percentage-string①">parse a percentage string</a> from <var>anchorX</var> or <a data-link-type="dfn" href="#parse-a-percentage-string" id="ref-for-parse-a-percentage-string②">parse a percentage string</a> from <var>anchorY</var> don’t return a <var>percentage</var>, then jump to the step labeled <i>next
+           <p>If <a data-link-type="dfn" href="#parse-a-percentage-string" id="ref-for-parse-a-percentage-string-2">parse a percentage string</a> from <var>anchorX</var> or <a data-link-type="dfn" href="#parse-a-percentage-string" id="ref-for-parse-a-percentage-string-3">parse a percentage string</a> from <var>anchorY</var> don’t return a <var>percentage</var>, then jump to the step labeled <i>next
        setting</i>.</p>
           <li>
-           <p>Let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-anchor" id="ref-for-webvtt-region-anchor①">WebVTT region anchor point</a> be the
+           <p>Let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-anchor" id="ref-for-webvtt-region-anchor-2">WebVTT region anchor point</a> be the
        tuple of the <var>percentage</var> values calculated from <var>anchorX</var> and <var>anchorY</var>.</p>
          </ol>
-        <dt>Otherwise if <var>name</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive④">case-sensitive</a> match for "<code>viewportanchor</code>"
+        <dt>Otherwise if <var>name</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">case-sensitive</a> match for "<code>viewportanchor</code>"
         <dd>
          <ol>
           <li>
@@ -3361,17 +3361,17 @@ Objects</a>.</p>
            <p>Let <var>viewportanchorY</var> be the trailing substring of <var>value</var> starting from the character
        immediately after the first U+002C COMMA character (,) in that string.</p>
           <li>
-           <p>If <a data-link-type="dfn" href="#parse-a-percentage-string" id="ref-for-parse-a-percentage-string③">parse a percentage string</a> from <var>viewportanchorX</var> or <a data-link-type="dfn" href="#parse-a-percentage-string" id="ref-for-parse-a-percentage-string④">parse a percentage
+           <p>If <a data-link-type="dfn" href="#parse-a-percentage-string" id="ref-for-parse-a-percentage-string-4">parse a percentage string</a> from <var>viewportanchorX</var> or <a data-link-type="dfn" href="#parse-a-percentage-string" id="ref-for-parse-a-percentage-string-5">parse a percentage
        string</a> from <var>viewportanchorY</var> don’t return a <var>percentage</var>, then jump to the step labeled <i>next setting</i>.</p>
           <li>
-           <p>Let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-viewport-anchor" id="ref-for-webvtt-region-viewport-anchor①">WebVTT region viewport anchor
+           <p>Let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-viewport-anchor" id="ref-for-webvtt-region-viewport-anchor-2">WebVTT region viewport anchor
        point</a> be the tuple of the <var>percentage</var> values calculated from <var>viewportanchorX</var> and <var>viewportanchorY</var>.</p>
          </ol>
-        <dt>Otherwise if <var>name</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive⑤">case-sensitive</a> match for "<code>scroll</code>"
+        <dt>Otherwise if <var>name</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">case-sensitive</a> match for "<code>scroll</code>"
         <dd>
          <ol>
           <li>
-           <p>If <var>value</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive⑥">case-sensitive</a> match for the string "<code>up</code>", then let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-scroll" id="ref-for-webvtt-region-scroll①">scroll value</a> be <a data-link-type="dfn" href="#webvtt-region-scroll-up" id="ref-for-webvtt-region-scroll-up">up</a>.</p>
+           <p>If <var>value</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">case-sensitive</a> match for the string "<code>up</code>", then let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-scroll" id="ref-for-webvtt-region-scroll-2">scroll value</a> be <a data-link-type="dfn" href="#webvtt-region-scroll-up" id="ref-for-webvtt-region-scroll-up-1">up</a>.</p>
          </ol>
        </dl>
       <li><i>Next setting</i>: Continue to the next setting, if any.
@@ -3384,11 +3384,11 @@ means that it is aborted at that point and returns nothing.</p>
     <li>
      <p>Let <var>input</var> be the string being parsed.</p>
     <li>
-     <p>If <var>input</var> does not match the syntax for a <a data-link-type="dfn" href="#webvtt-percentage" id="ref-for-webvtt-percentage⑨">WebVTT percentage</a>, then fail.</p>
+     <p>If <var>input</var> does not match the syntax for a <a data-link-type="dfn" href="#webvtt-percentage" id="ref-for-webvtt-percentage-10">WebVTT percentage</a>, then fail.</p>
     <li>
      <p>Remove the last character from <var>input</var>.</p>
     <li>
-     <p>Let <var>percentage</var> be the result of parsing <var>input</var> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#rules-for-parsing-floating-point-number-values" id="ref-for-rules-for-parsing-floating-point-number-values">rules for parsing
+     <p>Let <var>percentage</var> be the result of parsing <var>input</var> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#rules-for-parsing-floating-point-number-values">rules for parsing
  floating-point number values</a>. <a data-link-type="biblio" href="#biblio-html">[HTML]</a></p>
     <li>
      <p>If <var>percentage</var> is an error, is less than 0, or is greater than 100, then fail.</p>
@@ -3397,7 +3397,7 @@ means that it is aborted at that point and returns nothing.</p>
    </ol>
    <h3 class="heading settled algorithm" data-algorithm="WebVTT cue timings and settings parsing" data-level="5.3" id="cue-timings-and-settings-parsing"><span class="secno">5.3. </span><span class="content">WebVTT cue timings and settings parsing</span><a class="self-link" href="#cue-timings-and-settings-parsing"></a></h3>
    <p>When the algorithm above requires to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="collect-webvtt-cue-timings-and-settings">collect WebVTT cue timings and settings</dfn> from a
-string <var>input</var> using a <a data-link-type="dfn" href="#text-track-list-of-regions" id="ref-for-text-track-list-of-regions①">text track list of regions</a> <var>regions</var> for a <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue①⑨">WebVTT cue</a> <var>cue</var>,
+string <var>input</var> using a <a data-link-type="dfn" href="#text-track-list-of-regions" id="ref-for-text-track-list-of-regions-2">text track list of regions</a> <var>regions</var> for a <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-20">WebVTT cue</a> <var>cue</var>,
 the user agent must run the following algorithm.</p>
    <ol class="algorithm">
     <li>
@@ -3406,13 +3406,13 @@ the user agent must run the following algorithm.</p>
      <p>Let <var>position</var> be a pointer into <var>input</var>, initially pointing at the start of the
  string.</p>
     <li>
-     <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#skip-whitespace" id="ref-for-skip-whitespace">Skip whitespace</a>.</p>
+     <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#skip-whitespace">Skip whitespace</a>.</p>
     <li>
-     <p><a data-link-type="dfn" href="#collect-a-webvtt-timestamp" id="ref-for-collect-a-webvtt-timestamp">Collect a WebVTT timestamp</a>. If that algorithm fails, then abort these steps and
- return failure. Otherwise, let <var>cue</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-start-time" id="ref-for-text-track-cue-start-time">text track cue start time</a> be the collected
+     <p><a data-link-type="dfn" href="#collect-a-webvtt-timestamp" id="ref-for-collect-a-webvtt-timestamp-1">Collect a WebVTT timestamp</a>. If that algorithm fails, then abort these steps and
+ return failure. Otherwise, let <var>cue</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-start-time">text track cue start time</a> be the collected
  time.</p>
     <li>
-     <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#skip-whitespace" id="ref-for-skip-whitespace①">Skip whitespace</a>.</p>
+     <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#skip-whitespace">Skip whitespace</a>.</p>
     <li>
      <p>If  the character at <var>position</var> is not a
  U+002D HYPHEN-MINUS character (-) then abort these steps and return failure. Otherwise, move <var>position</var> forwards one character.</p>
@@ -3423,21 +3423,21 @@ the user agent must run the following algorithm.</p>
      <p>If  the character at <var>position</var> is not a
  U+003E GREATER-THAN SIGN character (>) then abort these steps and return failure. Otherwise, move <var>position</var> forwards one character.</p>
     <li>
-     <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#skip-whitespace" id="ref-for-skip-whitespace②">Skip whitespace</a>.</p>
+     <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#skip-whitespace">Skip whitespace</a>.</p>
     <li>
-     <p><a data-link-type="dfn" href="#collect-a-webvtt-timestamp" id="ref-for-collect-a-webvtt-timestamp①">Collect a WebVTT timestamp</a>. If that algorithm fails, then abort these steps and
- return failure. Otherwise, let <var>cue</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-end-time" id="ref-for-text-track-cue-end-time">text track cue end time</a> be the collected
+     <p><a data-link-type="dfn" href="#collect-a-webvtt-timestamp" id="ref-for-collect-a-webvtt-timestamp-2">Collect a WebVTT timestamp</a>. If that algorithm fails, then abort these steps and
+ return failure. Otherwise, let <var>cue</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-end-time">text track cue end time</a> be the collected
  time.</p>
     <li>
      <p>Let <var>remainder</var> be the trailing substring of <var>input</var> starting at <var>position</var>.</p>
     <li>
-     <p><a data-link-type="dfn" href="#parse-the-webvtt-cue-settings" id="ref-for-parse-the-webvtt-cue-settings">Parse the WebVTT cue settings</a> from <var>remainder</var> using <var>regions</var> for <var>cue</var>.</p>
+     <p><a data-link-type="dfn" href="#parse-the-webvtt-cue-settings" id="ref-for-parse-the-webvtt-cue-settings-1">Parse the WebVTT cue settings</a> from <var>remainder</var> using <var>regions</var> for <var>cue</var>.</p>
    </ol>
-   <p>When the user agent is to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="parse-the-webvtt-cue-settings">parse the WebVTT cue settings</dfn> from a string <var>input</var> using a <a data-link-type="dfn" href="#text-track-list-of-regions" id="ref-for-text-track-list-of-regions②">text track list of regions</a> <var>regions</var> for a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue" id="ref-for-text-track-cue①">text track cue</a> <var>cue</var>, the user agent must
+   <p>When the user agent is to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="parse-the-webvtt-cue-settings">parse the WebVTT cue settings</dfn> from a string <var>input</var> using a <a data-link-type="dfn" href="#text-track-list-of-regions" id="ref-for-text-track-list-of-regions-3">text track list of regions</a> <var>regions</var> for a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue">text track cue</a> <var>cue</var>, the user agent must
 run the following steps:</p>
    <ol class="algorithm">
     <li>
-     <p>Let <var>settings</var> be the result of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#split-a-string-on-spaces" id="ref-for-split-a-string-on-spaces①">splitting <var>input</var> on
+     <p>Let <var>settings</var> be the result of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#split-a-string-on-spaces">splitting <var>input</var> on
  spaces</a>.</p>
     <li>
      <p>For each token <var>setting</var> in the list <var>settings</var>, run the following substeps:</p>
@@ -3455,22 +3455,22 @@ run the following steps:</p>
       <li>
        <p>Run the appropriate substeps that apply for the value of <var>name</var>, as follows:</p>
        <dl>
-        <dt>If <var>name</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive⑦">case-sensitive</a> match for "<code>region</code>"
+        <dt>If <var>name</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">case-sensitive</a> match for "<code>region</code>"
         <dd>
          <ol>
           <li>
-           <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-region" id="ref-for-webvtt-cue-region②">WebVTT cue region</a> be the last <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region①⓪">WebVTT region</a> in <var>regions</var> whose <a data-link-type="dfn" href="#webvtt-region-identifier" id="ref-for-webvtt-region-identifier③">WebVTT region identifier</a> is <var>value</var>, if any, or null otherwise.</p>
+           <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-region" id="ref-for-webvtt-cue-region-3">WebVTT cue region</a> be the last <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region-11">WebVTT region</a> in <var>regions</var> whose <a data-link-type="dfn" href="#webvtt-region-identifier" id="ref-for-webvtt-region-identifier-4">WebVTT region identifier</a> is <var>value</var>, if any, or null otherwise.</p>
          </ol>
-        <dt>If <var>name</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive⑧">case-sensitive</a> match for "<code>vertical</code>"
+        <dt>If <var>name</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">case-sensitive</a> match for "<code>vertical</code>"
         <dd>
          <ol>
           <li>
-           <p>If <var>value</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive⑨">case-sensitive</a> match for the string "<code>rl</code>", then let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction①③">WebVTT cue writing direction</a> be <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-left-writing-direction" id="ref-for-webvtt-cue-vertical-growing-left-writing-direction③">vertical growing left</a>.</p>
+           <p>If <var>value</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">case-sensitive</a> match for the string "<code>rl</code>", then let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-14">WebVTT cue writing direction</a> be <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-left-writing-direction" id="ref-for-webvtt-cue-vertical-growing-left-writing-direction-4">vertical growing left</a>.</p>
           <li>
-           <p>Otherwise, if <var>value</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive①⓪">case-sensitive</a> match for the string
-       "<code>lr</code>", then let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction①④">WebVTT cue writing direction</a> be <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-right-writing-direction" id="ref-for-webvtt-cue-vertical-growing-right-writing-direction③">vertical growing right</a>.</p>
+           <p>Otherwise, if <var>value</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">case-sensitive</a> match for the string
+       "<code>lr</code>", then let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-15">WebVTT cue writing direction</a> be <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-right-writing-direction" id="ref-for-webvtt-cue-vertical-growing-right-writing-direction-4">vertical growing right</a>.</p>
          </ol>
-        <dt>If <var>name</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive①①">case-sensitive</a> match for "<code>line</code>"
+        <dt>If <var>name</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">case-sensitive</a> match for "<code>line</code>"
         <dd>
          <ol>
           <li>
@@ -3481,14 +3481,14 @@ run the following steps:</p>
           <li>
            <p>Otherwise let <var>linepos</var> be the full <var>value</var> string and <var>linealign</var> be null.</p>
           <li>
-           <p>If <var>linepos</var> does not contain at least one <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits" id="ref-for-ascii-digits⑨">ASCII digit</a>, then jump to the step
+           <p>If <var>linepos</var> does not contain at least one <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits">ASCII digit</a>, then jump to the step
        labeled <i>next setting</i>.</p>
           <li>
            <dl>
             <dt>
              <p>If the last character in <var>linepos</var> is a U+0025 PERCENT SIGN character (%)</p>
             <dd>
-             <p>If <a data-link-type="dfn" href="#parse-a-percentage-string" id="ref-for-parse-a-percentage-string⑤">parse a percentage string</a> from <var>linepos</var> doesn’t fail, let <var>number</var> be the
+             <p>If <a data-link-type="dfn" href="#parse-a-percentage-string" id="ref-for-parse-a-percentage-string-6">parse a percentage string</a> from <var>linepos</var> doesn’t fail, let <var>number</var> be the
          returned <var>percentage</var>, otherwise jump to the step labeled <i>next setting</i>.</p>
             <dt>
              <p>Otherwise</p>
@@ -3496,7 +3496,7 @@ run the following steps:</p>
              <ol>
               <li>
                <p>If <var>linepos</var> contains any characters other than U+002D HYPHEN-MINUS characters
-           (-), <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits" id="ref-for-ascii-digits①⓪">ASCII digits</a>, and U+002E DOT character (.), then jump to the step labeled <i>next setting</i>.</p>
+           (-), <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits">ASCII digits</a>, and U+002E DOT character (.), then jump to the step labeled <i>next setting</i>.</p>
               <li>
                <p>If any character in <var>linepos</var> other than the first character is a U+002D
            HYPHEN-MINUS character (-), then jump to the step labeled <i>next setting</i>.</p>
@@ -3505,10 +3505,10 @@ run the following steps:</p>
            labeled <i>next setting</i>.</p>
               <li>
                <p>If there is a U+002E DOT character (.) and the character before or the character
-           after is not an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits" id="ref-for-ascii-digits①①">ASCII digit</a>, or if the U+002E DOT character (.) is the first or
+           after is not an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits">ASCII digit</a>, or if the U+002E DOT character (.) is the first or
            the last character, then jump to the step labeled <i>next setting</i>.</p>
               <li>
-               <p>Let <var>number</var> be the result of parsing <var>linepos</var> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#rules-for-parsing-floating-point-number-values" id="ref-for-rules-for-parsing-floating-point-number-values①">rules for parsing
+               <p>Let <var>number</var> be the result of parsing <var>linepos</var> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#rules-for-parsing-floating-point-number-values">rules for parsing
            floating-point number values</a>. <a data-link-type="biblio" href="#biblio-html">[HTML]</a></p>
               <li>
                <p>If <var>number</var> is an error, then jump to the step labeled <i>next
@@ -3516,23 +3516,23 @@ run the following steps:</p>
              </ol>
            </dl>
           <li>
-           <p>If <var>linealign</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive①②">case-sensitive</a> match for the string "<code>start</code>",
-       then let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-line-alignment" id="ref-for-webvtt-cue-line-alignment⑥">WebVTT cue line alignment</a> be <a data-link-type="dfn" href="#webvtt-cue-line-start-alignment" id="ref-for-webvtt-cue-line-start-alignment④">start alignment</a>.</p>
+           <p>If <var>linealign</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">case-sensitive</a> match for the string "<code>start</code>",
+       then let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-line-alignment" id="ref-for-webvtt-cue-line-alignment-7">WebVTT cue line alignment</a> be <a data-link-type="dfn" href="#webvtt-cue-line-start-alignment" id="ref-for-webvtt-cue-line-start-alignment-5">start alignment</a>.</p>
           <li>
-           <p>Otherwise, if <var>linealign</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive①③">case-sensitive</a> match for the string
-       "<code>center</code>", then let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-line-alignment" id="ref-for-webvtt-cue-line-alignment⑦">WebVTT cue line alignment</a> be <a data-link-type="dfn" href="#webvtt-cue-line-center-alignment" id="ref-for-webvtt-cue-line-center-alignment①">center alignment</a>.</p>
+           <p>Otherwise, if <var>linealign</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">case-sensitive</a> match for the string
+       "<code>center</code>", then let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-line-alignment" id="ref-for-webvtt-cue-line-alignment-8">WebVTT cue line alignment</a> be <a data-link-type="dfn" href="#webvtt-cue-line-center-alignment" id="ref-for-webvtt-cue-line-center-alignment-2">center alignment</a>.</p>
           <li>
-           <p>Otherwise, if <var>linealign</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive①④">case-sensitive</a> match for the string
-       "<code>end</code>", then let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-line-alignment" id="ref-for-webvtt-cue-line-alignment⑧">WebVTT cue line alignment</a> be <a data-link-type="dfn" href="#webvtt-cue-line-end-alignment" id="ref-for-webvtt-cue-line-end-alignment①">end alignment</a>.</p>
+           <p>Otherwise, if <var>linealign</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">case-sensitive</a> match for the string
+       "<code>end</code>", then let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-line-alignment" id="ref-for-webvtt-cue-line-alignment-9">WebVTT cue line alignment</a> be <a data-link-type="dfn" href="#webvtt-cue-line-end-alignment" id="ref-for-webvtt-cue-line-end-alignment-2">end alignment</a>.</p>
           <li>
            <p>Otherwise, if <var>linealign</var> is not null, then jump to the step labeled <i>next
        setting</i>.</p>
           <li>
-           <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line②①">WebVTT cue line</a> be <var>number</var>.</p>
+           <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line-22">WebVTT cue line</a> be <var>number</var>.</p>
           <li>
-           <p>If the last character in <var>linepos</var> is a U+0025 PERCENT SIGN character (%), then let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag⑨">WebVTT cue snap-to-lines flag</a> be false. Otherwise, let it be true.</p>
+           <p>If the last character in <var>linepos</var> is a U+0025 PERCENT SIGN character (%), then let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag-10">WebVTT cue snap-to-lines flag</a> be false. Otherwise, let it be true.</p>
          </ol>
-        <dt>If <var>name</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive①⑤">case-sensitive</a> match for "<code>position</code>"
+        <dt>If <var>name</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">case-sensitive</a> match for "<code>position</code>"
         <dd>
          <ol>
           <li>
@@ -3543,54 +3543,54 @@ run the following steps:</p>
           <li>
            <p>Otherwise let <var>colpos</var> be the full <var>value</var> string and <var>colalign</var> be null.</p>
           <li>
-           <p>If <a data-link-type="dfn" href="#parse-a-percentage-string" id="ref-for-parse-a-percentage-string⑥">parse a percentage string</a> from <var>colpos</var> doesn’t fail, let <var>number</var> be the
-       returned <var>percentage</var>, otherwise jump to the step labeled <i>next setting</i> (<a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position②⓪">position</a>’s value remains the special value <a data-link-type="dfn" href="#webvtt-cue-automatic-position" id="ref-for-webvtt-cue-automatic-position⑥">auto</a>).</p>
+           <p>If <a data-link-type="dfn" href="#parse-a-percentage-string" id="ref-for-parse-a-percentage-string-7">parse a percentage string</a> from <var>colpos</var> doesn’t fail, let <var>number</var> be the
+       returned <var>percentage</var>, otherwise jump to the step labeled <i>next setting</i> (<a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position-21">position</a>’s value remains the special value <a data-link-type="dfn" href="#webvtt-cue-automatic-position" id="ref-for-webvtt-cue-automatic-position-7">auto</a>).</p>
           <li>
-           <p>If <var>colalign</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive①⑥">case-sensitive</a> match for the string
-       "<code>line-left</code>", then let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-position-alignment" id="ref-for-webvtt-cue-position-alignment⑦">WebVTT cue position alignment</a> be <a data-link-type="dfn" href="#webvtt-cue-position-line-left-alignment" id="ref-for-webvtt-cue-position-line-left-alignment③">line-left alignment</a>.</p>
+           <p>If <var>colalign</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">case-sensitive</a> match for the string
+       "<code>line-left</code>", then let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-position-alignment" id="ref-for-webvtt-cue-position-alignment-8">WebVTT cue position alignment</a> be <a data-link-type="dfn" href="#webvtt-cue-position-line-left-alignment" id="ref-for-webvtt-cue-position-line-left-alignment-4">line-left alignment</a>.</p>
           <li>
-           <p>Otherwise, if <var>colalign</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive①⑦">case-sensitive</a> match for the string
-       "<code>center</code>", then let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-position-alignment" id="ref-for-webvtt-cue-position-alignment⑧">WebVTT cue position alignment</a> be <a data-link-type="dfn" href="#webvtt-cue-position-center-alignment" id="ref-for-webvtt-cue-position-center-alignment①">center alignment</a>.</p>
+           <p>Otherwise, if <var>colalign</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">case-sensitive</a> match for the string
+       "<code>center</code>", then let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-position-alignment" id="ref-for-webvtt-cue-position-alignment-9">WebVTT cue position alignment</a> be <a data-link-type="dfn" href="#webvtt-cue-position-center-alignment" id="ref-for-webvtt-cue-position-center-alignment-2">center alignment</a>.</p>
           <li>
-           <p>Otherwise, if <var>colalign</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive①⑧">case-sensitive</a> match for the string
-       "<code>line-right</code>", then let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-position-alignment" id="ref-for-webvtt-cue-position-alignment⑨">WebVTT cue position alignment</a> be <a data-link-type="dfn" href="#webvtt-cue-position-line-right-alignment" id="ref-for-webvtt-cue-position-line-right-alignment②">line-right alignment</a>.</p>
+           <p>Otherwise, if <var>colalign</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">case-sensitive</a> match for the string
+       "<code>line-right</code>", then let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-position-alignment" id="ref-for-webvtt-cue-position-alignment-10">WebVTT cue position alignment</a> be <a data-link-type="dfn" href="#webvtt-cue-position-line-right-alignment" id="ref-for-webvtt-cue-position-line-right-alignment-3">line-right alignment</a>.</p>
           <li>
            <p>Otherwise, if <var>colalign</var> is not null, then jump to the step labeled <i>next
        setting</i>.</p>
           <li>
-           <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position②①">position</a> be <var>number</var>.</p>
+           <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position-22">position</a> be <var>number</var>.</p>
          </ol>
-        <dt>If <var>name</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive①⑨">case-sensitive</a> match for "<code>size</code>"
+        <dt>If <var>name</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">case-sensitive</a> match for "<code>size</code>"
         <dd>
          <ol>
           <li>
-           <p>If <a data-link-type="dfn" href="#parse-a-percentage-string" id="ref-for-parse-a-percentage-string⑦">parse a percentage string</a> from <var>value</var> doesn’t fail, let <var>number</var> be the
+           <p>If <a data-link-type="dfn" href="#parse-a-percentage-string" id="ref-for-parse-a-percentage-string-8">parse a percentage string</a> from <var>value</var> doesn’t fail, let <var>number</var> be the
        returned <var>percentage</var>, otherwise jump to the step labeled <i>next setting</i>.</p>
           <li>
-           <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-size" id="ref-for-webvtt-cue-size⑦">WebVTT cue size</a> be <var>number</var>.</p>
+           <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-size" id="ref-for-webvtt-cue-size-8">WebVTT cue size</a> be <var>number</var>.</p>
          </ol>
-        <dt>If <var>name</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive②⓪">case-sensitive</a> match for "<code>align</code>"
+        <dt>If <var>name</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">case-sensitive</a> match for "<code>align</code>"
         <dd>
          <ol>
           <li>
-           <p>If <var>value</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive②①">case-sensitive</a> match for the string "<code>start</code>", then
-       let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment①③">WebVTT cue text alignment</a> be <a data-link-type="dfn" href="#webvtt-cue-start-alignment" id="ref-for-webvtt-cue-start-alignment⑤">start
+           <p>If <var>value</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">case-sensitive</a> match for the string "<code>start</code>", then
+       let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment-14">WebVTT cue text alignment</a> be <a data-link-type="dfn" href="#webvtt-cue-start-alignment" id="ref-for-webvtt-cue-start-alignment-6">start
        alignment</a>.</p>
           <li>
-           <p>If <var>value</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive②②">case-sensitive</a> match for the string "<code>center</code>", then
-       let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment①④">WebVTT cue text alignment</a> be <a data-link-type="dfn" href="#webvtt-cue-center-alignment" id="ref-for-webvtt-cue-center-alignment⑤">center
+           <p>If <var>value</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">case-sensitive</a> match for the string "<code>center</code>", then
+       let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment-15">WebVTT cue text alignment</a> be <a data-link-type="dfn" href="#webvtt-cue-center-alignment" id="ref-for-webvtt-cue-center-alignment-6">center
        alignment</a>.</p>
           <li>
-           <p>If <var>value</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive②③">case-sensitive</a> match for the string "<code>end</code>", then
-       let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment①⑤">WebVTT cue text alignment</a> be <a data-link-type="dfn" href="#webvtt-cue-end-alignment" id="ref-for-webvtt-cue-end-alignment④">end
+           <p>If <var>value</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">case-sensitive</a> match for the string "<code>end</code>", then
+       let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment-16">WebVTT cue text alignment</a> be <a data-link-type="dfn" href="#webvtt-cue-end-alignment" id="ref-for-webvtt-cue-end-alignment-5">end
        alignment</a>.</p>
           <li>
-           <p>If <var>value</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive②④">case-sensitive</a> match for the string "<code>left</code>", then
-       let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment①⑥">WebVTT cue text alignment</a> be <a data-link-type="dfn" href="#webvtt-cue-left-alignment" id="ref-for-webvtt-cue-left-alignment④">left
+           <p>If <var>value</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">case-sensitive</a> match for the string "<code>left</code>", then
+       let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment-17">WebVTT cue text alignment</a> be <a data-link-type="dfn" href="#webvtt-cue-left-alignment" id="ref-for-webvtt-cue-left-alignment-5">left
        alignment</a>.</p>
           <li>
-           <p>If <var>value</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive②⑤">case-sensitive</a> match for the string "<code>right</code>", then
-       let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment①⑦">WebVTT cue text alignment</a> be <a data-link-type="dfn" href="#webvtt-cue-right-alignment" id="ref-for-webvtt-cue-right-alignment④">right
+           <p>If <var>value</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">case-sensitive</a> match for the string "<code>right</code>", then
+       let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment-18">WebVTT cue text alignment</a> be <a data-link-type="dfn" href="#webvtt-cue-right-alignment" id="ref-for-webvtt-cue-right-alignment-5">right
        alignment</a>.</p>
          </ol>
        </dl>
@@ -3609,10 +3609,10 @@ user agent must run the following steps:</p>
     <li>
      <p>If <var>position</var> is past the end of <var>input</var>, return an error and abort these steps.</p>
     <li>
-     <p>If the character indicated by <var>position</var> is not an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits" id="ref-for-ascii-digits①②">ASCII digit</a>, then return an error
+     <p>If the character indicated by <var>position</var> is not an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits">ASCII digit</a>, then return an error
  and abort these steps.</p>
     <li>
-     <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points" id="ref-for-collect-a-sequence-of-code-points④">Collect a sequence of code points</a> that are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits" id="ref-for-ascii-digits①③">ASCII digits</a>, and let <var>string</var> be
+     <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points">Collect a sequence of code points</a> that are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits">ASCII digits</a>, and let <var>string</var> be
  the collected substring.</p>
     <li>
      <p>Interpret <var>string</var> as a base-ten integer. Let <var>value<sub>1</sub></var> be that
@@ -3624,7 +3624,7 @@ user agent must run the following steps:</p>
      <p>If <var>position</var> is beyond the end of <var>input</var> or if the character at <var>position</var> is not a U+003A
  COLON character (:), then return an error and abort these steps. Otherwise, move <var>position</var> forwards one character.</p>
     <li>
-     <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points" id="ref-for-collect-a-sequence-of-code-points⑤">collect a sequence of code points</a> that are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits" id="ref-for-ascii-digits①④">ASCII digits</a>, and let <var>string</var> be
+     <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points">collect a sequence of code points</a> that are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits">ASCII digits</a>, and let <var>string</var> be
  the collected substring.</p>
     <li>
      <p>If <var>string</var> is not exactly two characters in length, return an error and abort these
@@ -3639,7 +3639,7 @@ user agent must run the following steps:</p>
        <p>If <var>position</var> is beyond the end of <var>input</var> or if the character at <var>position</var> is not a
    U+003A COLON character (:), then return an error and abort these steps. Otherwise, move <var>position</var> forwards one character.</p>
       <li>
-       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points" id="ref-for-collect-a-sequence-of-code-points⑥">collect a sequence of code points</a> that are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits" id="ref-for-ascii-digits①⑤">ASCII digits</a>, and let <var>string</var> be
+       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points">collect a sequence of code points</a> that are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits">ASCII digits</a>, and let <var>string</var> be
    the collected substring.</p>
       <li>
        <p>If <var>string</var> is not exactly two characters in length, return an error and abort these
@@ -3654,7 +3654,7 @@ user agent must run the following steps:</p>
      <p>If <var>position</var> is beyond the end of <var>input</var> or if the character at <var>position</var> is not a U+002E
  FULL STOP character (.), then return an error and abort these steps. Otherwise, move <var>position</var> forwards one character.</p>
     <li>
-     <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points" id="ref-for-collect-a-sequence-of-code-points⑦">collect a sequence of code points</a> that are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits" id="ref-for-ascii-digits①⑥">ASCII digits</a>, and let <var>string</var> be
+     <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points">collect a sequence of code points</a> that are <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits">ASCII digits</a>, and let <var>string</var> be
  the collected substring.</p>
     <li>
      <p>If <var>string</var> is not exactly three characters in length, return an error and abort these
@@ -3671,75 +3671,75 @@ user agent must run the following steps:</p>
      <p>Return <var>result</var>.</p>
    </ol>
    <h3 class="heading settled algorithm" data-algorithm="WebVTT cue text parsing rules" data-level="5.4" id="cue-text-parsing-rules"><span class="secno">5.4. </span><span class="content">WebVTT cue text parsing rules</span><a class="self-link" href="#cue-text-parsing-rules"></a></h3>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-node-object">WebVTT Node Object</dfn> is a conceptual construct used to represent components of <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text⑤">WebVTT cue text</a> so that its processing can be described without reference to the underlying
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-node-object">WebVTT Node Object</dfn> is a conceptual construct used to represent components of <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-6">WebVTT cue text</a> so that its processing can be described without reference to the underlying
 syntax.</p>
-   <p>There are two broad classes of <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object">WebVTT Node Objects</a>: <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object">WebVTT Internal Node Objects</a> and <a data-link-type="dfn" href="#webvtt-leaf-node-object" id="ref-for-webvtt-leaf-node-object">WebVTT
+   <p>There are two broad classes of <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-1">WebVTT Node Objects</a>: <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-1">WebVTT Internal Node Objects</a> and <a data-link-type="dfn" href="#webvtt-leaf-node-object" id="ref-for-webvtt-leaf-node-object-1">WebVTT
 Leaf Node Objects</a>.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT Internal Node Object" data-noexport="" id="webvtt-internal-node-object">WebVTT Internal Node Objects</dfn> are those that can
-contain further <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object①">WebVTT Node Objects</a>. They are conceptually similar to
-elements in HTML or the DOM. <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object①">WebVTT Internal Node Objects</a> have an ordered list of child <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object②">WebVTT Node Objects</a>. The <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object②">WebVTT
+contain further <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-2">WebVTT Node Objects</a>. They are conceptually similar to
+elements in HTML or the DOM. <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-2">WebVTT Internal Node Objects</a> have an ordered list of child <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-3">WebVTT Node Objects</a>. The <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-3">WebVTT
 Internal Node Object</a> is said to be the <i>parent</i> of the children. Cycles do not occur; the
-parent-child relationships so constructed form a tree structure. <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object③">WebVTT Internal Node Objects</a> also have an ordered list of class names, known as their <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT Node Object’s applicable classes" data-noexport="" id="webvtt-node-objects-applicable-classes">applicable classes</dfn>, and a language, known as
+parent-child relationships so constructed form a tree structure. <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-4">WebVTT Internal Node Objects</a> also have an ordered list of class names, known as their <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT Node Object’s applicable classes" data-noexport="" id="webvtt-node-objects-applicable-classes">applicable classes</dfn>, and a language, known as
 their <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT Node Object’s applicable language" data-noexport="" id="webvtt-node-objects-applicable-language">applicable language</dfn>, which is to be
 interpreted as a BCP 47 language tag. <a data-link-type="biblio" href="#biblio-bcp47">[BCP47]</a></p>
-   <p class="note" role="note">User agents will add a language tag as the <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language">applicable language</a> even if it is not a valid or not even well-formed language tag. <a data-link-type="biblio" href="#biblio-bcp47">[BCP47]</a></p>
-   <p>There are several concrete classes of <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object④">WebVTT Internal Node
+   <p class="note" role="note">User agents will add a language tag as the <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language-1">applicable language</a> even if it is not a valid or not even well-formed language tag. <a data-link-type="biblio" href="#biblio-bcp47">[BCP47]</a></p>
+   <p>There are several concrete classes of <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-5">WebVTT Internal Node
 Objects</a>:</p>
    <dl>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="List of WebVTT Node Objects" data-noexport="" id="list-of-webvtt-node-objects">Lists of WebVTT Node Objects</dfn>
     <dd>
-     <p>These are used as root nodes for trees of <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object③">WebVTT Node
+     <p>These are used as root nodes for trees of <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-4">WebVTT Node
   Objects</a>.</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT Class Object" data-noexport="" id="webvtt-class-object">WebVTT Class Objects</dfn>
     <dd>
-     <p>These represent spans of text (a <a data-link-type="dfn" href="#webvtt-cue-class-span" id="ref-for-webvtt-cue-class-span①">WebVTT cue class span</a>) in <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text⑥">WebVTT cue text</a>, and
-  are used to annotate parts of the cue with <a data-link-type="dfn" href="#webvtt-node-objects-applicable-classes" id="ref-for-webvtt-node-objects-applicable-classes">applicable classes</a> without implying further meaning (such as italics or bold).</p>
+     <p>These represent spans of text (a <a data-link-type="dfn" href="#webvtt-cue-class-span" id="ref-for-webvtt-cue-class-span-2">WebVTT cue class span</a>) in <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-7">WebVTT cue text</a>, and
+  are used to annotate parts of the cue with <a data-link-type="dfn" href="#webvtt-node-objects-applicable-classes" id="ref-for-webvtt-node-objects-applicable-classes-1">applicable classes</a> without implying further meaning (such as italics or bold).</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT Italic Object" data-noexport="" id="webvtt-italic-object">WebVTT Italic Objects</dfn>
     <dd>
-     <p>These represent spans of italic text (a <a data-link-type="dfn" href="#webvtt-cue-italics-span" id="ref-for-webvtt-cue-italics-span①">WebVTT cue italics span</a>) in <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text⑦">WebVTT cue
+     <p>These represent spans of italic text (a <a data-link-type="dfn" href="#webvtt-cue-italics-span" id="ref-for-webvtt-cue-italics-span-2">WebVTT cue italics span</a>) in <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-8">WebVTT cue
   text</a>.</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT Bold Object" data-noexport="" id="webvtt-bold-object">WebVTT Bold Objects</dfn>
     <dd>
-     <p>These represent spans of bold text (a <a data-link-type="dfn" href="#webvtt-cue-bold-span" id="ref-for-webvtt-cue-bold-span①">WebVTT cue bold span</a>) in <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text⑧">WebVTT cue
+     <p>These represent spans of bold text (a <a data-link-type="dfn" href="#webvtt-cue-bold-span" id="ref-for-webvtt-cue-bold-span-2">WebVTT cue bold span</a>) in <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-9">WebVTT cue
   text</a>.</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT Underline Object" data-noexport="" id="webvtt-underline-object">WebVTT Underline Objects</dfn>
     <dd>
-     <p>These represent spans of underline text (a <a data-link-type="dfn" href="#webvtt-cue-underline-span" id="ref-for-webvtt-cue-underline-span①">WebVTT cue underline span</a>) in <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text⑨">WebVTT cue
+     <p>These represent spans of underline text (a <a data-link-type="dfn" href="#webvtt-cue-underline-span" id="ref-for-webvtt-cue-underline-span-2">WebVTT cue underline span</a>) in <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-10">WebVTT cue
   text</a>.</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT Ruby Object" data-noexport="" id="webvtt-ruby-object">WebVTT Ruby Objects</dfn>
     <dd>
-     <p>These represent spans of ruby (a <a data-link-type="dfn" href="#webvtt-cue-ruby-span" id="ref-for-webvtt-cue-ruby-span②">WebVTT cue ruby span</a>) in <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text①⓪">WebVTT cue text</a>.</p>
+     <p>These represent spans of ruby (a <a data-link-type="dfn" href="#webvtt-cue-ruby-span" id="ref-for-webvtt-cue-ruby-span-3">WebVTT cue ruby span</a>) in <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-11">WebVTT cue text</a>.</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT Ruby Text Object" data-noexport="" id="webvtt-ruby-text-object">WebVTT Ruby Text Objects</dfn>
     <dd>
-     <p>These represent spans of ruby text (a <a data-link-type="dfn" href="#webvtt-cue-ruby-text-span" id="ref-for-webvtt-cue-ruby-text-span">WebVTT cue ruby text span</a>) in <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text①①">WebVTT cue
+     <p>These represent spans of ruby text (a <a data-link-type="dfn" href="#webvtt-cue-ruby-text-span" id="ref-for-webvtt-cue-ruby-text-span-1">WebVTT cue ruby text span</a>) in <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-12">WebVTT cue
   text</a>.</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT Voice Object" data-noexport="" id="webvtt-voice-object">WebVTT Voice Objects</dfn>
     <dd>
-     <p>These represent spans of text associated with a specific voice (a <a data-link-type="dfn" href="#webvtt-cue-voice-span" id="ref-for-webvtt-cue-voice-span②">WebVTT cue voice span</a>)
-  in <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text①②">WebVTT cue text</a>. A <a data-link-type="dfn" href="#webvtt-voice-object" id="ref-for-webvtt-voice-object">WebVTT Voice Object</a> has a value, which is the name of the
+     <p>These represent spans of text associated with a specific voice (a <a data-link-type="dfn" href="#webvtt-cue-voice-span" id="ref-for-webvtt-cue-voice-span-3">WebVTT cue voice span</a>)
+  in <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-13">WebVTT cue text</a>. A <a data-link-type="dfn" href="#webvtt-voice-object" id="ref-for-webvtt-voice-object-1">WebVTT Voice Object</a> has a value, which is the name of the
   voice.</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT Language Object" data-noexport="" id="webvtt-language-object">WebVTT Language Objects</dfn>
     <dd>
-     <p>These represent spans of text (a <a data-link-type="dfn" href="#webvtt-cue-language-span" id="ref-for-webvtt-cue-language-span①">WebVTT cue language span</a>) in <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text①③">WebVTT cue text</a>,
-  and are used to annotate parts of the cue where the <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language①">applicable language</a> might be different than the surrounding text’s, without implying
+     <p>These represent spans of text (a <a data-link-type="dfn" href="#webvtt-cue-language-span" id="ref-for-webvtt-cue-language-span-2">WebVTT cue language span</a>) in <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-14">WebVTT cue text</a>,
+  and are used to annotate parts of the cue where the <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language-2">applicable language</a> might be different than the surrounding text’s, without implying
   further meaning (such as italics or bold).</p>
    </dl>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT Leaf Node Object" data-noexport="" id="webvtt-leaf-node-object">WebVTT Leaf Node Objects</dfn> are those that contain data,
-such as text, and cannot contain child <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object④">WebVTT Node Objects</a>.</p>
-   <p>There are two concrete classes of <a data-link-type="dfn" href="#webvtt-leaf-node-object" id="ref-for-webvtt-leaf-node-object①">WebVTT Leaf Node
+such as text, and cannot contain child <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-5">WebVTT Node Objects</a>.</p>
+   <p>There are two concrete classes of <a data-link-type="dfn" href="#webvtt-leaf-node-object" id="ref-for-webvtt-leaf-node-object-2">WebVTT Leaf Node
 Objects</a>:</p>
    <dl>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT Text Object" data-noexport="" id="webvtt-text-object">WebVTT Text Objects</dfn>
     <dd>
-     <p>A fragment of text. A <a data-link-type="dfn" href="#webvtt-text-object" id="ref-for-webvtt-text-object">WebVTT Text Object</a> has a value, which is the text it
+     <p>A fragment of text. A <a data-link-type="dfn" href="#webvtt-text-object" id="ref-for-webvtt-text-object-1">WebVTT Text Object</a> has a value, which is the text it
   represents.</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT Timestamp Object" data-noexport="" id="webvtt-timestamp-object">WebVTT Timestamp Objects</dfn>
     <dd>
-     <p>A timestamp. A <a data-link-type="dfn" href="#webvtt-timestamp-object" id="ref-for-webvtt-timestamp-object">WebVTT Timestamp Object</a> has a value, in seconds and fractions of a
+     <p>A timestamp. A <a data-link-type="dfn" href="#webvtt-timestamp-object" id="ref-for-webvtt-timestamp-object-1">WebVTT Timestamp Object</a> has a value, in seconds and fractions of a
   second, which is the time represented by the timestamp.</p>
    </dl>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue-text-parsing-rules">WebVTT cue text parsing rules</dfn> consist of the following algorithm. The input is a
-string <var>input</var> supposedly containing <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text①④">WebVTT cue text</a>, and optionally a fallback language <var>language</var>. This algorithm returns a <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects①">list of WebVTT Node Objects</a>.</p>
+string <var>input</var> supposedly containing <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-15">WebVTT cue text</a>, and optionally a fallback language <var>language</var>. This algorithm returns a <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-2">list of WebVTT Node Objects</a>.</p>
    <ol class="algorithm">
     <li>
      <p>Let <var>input</var> be the string being parsed.</p>
@@ -3747,19 +3747,19 @@ string <var>input</var> supposedly containing <a data-link-type="dfn" href="#web
      <p>Let <var>position</var> be a pointer into <var>input</var>, initially pointing at the start of the
  string.</p>
     <li>
-     <p>Let <var>result</var> be a <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects②">list of WebVTT Node Objects</a>, initially empty.</p>
+     <p>Let <var>result</var> be a <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-3">list of WebVTT Node Objects</a>, initially empty.</p>
     <li>
-     <p>Let <var>current</var> be the <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object⑤">WebVTT Internal Node Object</a> <var>result</var>.</p>
+     <p>Let <var>current</var> be the <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-6">WebVTT Internal Node Object</a> <var>result</var>.</p>
     <li>
      <p>Let <var>language stack</var> be a stack of language tags, initially empty.</p>
     <li>
-     <p>If <var>language</var> is set, set <var>result</var>’s <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language②">applicable language</a> to <var>language</var>, and push <var>language</var> onto the <var>language
+     <p>If <var>language</var> is set, set <var>result</var>’s <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language-3">applicable language</a> to <var>language</var>, and push <var>language</var> onto the <var>language
  stack</var>.</p>
     <li>
      <p><i>Loop</i>: If <var>position</var> is past the end of <var>input</var>, return <var>result</var> and abort these
  steps.</p>
     <li>
-     <p>Let <var>token</var> be the result of invoking the <a data-link-type="dfn" href="#webvtt-cue-text-tokenizer" id="ref-for-webvtt-cue-text-tokenizer">WebVTT cue text tokenizer</a>.</p>
+     <p>Let <var>token</var> be the result of invoking the <a data-link-type="dfn" href="#webvtt-cue-text-tokenizer" id="ref-for-webvtt-cue-text-tokenizer-1">WebVTT cue text tokenizer</a>.</p>
     <li>
      <p>Run the appropriate steps given the type of <var>token</var>:</p>
      <dl>
@@ -3767,9 +3767,9 @@ string <var>input</var> supposedly containing <a data-link-type="dfn" href="#web
       <dd>
        <ol>
         <li>
-         <p>Create a <a data-link-type="dfn" href="#webvtt-text-object" id="ref-for-webvtt-text-object①">WebVTT Text Object</a> whose value is the value of the string token <var>token</var>.</p>
+         <p>Create a <a data-link-type="dfn" href="#webvtt-text-object" id="ref-for-webvtt-text-object-2">WebVTT Text Object</a> whose value is the value of the string token <var>token</var>.</p>
         <li>
-         <p>Append the newly created <a data-link-type="dfn" href="#webvtt-text-object" id="ref-for-webvtt-text-object②">WebVTT Text Object</a> to <var>current</var>.</p>
+         <p>Append the newly created <a data-link-type="dfn" href="#webvtt-text-object" id="ref-for-webvtt-text-object-3">WebVTT Text Object</a> to <var>current</var>.</p>
        </ol>
       <dt>If <var>token</var> is a start tag
       <dd>
@@ -3777,32 +3777,32 @@ string <var>input</var> supposedly containing <a data-link-type="dfn" href="#web
        <dl>
         <dt>If the tag name is "<code>c</code>"
         <dd>
-         <p><a data-link-type="dfn" href="#attach-a-webvtt-internal-node-object" id="ref-for-attach-a-webvtt-internal-node-object">Attach</a> a <a data-link-type="dfn" href="#webvtt-class-object" id="ref-for-webvtt-class-object">WebVTT Class Object</a>.</p>
+         <p><a data-link-type="dfn" href="#attach-a-webvtt-internal-node-object" id="ref-for-attach-a-webvtt-internal-node-object-1">Attach</a> a <a data-link-type="dfn" href="#webvtt-class-object" id="ref-for-webvtt-class-object-1">WebVTT Class Object</a>.</p>
         <dt>If the tag name is "<code>i</code>"
         <dd>
-         <p><a data-link-type="dfn" href="#attach-a-webvtt-internal-node-object" id="ref-for-attach-a-webvtt-internal-node-object①">Attach</a> a <a data-link-type="dfn" href="#webvtt-italic-object" id="ref-for-webvtt-italic-object">WebVTT Italic Object</a>.</p>
+         <p><a data-link-type="dfn" href="#attach-a-webvtt-internal-node-object" id="ref-for-attach-a-webvtt-internal-node-object-2">Attach</a> a <a data-link-type="dfn" href="#webvtt-italic-object" id="ref-for-webvtt-italic-object-1">WebVTT Italic Object</a>.</p>
         <dt>If the tag name is "<code>b</code>"
         <dd>
-         <p><a data-link-type="dfn" href="#attach-a-webvtt-internal-node-object" id="ref-for-attach-a-webvtt-internal-node-object②">Attach</a> a <a data-link-type="dfn" href="#webvtt-bold-object" id="ref-for-webvtt-bold-object①">WebVTT Bold Object</a>.</p>
+         <p><a data-link-type="dfn" href="#attach-a-webvtt-internal-node-object" id="ref-for-attach-a-webvtt-internal-node-object-3">Attach</a> a <a data-link-type="dfn" href="#webvtt-bold-object" id="ref-for-webvtt-bold-object-2">WebVTT Bold Object</a>.</p>
         <dt>If the tag name is "<code>u</code>"
         <dd>
-         <p><a data-link-type="dfn" href="#attach-a-webvtt-internal-node-object" id="ref-for-attach-a-webvtt-internal-node-object③">Attach</a> a <a data-link-type="dfn" href="#webvtt-underline-object" id="ref-for-webvtt-underline-object">WebVTT Underline
+         <p><a data-link-type="dfn" href="#attach-a-webvtt-internal-node-object" id="ref-for-attach-a-webvtt-internal-node-object-4">Attach</a> a <a data-link-type="dfn" href="#webvtt-underline-object" id="ref-for-webvtt-underline-object-1">WebVTT Underline
       Object</a>.</p>
         <dt>If the tag name is "<code>ruby</code>"
         <dd>
-         <p><a data-link-type="dfn" href="#attach-a-webvtt-internal-node-object" id="ref-for-attach-a-webvtt-internal-node-object④">Attach</a> a <a data-link-type="dfn" href="#webvtt-ruby-object" id="ref-for-webvtt-ruby-object">WebVTT Ruby Object</a>.</p>
+         <p><a data-link-type="dfn" href="#attach-a-webvtt-internal-node-object" id="ref-for-attach-a-webvtt-internal-node-object-5">Attach</a> a <a data-link-type="dfn" href="#webvtt-ruby-object" id="ref-for-webvtt-ruby-object-1">WebVTT Ruby Object</a>.</p>
         <dt>If the tag name is "<code>rt</code>"
         <dd>
-         <p>If <var>current</var> is a <a data-link-type="dfn" href="#webvtt-ruby-object" id="ref-for-webvtt-ruby-object①">WebVTT Ruby Object</a>, then <a data-link-type="dfn" href="#attach-a-webvtt-internal-node-object" id="ref-for-attach-a-webvtt-internal-node-object⑤">attach</a> a <a data-link-type="dfn" href="#webvtt-ruby-text-object" id="ref-for-webvtt-ruby-text-object">WebVTT Ruby Text Object</a>.</p>
+         <p>If <var>current</var> is a <a data-link-type="dfn" href="#webvtt-ruby-object" id="ref-for-webvtt-ruby-object-2">WebVTT Ruby Object</a>, then <a data-link-type="dfn" href="#attach-a-webvtt-internal-node-object" id="ref-for-attach-a-webvtt-internal-node-object-6">attach</a> a <a data-link-type="dfn" href="#webvtt-ruby-text-object" id="ref-for-webvtt-ruby-text-object-1">WebVTT Ruby Text Object</a>.</p>
         <dt>If the tag name is "<code>v</code>"
         <dd>
-         <p><a data-link-type="dfn" href="#attach-a-webvtt-internal-node-object" id="ref-for-attach-a-webvtt-internal-node-object⑥">Attach</a> a <a data-link-type="dfn" href="#webvtt-voice-object" id="ref-for-webvtt-voice-object①">WebVTT Voice Object</a>, and
+         <p><a data-link-type="dfn" href="#attach-a-webvtt-internal-node-object" id="ref-for-attach-a-webvtt-internal-node-object-7">Attach</a> a <a data-link-type="dfn" href="#webvtt-voice-object" id="ref-for-webvtt-voice-object-2">WebVTT Voice Object</a>, and
       set its value to the token’s annotation string, or the empty string if there is no annotation
       string.</p>
         <dt>If the tag name is "<code>lang</code>"
         <dd>
          <p>Push the value of the token’s annotation string, or the empty string if there is no
-      annotation string, onto the <var>language stack</var>; then <a data-link-type="dfn" href="#attach-a-webvtt-internal-node-object" id="ref-for-attach-a-webvtt-internal-node-object⑦">attach</a> a <a data-link-type="dfn" href="#webvtt-language-object" id="ref-for-webvtt-language-object">WebVTT Language Object</a>.</p>
+      annotation string, onto the <var>language stack</var>; then <a data-link-type="dfn" href="#attach-a-webvtt-internal-node-object" id="ref-for-attach-a-webvtt-internal-node-object-8">attach</a> a <a data-link-type="dfn" href="#webvtt-language-object" id="ref-for-webvtt-language-object-1">WebVTT Language Object</a>.</p>
         <dt>Otherwise
         <dd>
          <p>Ignore the token.</p>
@@ -3811,14 +3811,14 @@ string <var>input</var> supposedly containing <a data-link-type="dfn" href="#web
     concrete class, the user agent must run the following steps:</p>
        <ol>
         <li>
-         <p>Create a new <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object⑥">WebVTT Internal Node Object</a> of the specified concrete
+         <p>Create a new <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-7">WebVTT Internal Node Object</a> of the specified concrete
      class.</p>
         <li>
-         <p>Set the new object’s list of <a data-link-type="dfn" href="#webvtt-node-objects-applicable-classes" id="ref-for-webvtt-node-objects-applicable-classes①">applicable
+         <p>Set the new object’s list of <a data-link-type="dfn" href="#webvtt-node-objects-applicable-classes" id="ref-for-webvtt-node-objects-applicable-classes-2">applicable
      classes</a> to the list of classes in the token, excluding any classes that are the empty
      string.</p>
         <li>
-         <p>Set the new object’s <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language③">applicable
+         <p>Set the new object’s <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language-4">applicable
      language</a> to the top entry on the <var>language stack</var>, if the stack is not empty.</p>
         <li>
          <p>Append the newly created node object to <var>current</var>.</p>
@@ -3829,23 +3829,23 @@ string <var>input</var> supposedly containing <a data-link-type="dfn" href="#web
       <dd>
        <p>If any of the following conditions is true, then let <var>current</var> be the parent node of <var>current</var>.</p>
        <ul class="brief">
-        <li>The tag name of the end tag token <var>token</var> is "<code>c</code>" and <var>current</var> is a <a data-link-type="dfn" href="#webvtt-class-object" id="ref-for-webvtt-class-object①">WebVTT
+        <li>The tag name of the end tag token <var>token</var> is "<code>c</code>" and <var>current</var> is a <a data-link-type="dfn" href="#webvtt-class-object" id="ref-for-webvtt-class-object-2">WebVTT
      Class Object</a>.
-        <li>The tag name of the end tag token <var>token</var> is "<code>i</code>" and <var>current</var> is a <a data-link-type="dfn" href="#webvtt-italic-object" id="ref-for-webvtt-italic-object①">WebVTT
+        <li>The tag name of the end tag token <var>token</var> is "<code>i</code>" and <var>current</var> is a <a data-link-type="dfn" href="#webvtt-italic-object" id="ref-for-webvtt-italic-object-2">WebVTT
      Italic Object</a>.
-        <li>The tag name of the end tag token <var>token</var> is "<code>b</code>" and <var>current</var> is a <a data-link-type="dfn" href="#webvtt-bold-object" id="ref-for-webvtt-bold-object②">WebVTT
+        <li>The tag name of the end tag token <var>token</var> is "<code>b</code>" and <var>current</var> is a <a data-link-type="dfn" href="#webvtt-bold-object" id="ref-for-webvtt-bold-object-3">WebVTT
      Bold Object</a>.
-        <li>The tag name of the end tag token <var>token</var> is "<code>u</code>" and <var>current</var> is a <a data-link-type="dfn" href="#webvtt-underline-object" id="ref-for-webvtt-underline-object①">WebVTT
+        <li>The tag name of the end tag token <var>token</var> is "<code>u</code>" and <var>current</var> is a <a data-link-type="dfn" href="#webvtt-underline-object" id="ref-for-webvtt-underline-object-2">WebVTT
      Underline Object</a>.
-        <li>The tag name of the end tag token <var>token</var> is "<code>ruby</code>" and <var>current</var> is a <a data-link-type="dfn" href="#webvtt-ruby-object" id="ref-for-webvtt-ruby-object②">WebVTT Ruby Object</a>.
-        <li>The tag name of the end tag token <var>token</var> is "<code>rt</code>" and <var>current</var> is a <a data-link-type="dfn" href="#webvtt-ruby-text-object" id="ref-for-webvtt-ruby-text-object①">WebVTT
+        <li>The tag name of the end tag token <var>token</var> is "<code>ruby</code>" and <var>current</var> is a <a data-link-type="dfn" href="#webvtt-ruby-object" id="ref-for-webvtt-ruby-object-3">WebVTT Ruby Object</a>.
+        <li>The tag name of the end tag token <var>token</var> is "<code>rt</code>" and <var>current</var> is a <a data-link-type="dfn" href="#webvtt-ruby-text-object" id="ref-for-webvtt-ruby-text-object-2">WebVTT
      Ruby Text Object</a>.
-        <li>The tag name of the end tag token <var>token</var> is "<code>v</code>" and <var>current</var> is a <a data-link-type="dfn" href="#webvtt-voice-object" id="ref-for-webvtt-voice-object②">WebVTT
+        <li>The tag name of the end tag token <var>token</var> is "<code>v</code>" and <var>current</var> is a <a data-link-type="dfn" href="#webvtt-voice-object" id="ref-for-webvtt-voice-object-3">WebVTT
      Voice Object</a>.
        </ul>
-       <p>Otherwise, if the tag name of the end tag token <var>token</var> is "<code>lang</code>" and <var>current</var> is a <a data-link-type="dfn" href="#webvtt-language-object" id="ref-for-webvtt-language-object①">WebVTT Language Object</a>, then let <var>current</var> be the parent node of <var>current</var>, and pop
+       <p>Otherwise, if the tag name of the end tag token <var>token</var> is "<code>lang</code>" and <var>current</var> is a <a data-link-type="dfn" href="#webvtt-language-object" id="ref-for-webvtt-language-object-2">WebVTT Language Object</a>, then let <var>current</var> be the parent node of <var>current</var>, and pop
     the top value from the <var>language stack</var>.</p>
-       <p>Otherwise, if the tag name of the end tag token <var>token</var> is "<code>ruby</code>" and <var>current</var> is a <a data-link-type="dfn" href="#webvtt-ruby-text-object" id="ref-for-webvtt-ruby-text-object②">WebVTT Ruby Text Object</a>, then let <var>current</var> be the parent node of the parent node of <var>current</var>.</p>
+       <p>Otherwise, if the tag name of the end tag token <var>token</var> is "<code>ruby</code>" and <var>current</var> is a <a data-link-type="dfn" href="#webvtt-ruby-text-object" id="ref-for-webvtt-ruby-text-object-3">WebVTT Ruby Text Object</a>, then let <var>current</var> be the parent node of the parent node of <var>current</var>.</p>
        <p>Otherwise, ignore the token.</p>
       <dt>If <var>token</var> is a timestamp tag
       <dd>
@@ -3856,10 +3856,10 @@ string <var>input</var> supposedly containing <a data-link-type="dfn" href="#web
          <p>Let <var>position</var> be a pointer into <var>input</var>, initially pointing at the start of the
      string.</p>
         <li>
-         <p><a data-link-type="dfn" href="#collect-a-webvtt-timestamp" id="ref-for-collect-a-webvtt-timestamp②">Collect a WebVTT timestamp</a>.</p>
+         <p><a data-link-type="dfn" href="#collect-a-webvtt-timestamp" id="ref-for-collect-a-webvtt-timestamp-3">Collect a WebVTT timestamp</a>.</p>
         <li>
          <p>If that algorithm does not fail, and if <var>position</var> now points at the end of <var>input</var> (i.e.
-      there are no trailing characters after the timestamp), then create a <a data-link-type="dfn" href="#webvtt-timestamp-object" id="ref-for-webvtt-timestamp-object①">WebVTT Timestamp
+      there are no trailing characters after the timestamp), then create a <a data-link-type="dfn" href="#webvtt-timestamp-object" id="ref-for-webvtt-timestamp-object-2">WebVTT Timestamp
       Object</a> whose value is the collected time, then append it to <var>current</var>.</p>
          <p>Otherwise, ignore the token.</p>
        </ol>
@@ -3876,7 +3876,7 @@ value).</p>
      <p>Let <var>input</var> and <var>position</var> be the same variables as those of the same name in the algorithm
  that invoked these steps.</p>
     <li>
-     <p>Let <var>tokenizer state</var> be <a data-link-type="dfn" href="#webvtt-data-state" id="ref-for-webvtt-data-state">WebVTT data state</a>.</p>
+     <p>Let <var>tokenizer state</var> be <a data-link-type="dfn" href="#webvtt-data-state" id="ref-for-webvtt-data-state-1">WebVTT data state</a>.</p>
     <li>
      <p>Let <var>result</var> be the empty string.</p>
     <li>
@@ -3895,11 +3895,11 @@ value).</p>
        <dl>
         <dt>U+0026 AMPERSAND (&amp;)
         <dd>
-         <p>Set <var>tokenizer state</var> to the <a data-link-type="dfn" href="#html-character-reference-in-data-state" id="ref-for-html-character-reference-in-data-state">HTML character reference in data state</a>, and jump to the
+         <p>Set <var>tokenizer state</var> to the <a data-link-type="dfn" href="#html-character-reference-in-data-state" id="ref-for-html-character-reference-in-data-state-1">HTML character reference in data state</a>, and jump to the
       step labeled <i>next</i>.</p>
         <dt>U+003C LESS-THAN SIGN (&lt;)
         <dd>
-         <p>If <var>result</var> is the empty string, then set <var>tokenizer state</var> to the <a data-link-type="dfn" href="#webvtt-tag-state" id="ref-for-webvtt-tag-state">WebVTT tag state</a> and jump to the step labeled <i>next</i>.</p>
+         <p>If <var>result</var> is the empty string, then set <var>tokenizer state</var> to the <a data-link-type="dfn" href="#webvtt-tag-state" id="ref-for-webvtt-tag-state-1">WebVTT tag state</a> and jump to the step labeled <i>next</i>.</p>
          <p>Otherwise, return a string token whose value is <var>result</var> and abort these steps.</p>
         <dt>End-of-file marker
         <dd>
@@ -3910,11 +3910,11 @@ value).</p>
        </dl>
       <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="html-character-reference-in-data-state">HTML character reference in data state</dfn>
       <dd>
-       <p>Attempt to <a data-link-type="dfn" href="#consume-an-html-character-reference" id="ref-for-consume-an-html-character-reference">consume an HTML character reference</a>, with no <a data-link-type="dfn">additional allowed
+       <p>Attempt to <a data-link-type="dfn" href="#consume-an-html-character-reference" id="ref-for-consume-an-html-character-reference-1">consume an HTML character reference</a>, with no <a data-link-type="dfn">additional allowed
     character</a>.</p>
        <p>If nothing is returned, append a U+0026 AMPERSAND character (&amp;) to <var>result</var>.</p>
        <p>Otherwise, append the data of the character tokens that were returned to <var>result</var>.</p>
-       <p>Then, in any case, set <var>tokenizer state</var> to the <a data-link-type="dfn" href="#webvtt-data-state" id="ref-for-webvtt-data-state①">WebVTT data state</a>, and jump to the
+       <p>Then, in any case, set <var>tokenizer state</var> to the <a data-link-type="dfn" href="#webvtt-data-state" id="ref-for-webvtt-data-state-2">WebVTT data state</a>, and jump to the
     step labeled <i>next</i>.</p>
       <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-tag-state">WebVTT tag state</dfn>
       <dd>
@@ -3925,18 +3925,18 @@ value).</p>
         <dt>U+000C FORM FEED (FF) character
         <dt>U+0020 SPACE character
         <dd>
-         <p>Set <var>tokenizer state</var> to the <a data-link-type="dfn" href="#webvtt-start-tag-annotation-state" id="ref-for-webvtt-start-tag-annotation-state">WebVTT start tag annotation state</a>, and jump to the step
+         <p>Set <var>tokenizer state</var> to the <a data-link-type="dfn" href="#webvtt-start-tag-annotation-state" id="ref-for-webvtt-start-tag-annotation-state-1">WebVTT start tag annotation state</a>, and jump to the step
       labeled <i>next</i>.</p>
         <dt>U+002E FULL STOP character (.)
         <dd>
-         <p>Set <var>tokenizer state</var> to the <a data-link-type="dfn" href="#webvtt-start-tag-class-state" id="ref-for-webvtt-start-tag-class-state">WebVTT start tag class state</a>, and jump to the step
+         <p>Set <var>tokenizer state</var> to the <a data-link-type="dfn" href="#webvtt-start-tag-class-state" id="ref-for-webvtt-start-tag-class-state-1">WebVTT start tag class state</a>, and jump to the step
       labeled <i>next</i>.</p>
         <dt>U+002F SOLIDUS character (/)
         <dd>
-         <p>Set <var>tokenizer state</var> to the <a data-link-type="dfn" href="#webvtt-end-tag-state" id="ref-for-webvtt-end-tag-state">WebVTT end tag state</a>, and jump to the step labeled <i>next</i>.</p>
-        <dt><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits" id="ref-for-ascii-digits①⑦">ASCII digits</a>
+         <p>Set <var>tokenizer state</var> to the <a data-link-type="dfn" href="#webvtt-end-tag-state" id="ref-for-webvtt-end-tag-state-1">WebVTT end tag state</a>, and jump to the step labeled <i>next</i>.</p>
+        <dt><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits">ASCII digits</a>
         <dd>
-         <p>Set <var>result</var> to <var>c</var>, set <var>tokenizer state</var> to the <a data-link-type="dfn" href="#webvtt-timestamp-tag-state" id="ref-for-webvtt-timestamp-tag-state">WebVTT timestamp tag state</a>, and
+         <p>Set <var>result</var> to <var>c</var>, set <var>tokenizer state</var> to the <a data-link-type="dfn" href="#webvtt-timestamp-tag-state" id="ref-for-webvtt-timestamp-tag-state-1">WebVTT timestamp tag state</a>, and
       jump to the step labeled <i>next</i>.</p>
         <dt>U+003E GREATER-THAN SIGN character (>)
         <dd>
@@ -3948,7 +3948,7 @@ value).</p>
       and abort these steps.</p>
         <dt>Anything else
         <dd>
-         <p>Set <var>result</var> to <var>c</var>, set <var>tokenizer state</var> to the <a data-link-type="dfn" href="#webvtt-start-tag-state" id="ref-for-webvtt-start-tag-state">WebVTT start tag state</a>, and jump
+         <p>Set <var>result</var> to <var>c</var>, set <var>tokenizer state</var> to the <a data-link-type="dfn" href="#webvtt-start-tag-state" id="ref-for-webvtt-start-tag-state-1">WebVTT start tag state</a>, and jump
       to the step labeled <i>next</i>.</p>
        </dl>
       <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-start-tag-state">WebVTT start tag state</dfn>
@@ -3959,15 +3959,15 @@ value).</p>
         <dt>U+000C FORM FEED (FF) character
         <dt>U+0020 SPACE character
         <dd>
-         <p>Set <var>tokenizer state</var> to the <a data-link-type="dfn" href="#webvtt-start-tag-annotation-state" id="ref-for-webvtt-start-tag-annotation-state①">WebVTT start tag annotation state</a>, and jump to the step
+         <p>Set <var>tokenizer state</var> to the <a data-link-type="dfn" href="#webvtt-start-tag-annotation-state" id="ref-for-webvtt-start-tag-annotation-state-2">WebVTT start tag annotation state</a>, and jump to the step
       labeled <i>next</i>.</p>
         <dt>U+000A LINE FEED (LF) character
         <dd>
-         <p>Set <var>buffer</var> to <var>c</var>, set <var>tokenizer state</var> to the <a data-link-type="dfn" href="#webvtt-start-tag-annotation-state" id="ref-for-webvtt-start-tag-annotation-state②">WebVTT start tag annotation state</a>,
+         <p>Set <var>buffer</var> to <var>c</var>, set <var>tokenizer state</var> to the <a data-link-type="dfn" href="#webvtt-start-tag-annotation-state" id="ref-for-webvtt-start-tag-annotation-state-3">WebVTT start tag annotation state</a>,
       and jump to the step labeled <i>next</i>.</p>
         <dt>U+002E FULL STOP character (.)
         <dd>
-         <p>Set <var>tokenizer state</var> to the <a data-link-type="dfn" href="#webvtt-start-tag-class-state" id="ref-for-webvtt-start-tag-class-state①">WebVTT start tag class state</a>, and jump to the step
+         <p>Set <var>tokenizer state</var> to the <a data-link-type="dfn" href="#webvtt-start-tag-class-state" id="ref-for-webvtt-start-tag-class-state-2">WebVTT start tag class state</a>, and jump to the step
       labeled <i>next</i>.</p>
         <dt>U+003E GREATER-THAN SIGN character (>)
         <dd>
@@ -3989,12 +3989,12 @@ value).</p>
         <dt>U+000C FORM FEED (FF) character
         <dt>U+0020 SPACE character
         <dd>
-         <p>Append to <var>classes</var> an entry whose value is <var>buffer</var>, set <var>buffer</var> to the empty string, set <var>tokenizer state</var> to the <a data-link-type="dfn" href="#webvtt-start-tag-annotation-state" id="ref-for-webvtt-start-tag-annotation-state③">WebVTT start tag annotation state</a>, and jump to the step
+         <p>Append to <var>classes</var> an entry whose value is <var>buffer</var>, set <var>buffer</var> to the empty string, set <var>tokenizer state</var> to the <a data-link-type="dfn" href="#webvtt-start-tag-annotation-state" id="ref-for-webvtt-start-tag-annotation-state-4">WebVTT start tag annotation state</a>, and jump to the step
       labeled <i>next</i>.</p>
         <dt>U+000A LINE FEED (LF) character
         <dd>
          <p>Append to <var>classes</var> an entry whose value is <var>buffer</var>, set <var>buffer</var> to <var>c</var>, set <var>tokenizer
-      state</var> to the <a data-link-type="dfn" href="#webvtt-start-tag-annotation-state" id="ref-for-webvtt-start-tag-annotation-state④">WebVTT start tag annotation state</a>, and jump to the step labeled <i>next</i>.</p>
+      state</var> to the <a data-link-type="dfn" href="#webvtt-start-tag-annotation-state" id="ref-for-webvtt-start-tag-annotation-state-5">WebVTT start tag annotation state</a>, and jump to the step labeled <i>next</i>.</p>
         <dt>U+002E FULL STOP character (.)
         <dd>
          <p>Append to <var>classes</var> an entry whose value is <var>buffer</var>, set <var>buffer</var> to the empty string, and
@@ -4018,7 +4018,7 @@ value).</p>
        <dl>
         <dt>U+0026 AMPERSAND (&amp;)
         <dd>
-         <p>Set <var>tokenizer state</var> to the <a data-link-type="dfn" href="#html-character-reference-in-annotation-state" id="ref-for-html-character-reference-in-annotation-state">HTML character reference in annotation state</a>, and jump
+         <p>Set <var>tokenizer state</var> to the <a data-link-type="dfn" href="#html-character-reference-in-annotation-state" id="ref-for-html-character-reference-in-annotation-state-1">HTML character reference in annotation state</a>, and jump
       to the step labeled <i>next</i>.</p>
         <dt>U+003E GREATER-THAN SIGN character (>)
         <dd>
@@ -4026,8 +4026,8 @@ value).</p>
       marker" entry below.</p>
         <dt>End-of-file marker
         <dd>
-         <p>Remove any leading or trailing <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-whitespace" id="ref-for-ascii-whitespace③">ASCII whitespace</a> characters from <var>buffer</var>, and
-      replace any sequence of one or more consecutive <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-whitespace" id="ref-for-ascii-whitespace④">ASCII whitespace</a> characters in <var>buffer</var> with a single U+0020 SPACE character; then, return a start tag whose tag name is <var>result</var>,
+         <p>Remove any leading or trailing <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-whitespace">ASCII whitespace</a> characters from <var>buffer</var>, and
+      replace any sequence of one or more consecutive <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-whitespace">ASCII whitespace</a> characters in <var>buffer</var> with a single U+0020 SPACE character; then, return a start tag whose tag name is <var>result</var>,
       with the classes given in <var>classes</var>, and with <var>buffer</var> as the annotation, and abort these
       steps.</p>
         <dt>Anything else
@@ -4036,11 +4036,11 @@ value).</p>
        </dl>
       <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="html-character-reference-in-annotation-state">HTML character reference in annotation state</dfn>
       <dd>
-       <p>Attempt to <a data-link-type="dfn" href="#consume-an-html-character-reference" id="ref-for-consume-an-html-character-reference①">consume an HTML character reference</a>, with the <a data-link-type="dfn">additional allowed
+       <p>Attempt to <a data-link-type="dfn" href="#consume-an-html-character-reference" id="ref-for-consume-an-html-character-reference-2">consume an HTML character reference</a>, with the <a data-link-type="dfn">additional allowed
     character</a> being U+003E GREATER-THAN SIGN (>).</p>
        <p>If nothing is returned, append a U+0026 AMPERSAND character (&amp;) to <var>buffer</var>.</p>
        <p>Otherwise, append the data of the character tokens that were returned to <var>buffer</var>.</p>
-       <p>Then, in any case, set <var>tokenizer state</var> to the <a data-link-type="dfn" href="#webvtt-start-tag-annotation-state" id="ref-for-webvtt-start-tag-annotation-state⑤">WebVTT start tag annotation state</a>, and
+       <p>Then, in any case, set <var>tokenizer state</var> to the <a data-link-type="dfn" href="#webvtt-start-tag-annotation-state" id="ref-for-webvtt-start-tag-annotation-state-6">WebVTT start tag annotation state</a>, and
     jump to the step labeled <i>next</i>.</p>
       <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-end-tag-state">WebVTT end tag state</dfn>
       <dd>
@@ -4084,79 +4084,79 @@ means to attempt to <a data-link-type="dfn">consume a character reference</a> as
 in this specification. Finally, this context is <em>not</em> "as part of an attribute" (when it
 comes to handling a missing semicolon).</p>
    <h3 class="heading settled" data-level="5.5" id="dom-construction-rules"><span class="secno">5.5. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue-text-dom-construction-rules">WebVTT cue text DOM construction rules</dfn></span><a class="self-link" href="#dom-construction-rules"></a></h3>
-   <p class="note" role="note">For the purpose of retrieving a <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue②⓪">WebVTT cue</a>’s content via the <code class="idl"><a data-link-type="idl" href="#dom-vttcue-getcueashtml" id="ref-for-dom-vttcue-getcueashtml">getCueAsHTML()</a></code> method of the <code class="idl"><a data-link-type="idl" href="#vttcue" id="ref-for-vttcue">VTTCue</a></code> interface, it needs to be parsed to a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#documentfragment" id="ref-for-documentfragment">DocumentFragment</a></code>. This section describes how.</p>
-   <p>To convert a <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects③">list of WebVTT Node Objects</a> to a DOM tree for <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document">Document</a></code> <var>owner</var>, user
-agents must create a tree of DOM nodes that is isomorphous to the tree of <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object⑤">WebVTT Node Objects</a>, with the following mapping of <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object⑥">WebVTT
+   <p class="note" role="note">For the purpose of retrieving a <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-21">WebVTT cue</a>’s content via the <code class="idl"><a data-link-type="idl" href="#dom-vttcue-getcueashtml" id="ref-for-dom-vttcue-getcueashtml-1">getCueAsHTML()</a></code> method of the <code class="idl"><a data-link-type="idl" href="#vttcue" id="ref-for-vttcue-1">VTTCue</a></code> interface, it needs to be parsed to a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#documentfragment">DocumentFragment</a></code>. This section describes how.</p>
+   <p>To convert a <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-4">list of WebVTT Node Objects</a> to a DOM tree for <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code> <var>owner</var>, user
+agents must create a tree of DOM nodes that is isomorphous to the tree of <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-6">WebVTT Node Objects</a>, with the following mapping of <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-7">WebVTT
 Node Objects</a> to DOM nodes:</p>
    <table class="complex data">
     <thead>
      <tr>
-      <th><a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object⑦">WebVTT Node Object</a>
+      <th><a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-8">WebVTT Node Object</a>
       <th>DOM node
     <tbody>
      <tr>
-      <td class="long"><a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects④">List of WebVTT Node Objects</a>
-      <td class="long"><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#documentfragment" id="ref-for-documentfragment①">DocumentFragment</a></code> node.
+      <td class="long"><a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-5">List of WebVTT Node Objects</a>
+      <td class="long"><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#documentfragment">DocumentFragment</a></code> node.
      <tr>
-      <td class="long"><a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object③">WebVTT Region Object</a>
-      <td class="long"><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#documentfragment" id="ref-for-documentfragment②">DocumentFragment</a></code> node.
+      <td class="long"><a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object-4">WebVTT Region Object</a>
+      <td class="long"><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#documentfragment">DocumentFragment</a></code> node.
      <tr>
-      <td class="long"><a data-link-type="dfn" href="#webvtt-class-object" id="ref-for-webvtt-class-object②">WebVTT Class Object</a>
-      <td class="long">HTML <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element" id="ref-for-the-span-element">span</a> element.
+      <td class="long"><a data-link-type="dfn" href="#webvtt-class-object" id="ref-for-webvtt-class-object-3">WebVTT Class Object</a>
+      <td class="long">HTML <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element">span</a> element.
      <tr>
-      <td class="long"><a data-link-type="dfn" href="#webvtt-italic-object" id="ref-for-webvtt-italic-object②">WebVTT Italic Object</a>
-      <td class="long">HTML <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-i-element" id="ref-for-the-i-element">i</a> element.
+      <td class="long"><a data-link-type="dfn" href="#webvtt-italic-object" id="ref-for-webvtt-italic-object-3">WebVTT Italic Object</a>
+      <td class="long">HTML <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-i-element">i</a> element.
      <tr>
-      <td class="long"><a data-link-type="dfn" href="#webvtt-bold-object" id="ref-for-webvtt-bold-object③">WebVTT Bold Object</a>
-      <td class="long">HTML <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-b-element" id="ref-for-the-b-element">b</a> element.
+      <td class="long"><a data-link-type="dfn" href="#webvtt-bold-object" id="ref-for-webvtt-bold-object-4">WebVTT Bold Object</a>
+      <td class="long">HTML <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-b-element">b</a> element.
      <tr>
-      <td class="long"><a data-link-type="dfn" href="#webvtt-underline-object" id="ref-for-webvtt-underline-object②">WebVTT Underline Object</a>
-      <td class="long">HTML <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-u-element" id="ref-for-the-u-element">u</a> element.
+      <td class="long"><a data-link-type="dfn" href="#webvtt-underline-object" id="ref-for-webvtt-underline-object-3">WebVTT Underline Object</a>
+      <td class="long">HTML <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-u-element">u</a> element.
      <tr>
-      <td class="long"><a data-link-type="dfn" href="#webvtt-ruby-object" id="ref-for-webvtt-ruby-object③">WebVTT Ruby Object</a>
-      <td class="long">HTML <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-ruby-element" id="ref-for-the-ruby-element">ruby</a> element.
+      <td class="long"><a data-link-type="dfn" href="#webvtt-ruby-object" id="ref-for-webvtt-ruby-object-4">WebVTT Ruby Object</a>
+      <td class="long">HTML <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-ruby-element">ruby</a> element.
      <tr>
-      <td class="long"><a data-link-type="dfn" href="#webvtt-ruby-text-object" id="ref-for-webvtt-ruby-text-object③">WebVTT Ruby Text Object</a>
-      <td class="long">HTML <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-rt-element" id="ref-for-the-rt-element">rt</a> element.
+      <td class="long"><a data-link-type="dfn" href="#webvtt-ruby-text-object" id="ref-for-webvtt-ruby-text-object-4">WebVTT Ruby Text Object</a>
+      <td class="long">HTML <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-rt-element">rt</a> element.
      <tr>
-      <td class="long"><a data-link-type="dfn" href="#webvtt-voice-object" id="ref-for-webvtt-voice-object③">WebVTT Voice Object</a>
-      <td class="long">HTML <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element" id="ref-for-the-span-element①">span</a> element with a <a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/dom.html#attr-title" id="ref-for-attr-title">title</a> attribute set to
-   the <a data-link-type="dfn" href="#webvtt-voice-object" id="ref-for-webvtt-voice-object④">WebVTT Voice Object</a>’s value.
+      <td class="long"><a data-link-type="dfn" href="#webvtt-voice-object" id="ref-for-webvtt-voice-object-4">WebVTT Voice Object</a>
+      <td class="long">HTML <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element">span</a> element with a <a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/dom.html#attr-title">title</a> attribute set to
+   the <a data-link-type="dfn" href="#webvtt-voice-object" id="ref-for-webvtt-voice-object-5">WebVTT Voice Object</a>’s value.
      <tr>
-      <td class="long"><a data-link-type="dfn" href="#webvtt-language-object" id="ref-for-webvtt-language-object②">WebVTT Language Object</a>
-      <td class="long">HTML <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element" id="ref-for-the-span-element②">span</a> element with a <a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/dom.html#attr-lang" id="ref-for-attr-lang">lang</a> attribute set to
-   the <a data-link-type="dfn" href="#webvtt-language-object" id="ref-for-webvtt-language-object③">WebVTT Language Object</a>’s <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language④">applicable
+      <td class="long"><a data-link-type="dfn" href="#webvtt-language-object" id="ref-for-webvtt-language-object-3">WebVTT Language Object</a>
+      <td class="long">HTML <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element">span</a> element with a <a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/dom.html#attr-lang">lang</a> attribute set to
+   the <a data-link-type="dfn" href="#webvtt-language-object" id="ref-for-webvtt-language-object-4">WebVTT Language Object</a>’s <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language-5">applicable
    language</a>.
      <tr>
-      <td class="long"><a data-link-type="dfn" href="#webvtt-text-object" id="ref-for-webvtt-text-object③">WebVTT Text Object</a>
-      <td class="long"><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#text" id="ref-for-text">Text</a></code> node whose <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-characterdata-data" id="ref-for-dom-characterdata-data">data</a></code> is the value of the <a data-link-type="dfn" href="#webvtt-text-object" id="ref-for-webvtt-text-object④">WebVTT Text
+      <td class="long"><a data-link-type="dfn" href="#webvtt-text-object" id="ref-for-webvtt-text-object-4">WebVTT Text Object</a>
+      <td class="long"><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#text">Text</a></code> node whose <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-characterdata-data">data</a></code> is the value of the <a data-link-type="dfn" href="#webvtt-text-object" id="ref-for-webvtt-text-object-5">WebVTT Text
    Object</a>.
      <tr>
-      <td class="long"><a data-link-type="dfn" href="#webvtt-timestamp-object" id="ref-for-webvtt-timestamp-object②">WebVTT Timestamp Object</a>
-      <td class="long"><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#processinginstruction" id="ref-for-processinginstruction">ProcessingInstruction</a></code> node whose <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-processinginstruction-target" id="ref-for-dom-processinginstruction-target">target</a></code> is
-   "<code>timestamp</code>" and whose <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-characterdata-data" id="ref-for-dom-characterdata-data①">data</a></code> is a <a data-link-type="dfn" href="#webvtt-timestamp" id="ref-for-webvtt-timestamp⑦">WebVTT timestamp</a> representing the value of the <a data-link-type="dfn" href="#webvtt-timestamp-object" id="ref-for-webvtt-timestamp-object③">WebVTT Timestamp Object</a>, with all optional components
+      <td class="long"><a data-link-type="dfn" href="#webvtt-timestamp-object" id="ref-for-webvtt-timestamp-object-3">WebVTT Timestamp Object</a>
+      <td class="long"><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#processinginstruction">ProcessingInstruction</a></code> node whose <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-processinginstruction-target">target</a></code> is
+   "<code>timestamp</code>" and whose <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-characterdata-data">data</a></code> is a <a data-link-type="dfn" href="#webvtt-timestamp" id="ref-for-webvtt-timestamp-8">WebVTT timestamp</a> representing the value of the <a data-link-type="dfn" href="#webvtt-timestamp-object" id="ref-for-webvtt-timestamp-object-4">WebVTT Timestamp Object</a>, with all optional components
    included, with one leading zero if the <var>hours</var> component is less than ten, and with no leading
    zeros otherwise.
    </table>
-   <p>HTML elements created as part of the mapping described above must have their <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-node-namespaceuri" id="ref-for-dom-node-namespaceuri">namespaceURI</a></code> set to the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#html-namespace" id="ref-for-html-namespace">HTML namespace</a>, use the appropriate IDL interface as defined
-in the HTML specification, and, if the corresponding <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object⑦">WebVTT Internal Node Object</a> has any <a data-link-type="dfn" href="#webvtt-node-objects-applicable-classes" id="ref-for-webvtt-node-objects-applicable-classes②">applicable classes</a>, must have a <a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/dom.html#classes" id="ref-for-classes">class</a> attribute set to the string obtained by concatenating all those classes, each
+   <p>HTML elements created as part of the mapping described above must have their <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-node-namespaceuri">namespaceURI</a></code> set to the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#html-namespace">HTML namespace</a>, use the appropriate IDL interface as defined
+in the HTML specification, and, if the corresponding <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-8">WebVTT Internal Node Object</a> has any <a data-link-type="dfn" href="#webvtt-node-objects-applicable-classes" id="ref-for-webvtt-node-objects-applicable-classes-3">applicable classes</a>, must have a <a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/dom.html#classes">class</a> attribute set to the string obtained by concatenating all those classes, each
 separated from the next by a single U+0020 SPACE character.</p>
-   <p>The <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-node-ownerdocument" id="ref-for-dom-node-ownerdocument">ownerDocument</a></code> attribute of all nodes in the DOM tree must be set to the given
+   <p>The <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-node-ownerdocument">ownerDocument</a></code> attribute of all nodes in the DOM tree must be set to the given
 document <var>owner</var>.</p>
    <p>All characteristics of the DOM nodes that are not described above or dependent on characteristics
 defined above must be left at their initial values.</p>
    <h3 class="heading settled algorithm" data-algorithm="WebVTT rules for extracting the chapter
 title" data-level="5.6" id="rules-for-extracting-the-chapter-title"><span class="secno">5.6. </span><span class="content">WebVTT rules for extracting the chapter
 title</span><a class="self-link" href="#rules-for-extracting-the-chapter-title"></a></h3>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-rules-for-extracting-the-chapter-title">WebVTT rules for extracting the chapter title</dfn> for a <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue②①">WebVTT cue</a> <var>cue</var> are as
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-rules-for-extracting-the-chapter-title">WebVTT rules for extracting the chapter title</dfn> for a <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-22">WebVTT cue</a> <var>cue</var> are as
 follows:</p>
    <ol class="algorithm">
     <li>
-     <p>Let <var>nodes</var> be the <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects⑤">list of WebVTT Node Objects</a> obtained by applying the <a data-link-type="dfn" href="#webvtt-cue-text-parsing-rules" id="ref-for-webvtt-cue-text-parsing-rules">WebVTT cue
- text parsing rules</a> to the <var>cue</var>’s <a data-link-type="dfn" href="#text-track-cue-text" id="ref-for-text-track-cue-text③">text track cue text</a>.</p>
+     <p>Let <var>nodes</var> be the <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-6">list of WebVTT Node Objects</a> obtained by applying the <a data-link-type="dfn" href="#webvtt-cue-text-parsing-rules" id="ref-for-webvtt-cue-text-parsing-rules-1">WebVTT cue
+ text parsing rules</a> to the <var>cue</var>’s <a data-link-type="dfn" href="#text-track-cue-text" id="ref-for-text-track-cue-text-4">text track cue text</a>.</p>
     <li>
-     <p>Return the concatenation of the values of each <a data-link-type="dfn" href="#webvtt-text-object" id="ref-for-webvtt-text-object⑤">WebVTT Text Object</a> in <var>nodes</var>, in a
- pre-order, depth-first traversal, excluding <a data-link-type="dfn" href="#webvtt-ruby-text-object" id="ref-for-webvtt-ruby-text-object④">WebVTT Ruby Text
+     <p>Return the concatenation of the values of each <a data-link-type="dfn" href="#webvtt-text-object" id="ref-for-webvtt-text-object-6">WebVTT Text Object</a> in <var>nodes</var>, in a
+ pre-order, depth-first traversal, excluding <a data-link-type="dfn" href="#webvtt-ruby-text-object" id="ref-for-webvtt-ruby-text-object-5">WebVTT Ruby Text
  Objects</a> and their descendants.</p>
    </ol>
    <h2 class="heading settled" data-level="6" id="rendering"><span class="secno">6. </span><span class="content">Rendering</span><a class="self-link" href="#rendering"></a></h2>
@@ -4165,47 +4165,47 @@ agent. The processing model is quite tightly linked to media elements in HTML, w
 available. When supporting WebVTT in media players that do not support CSS, equivalent visual
 rendering will need to be implemented.</p>
    <h3 class="heading settled algorithm" data-algorithm="Processing model" data-level="6.1" id="processing-model"><span class="secno">6.1. </span><span class="content">Processing model</span><a class="self-link" href="#processing-model"></a></h3>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="rules-for-updating-the-display-of-webvtt-text-tracks">rules for updating the display of WebVTT text tracks</dfn> render the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track" id="ref-for-text-track⑨">text tracks</a> of a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element" id="ref-for-media-element③">media element</a> (specifically, a <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/media.html#video" id="ref-for-video①">video</a> element), or of another playback
-mechanism, by applying the steps below. All the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track" id="ref-for-text-track①⓪">text tracks</a> that use these
-rules for a given <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element" id="ref-for-media-element④">media element</a>, or other playback mechanism, are rendered together, to avoid
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="rules-for-updating-the-display-of-webvtt-text-tracks">rules for updating the display of WebVTT text tracks</dfn> render the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track">text tracks</a> of a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media element</a> (specifically, a <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/media.html#video">video</a> element), or of another playback
+mechanism, by applying the steps below. All the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track">text tracks</a> that use these
+rules for a given <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media element</a>, or other playback mechanism, are rendered together, to avoid
 overlapping subtitles from multiple tracks. A fallback language <var>language</var> may be set when calling
 this algorithm.</p>
    <p class="note" role="note">In HTML, audio elements don’t have a visual rendering area and therefore, this
 algorithm will abort for audio elements. When authors do create WebVTT captions or subtitles for
 audio resources, they need to publish them in a video element for rendering by the user agent.</p>
-   <p>The output of the steps below is a set of CSS boxes that covers the rendering area of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element" id="ref-for-media-element⑤">media element</a> or other playback mechanism, which user agents are expected to render in a
+   <p>The output of the steps below is a set of CSS boxes that covers the rendering area of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media element</a> or other playback mechanism, which user agents are expected to render in a
 manner suiting the user.</p>
    <p>The rules are as follows:</p>
    <ol class="algorithm">
     <li>
-     <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element" id="ref-for-media-element⑥">media element</a> is an <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/media.html#audio" id="ref-for-audio">audio</a> element, or is another playback
+     <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media element</a> is an <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/media.html#audio">audio</a> element, or is another playback
  mechanism with no rendering area, abort these steps.</p>
     <li>
-     <p>Let <var>video</var> be the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element" id="ref-for-media-element⑦">media element</a> or other playback mechanism.</p>
+     <p>Let <var>video</var> be the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media element</a> or other playback mechanism.</p>
     <li>
      <p>Let <var>output</var> be an empty list of absolutely positioned CSS block boxes.</p>
     <li>
-     <p>If the user agent is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#expose-a-user-interface-to-the-user" id="ref-for-expose-a-user-interface-to-the-user">exposing a user
+     <p>If the user agent is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#expose-a-user-interface-to-the-user">exposing a user
  interface</a> for <var>video</var>, add to <var>output</var> one or more completely transparent positioned CSS block
  boxes that cover the same region as the user interface.</p>
     <li>
-     <p>If the last time these rules were run, the user agent was not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#expose-a-user-interface-to-the-user" id="ref-for-expose-a-user-interface-to-the-user①">exposing a user interface</a> for <var>video</var>, but now it is, optionally let <var>reset</var> be
+     <p>If the last time these rules were run, the user agent was not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#expose-a-user-interface-to-the-user">exposing a user interface</a> for <var>video</var>, but now it is, optionally let <var>reset</var> be
  true. Otherwise, let <var>reset</var> be false.</p>
     <li>
-     <p>Let <var>tracks</var> be the subset of <var>video</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#list-of-text-tracks" id="ref-for-list-of-text-tracks②">list of text tracks</a> that have as their <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#rules-for-updating-the-text-track-rendering" id="ref-for-rules-for-updating-the-text-track-rendering①">rules for updating the text track rendering</a> these <a data-link-type="dfn" href="#rules-for-updating-the-display-of-webvtt-text-tracks" id="ref-for-rules-for-updating-the-display-of-webvtt-text-tracks②">rules for updating the display of
- WebVTT text tracks</a>, and whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-mode" id="ref-for-text-track-mode①">text track mode</a> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-showing" id="ref-for-text-track-showing②">showing</a>.</p>
+     <p>Let <var>tracks</var> be the subset of <var>video</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#list-of-text-tracks">list of text tracks</a> that have as their <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#rules-for-updating-the-text-track-rendering">rules for updating the text track rendering</a> these <a data-link-type="dfn" href="#rules-for-updating-the-display-of-webvtt-text-tracks" id="ref-for-rules-for-updating-the-display-of-webvtt-text-tracks-3">rules for updating the display of
+ WebVTT text tracks</a>, and whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-mode">text track mode</a> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-showing">showing</a>.</p>
     <li>
-     <p>Let <var>cues</var> be an empty list of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue" id="ref-for-text-track-cue②">text track cues</a>.</p>
+     <p>Let <var>cues</var> be an empty list of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue">text track cues</a>.</p>
     <li>
-     <p>For each track <var>track</var> in <var>tracks</var>, append to <var>cues</var> all the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue" id="ref-for-text-track-cue③">cues</a> from <var>track</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-list-of-cues" id="ref-for-text-track-list-of-cues④">list of cues</a> that have their <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-active-flag" id="ref-for-text-track-cue-active-flag①">text track cue
+     <p>For each track <var>track</var> in <var>tracks</var>, append to <var>cues</var> all the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue">cues</a> from <var>track</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-list-of-cues">list of cues</a> that have their <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-active-flag">text track cue
  active flag</a> set.</p>
     <li>
-     <p>Let <var>regions</var> be an empty list of <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region①①">WebVTT regions</a>.</p>
+     <p>Let <var>regions</var> be an empty list of <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region-12">WebVTT regions</a>.</p>
     <li>
-     <p>For each track <var>track</var> in <var>tracks</var>, append to <var>regions</var> all the <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region①②">regions</a> with an identifier from <var>track</var>’s <a data-link-type="dfn" href="#text-track-list-of-regions" id="ref-for-text-track-list-of-regions③">list of
+     <p>For each track <var>track</var> in <var>tracks</var>, append to <var>regions</var> all the <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region-13">regions</a> with an identifier from <var>track</var>’s <a data-link-type="dfn" href="#text-track-list-of-regions" id="ref-for-text-track-list-of-regions-4">list of
  regions</a>.</p>
     <li>
-     <p>If <var>reset</var> is false, then, for each <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region①③">WebVTT region</a> <var>region</var> in <var>regions</var> let <var>regionNode</var> be a <a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object④">WebVTT region object</a>.</p>
+     <p>If <var>reset</var> is false, then, for each <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region-14">WebVTT region</a> <var>region</var> in <var>regions</var> let <var>regionNode</var> be a <a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object-5">WebVTT region object</a>.</p>
     <li>
      <p>Apply the following steps for each <var>regionNode</var>:</p>
      <ol>
@@ -4213,14 +4213,14 @@ manner suiting the user.</p>
        <p>Prepare some variables for the application of CSS properties to <var>regionNode</var> as follows:</p>
        <ul>
         <li>
-         <p>Let <var>regionWidth</var> be the <a data-link-type="dfn" href="#webvtt-region-width" id="ref-for-webvtt-region-width②">WebVTT region width</a>. Let <var>width</var> be <span class="css"><var>regionWidth</var> vw</span> (<a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-values-4/#vw" id="ref-for-vw">vw</a> is a CSS unit). <a data-link-type="biblio" href="#biblio-css-values">[CSS-VALUES]</a></p>
+         <p>Let <var>regionWidth</var> be the <a data-link-type="dfn" href="#webvtt-region-width" id="ref-for-webvtt-region-width-3">WebVTT region width</a>. Let <var>width</var> be <span class="css"><var>regionWidth</var> vw</span> (<a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-values-4/#vw">vw</a> is a CSS unit). <a data-link-type="biblio" href="#biblio-css-values">[CSS-VALUES]</a></p>
         <li>
-         <p>Let <var>lineHeight</var> be <span class="css">5.33vh</span> (<a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-values-4/#vh" id="ref-for-vh">vh</a> is a CSS unit) <a data-link-type="biblio" href="#biblio-css-values">[CSS-VALUES]</a> and <var>regionHeight</var> be the <a data-link-type="dfn" href="#webvtt-region-lines" id="ref-for-webvtt-region-lines②">WebVTT region lines</a>. Let <var>lines</var> be <var>lineHeight</var> multiplied by <var>regionHeight</var>.</p>
+         <p>Let <var>lineHeight</var> be <span class="css">5.33vh</span> (<a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-values-4/#vh">vh</a> is a CSS unit) <a data-link-type="biblio" href="#biblio-css-values">[CSS-VALUES]</a> and <var>regionHeight</var> be the <a data-link-type="dfn" href="#webvtt-region-lines" id="ref-for-webvtt-region-lines-3">WebVTT region lines</a>. Let <var>lines</var> be <var>lineHeight</var> multiplied by <var>regionHeight</var>.</p>
         <li>
-         <p>Let <var>viewportAnchorX</var> be the x dimension of the <a data-link-type="dfn" href="#webvtt-region-anchor" id="ref-for-webvtt-region-anchor②">WebVTT region anchor</a> and <var>regionAnchorX</var> be the x dimension of the <a data-link-type="dfn" href="#webvtt-region-anchor" id="ref-for-webvtt-region-anchor③">WebVTT region anchor</a>. Let <var>leftOffset</var> be <var>regionAnchorX</var> multiplied by <var>width</var> divided by 100.0. Let <var>left</var> be <var>leftOffset</var> subtracted
+         <p>Let <var>viewportAnchorX</var> be the x dimension of the <a data-link-type="dfn" href="#webvtt-region-anchor" id="ref-for-webvtt-region-anchor-3">WebVTT region anchor</a> and <var>regionAnchorX</var> be the x dimension of the <a data-link-type="dfn" href="#webvtt-region-anchor" id="ref-for-webvtt-region-anchor-4">WebVTT region anchor</a>. Let <var>leftOffset</var> be <var>regionAnchorX</var> multiplied by <var>width</var> divided by 100.0. Let <var>left</var> be <var>leftOffset</var> subtracted
      from <span class="css"><var>viewportAnchorX</var> vw</span>.</p>
         <li>
-         <p>Let <var>viewportAnchorY</var> be the y dimension of the <a data-link-type="dfn" href="#webvtt-region-anchor" id="ref-for-webvtt-region-anchor④">WebVTT region anchor</a> and <var>regionAnchorY</var> be the y dimension of the <a data-link-type="dfn" href="#webvtt-region-anchor" id="ref-for-webvtt-region-anchor⑤">WebVTT region anchor</a>. Let <var>topOffset</var> be <var>regionAnchorY</var> multiplied by <var>lines</var> divided by 100.0. Let <var>top</var> be <var>topOffset</var> subtracted
+         <p>Let <var>viewportAnchorY</var> be the y dimension of the <a data-link-type="dfn" href="#webvtt-region-anchor" id="ref-for-webvtt-region-anchor-5">WebVTT region anchor</a> and <var>regionAnchorY</var> be the y dimension of the <a data-link-type="dfn" href="#webvtt-region-anchor" id="ref-for-webvtt-region-anchor-6">WebVTT region anchor</a>. Let <var>topOffset</var> be <var>regionAnchorY</var> multiplied by <var>lines</var> divided by 100.0. Let <var>top</var> be <var>topOffset</var> subtracted
      from <span class="css"><var>viewportAnchorY</var> vh</span>.</p>
        </ul>
       <li>
@@ -4241,27 +4241,27 @@ manner suiting the user.</p>
        <p>Add the CSS box <var>box</var> to <var>output</var>.</p>
      </ol>
     <li>
-     <p>If <var>reset</var> is false, then, for each <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue②②">WebVTT cue</a> <var>cue</var> in <var>cues</var>: if <var>cue</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-display-state" id="ref-for-text-track-cue-display-state①">text track
+     <p>If <var>reset</var> is false, then, for each <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-23">WebVTT cue</a> <var>cue</var> in <var>cues</var>: if <var>cue</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-display-state">text track
   cue display state</a> has a set of CSS boxes, then:</p>
      <ul>
       <li>
-       <p>If <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-region" id="ref-for-webvtt-cue-region③">WebVTT cue region</a> is not null, add those boxes to that region’s <var>box</var> and remove <var>cue</var> from <var>cues</var>.</p>
+       <p>If <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-region" id="ref-for-webvtt-cue-region-4">WebVTT cue region</a> is not null, add those boxes to that region’s <var>box</var> and remove <var>cue</var> from <var>cues</var>.</p>
       <li>
        <p>Otherwise, add those boxes to <var>output</var> and remove <var>cue</var> from <var>cues</var>.</p>
      </ul>
     <li>
-     <p>For each <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue②③">WebVTT cue</a> <var>cue</var> in <var>cues</var> that has not yet had corresponding CSS boxes added
-  to <var>output</var>, in <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-order" id="ref-for-text-track-cue-order">text track cue order</a>, run the following substeps:</p>
+     <p>For each <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-24">WebVTT cue</a> <var>cue</var> in <var>cues</var> that has not yet had corresponding CSS boxes added
+  to <var>output</var>, in <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-order">text track cue order</a>, run the following substeps:</p>
      <ol>
       <li>
-       <p>Let <var>nodes</var> be the <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects⑥">list of WebVTT Node Objects</a> obtained by applying the <a data-link-type="dfn" href="#webvtt-cue-text-parsing-rules" id="ref-for-webvtt-cue-text-parsing-rules①">WebVTT
-   cue text parsing rules</a>, with the fallback language <var>language</var> if provided, to the <var>cue</var>’s <a data-link-type="dfn" href="#text-track-cue-text" id="ref-for-text-track-cue-text④">text track cue text</a>.</p>
+       <p>Let <var>nodes</var> be the <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-7">list of WebVTT Node Objects</a> obtained by applying the <a data-link-type="dfn" href="#webvtt-cue-text-parsing-rules" id="ref-for-webvtt-cue-text-parsing-rules-2">WebVTT
+   cue text parsing rules</a>, with the fallback language <var>language</var> if provided, to the <var>cue</var>’s <a data-link-type="dfn" href="#text-track-cue-text" id="ref-for-text-track-cue-text-5">text track cue text</a>.</p>
       <li>
-       <p>If <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-region" id="ref-for-webvtt-cue-region④">WebVTT cue region</a> is null, run the following substeps:</p>
+       <p>If <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-region" id="ref-for-webvtt-cue-region-5">WebVTT cue region</a> is null, run the following substeps:</p>
        <ol>
-        <li><a data-link-type="dfn" href="#apply-webvtt-cue-settings" id="ref-for-apply-webvtt-cue-settings">Apply WebVTT cue settings</a> to obtain CSS boxes <var>boxes</var> from <var>nodes</var>.
+        <li><a data-link-type="dfn" href="#apply-webvtt-cue-settings" id="ref-for-apply-webvtt-cue-settings-1">Apply WebVTT cue settings</a> to obtain CSS boxes <var>boxes</var> from <var>nodes</var>.
         <li>
-         <p>Let <var>cue</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-display-state" id="ref-for-text-track-cue-display-state②">text track cue display state</a> have the CSS boxes in <var>boxes</var>.</p>
+         <p>Let <var>cue</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-display-state">text track cue display state</a> have the CSS boxes in <var>boxes</var>.</p>
         <li>
          <p>Add the CSS boxes in <var>boxes</var> to <var>output</var>.</p>
        </ol>
@@ -4269,23 +4269,23 @@ manner suiting the user.</p>
        <p>Otherwise, run the following substeps:</p>
        <ol>
         <li>
-         <p>Let <var>region</var> be <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-region" id="ref-for-webvtt-cue-region⑤">WebVTT cue region</a>.</p>
+         <p>Let <var>region</var> be <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-region" id="ref-for-webvtt-cue-region-6">WebVTT cue region</a>.</p>
         <li>
-         <p>If <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-scroll" id="ref-for-webvtt-region-scroll②">WebVTT region scroll</a> setting is <a data-link-type="dfn" href="#webvtt-region-scroll-up" id="ref-for-webvtt-region-scroll-up①">up</a> and <var>region</var> already has one child, set <var>region</var>’s <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-transitions-1/#propdef-transition-property" id="ref-for-propdef-transition-property">transition-property</a> to <span class="css">top</span> and <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-transitions-1/#propdef-transition-duration" id="ref-for-propdef-transition-duration">transition-duration</a> to <span class="css">0.433s</span>.</p>
+         <p>If <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-scroll" id="ref-for-webvtt-region-scroll-3">WebVTT region scroll</a> setting is <a data-link-type="dfn" href="#webvtt-region-scroll-up" id="ref-for-webvtt-region-scroll-up-2">up</a> and <var>region</var> already has one child, set <var>region</var>’s <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-transitions-1/#propdef-transition-property">transition-property</a> to <span class="css">top</span> and <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-transitions-1/#propdef-transition-duration">transition-duration</a> to <span class="css">0.433s</span>.</p>
         <li>
-         <p>Let <var>offset</var> be <var>cue</var>’s <a data-link-type="dfn" href="#cue-computed-position" id="ref-for-cue-computed-position">computed position</a> multiplied
-     by <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-width" id="ref-for-webvtt-region-width③">WebVTT region width</a> and divided by 100 (i.e. interpret it as a percentage
+         <p>Let <var>offset</var> be <var>cue</var>’s <a data-link-type="dfn" href="#cue-computed-position" id="ref-for-cue-computed-position-1">computed position</a> multiplied
+     by <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-width" id="ref-for-webvtt-region-width-4">WebVTT region width</a> and divided by 100 (i.e. interpret it as a percentage
      of the region width).</p>
         <li>
-         <p>Adjust <var>offset</var> using <var>cue</var>’s <a data-link-type="dfn" href="#cue-computed-position-alignment" id="ref-for-cue-computed-position-alignment①">computed position
+         <p>Adjust <var>offset</var> using <var>cue</var>’s <a data-link-type="dfn" href="#cue-computed-position-alignment" id="ref-for-cue-computed-position-alignment-2">computed position
       alignment</a> as follows:</p>
          <dl class="switch">
-          <dt>If the <a data-link-type="dfn" href="#cue-computed-position-alignment" id="ref-for-cue-computed-position-alignment②">computed position alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-position-center-alignment" id="ref-for-webvtt-cue-position-center-alignment②">center alignment</a>
+          <dt>If the <a data-link-type="dfn" href="#cue-computed-position-alignment" id="ref-for-cue-computed-position-alignment-3">computed position alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-position-center-alignment" id="ref-for-webvtt-cue-position-center-alignment-3">center alignment</a>
           <dd>
-           <p>Subtract half of <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-width" id="ref-for-webvtt-region-width④">WebVTT region width</a> from <var>offset</var>.</p>
-          <dt>If the <a data-link-type="dfn" href="#cue-computed-position-alignment" id="ref-for-cue-computed-position-alignment③">computed position alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-position-line-right-alignment" id="ref-for-webvtt-cue-position-line-right-alignment③">line-right alignment</a>
+           <p>Subtract half of <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-width" id="ref-for-webvtt-region-width-5">WebVTT region width</a> from <var>offset</var>.</p>
+          <dt>If the <a data-link-type="dfn" href="#cue-computed-position-alignment" id="ref-for-cue-computed-position-alignment-4">computed position alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-position-line-right-alignment" id="ref-for-webvtt-cue-position-line-right-alignment-4">line-right alignment</a>
           <dd>
-           <p>Subtract <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-width" id="ref-for-webvtt-region-width⑤">WebVTT region width</a> from <var>offset</var>.</p>
+           <p>Subtract <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-width" id="ref-for-webvtt-region-width-6">WebVTT region width</a> from <var>offset</var>.</p>
          </dl>
         <li>
          <p>Let <var>left</var> be <span class="css"><var>offset</var> %</span>. <a data-link-type="biblio" href="#biblio-css-values">[CSS-VALUES]</a></p>
@@ -4298,7 +4298,7 @@ manner suiting the user.</p>
          <p>If there are no line boxes in <var>boxes</var>, skip the remainder of these substeps for <var>cue</var>.
      The cue is ignored.</p>
         <li>
-         <p>Let <var>cue</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-display-state" id="ref-for-text-track-cue-display-state③">text track cue display state</a> have the CSS boxes in <var>boxes</var>.</p>
+         <p>Let <var>cue</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-display-state">text track cue display state</a> have the CSS boxes in <var>boxes</var>.</p>
         <li>
          <p>Add the CSS boxes in <var>boxes</var> to <var>region</var>.</p>
         <li>
@@ -4309,96 +4309,96 @@ manner suiting the user.</p>
      <p>Return <var>output</var>.</p>
    </ol>
    <p>User agents may allow the user to override the above algorithm’s positioning of cues, e.g. by
-dragging them to another location on the <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/media.html#video" id="ref-for-video②">video</a>, or even off the <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/media.html#video" id="ref-for-video③">video</a> entirely.</p>
+dragging them to another location on the <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/media.html#video">video</a>, or even off the <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/media.html#video">video</a> entirely.</p>
    <p>When the algorithm above requires to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="apply-webvtt-cue-settings">apply WebVTT cue settings</dfn> to obtain CSS boxes
-from a <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects⑦">list of WebVTT Node Objects</a> <var>nodes</var>, the user agent must run the following
+from a <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-8">list of WebVTT Node Objects</a> <var>nodes</var>, the user agent must run the following
 algorithm.</p>
    <ol class="algorithm">
     <li>
-     <p>If the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction①⑤">WebVTT cue writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction①③">horizontal</a>, then let <var>writing-mode</var> be "horizontal-tb". Otherwise, if the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction①⑥">WebVTT
- cue writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-left-writing-direction" id="ref-for-webvtt-cue-vertical-growing-left-writing-direction④">vertical
- growing left</a>, then let <var>writing-mode</var> be "vertical-rl". Otherwise, the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction①⑦">WebVTT cue writing
- direction</a> is <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-right-writing-direction" id="ref-for-webvtt-cue-vertical-growing-right-writing-direction④">vertical growing
+     <p>If the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-16">WebVTT cue writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction-14">horizontal</a>, then let <var>writing-mode</var> be "horizontal-tb". Otherwise, if the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-17">WebVTT
+ cue writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-left-writing-direction" id="ref-for-webvtt-cue-vertical-growing-left-writing-direction-5">vertical
+ growing left</a>, then let <var>writing-mode</var> be "vertical-rl". Otherwise, the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-18">WebVTT cue writing
+ direction</a> is <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-right-writing-direction" id="ref-for-webvtt-cue-vertical-growing-right-writing-direction-5">vertical growing
  right</a>; let <var>writing-mode</var> be "vertical-lr".</p>
     <li>
      <p>Determine the value of <var>maximum size</var> for <var>cue</var> as per the appropriate rules from the following
   list:</p>
      <dl class="switch">
-      <dt>If the <a data-link-type="dfn" href="#cue-computed-position-alignment" id="ref-for-cue-computed-position-alignment④">computed position alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-position-line-left-alignment" id="ref-for-webvtt-cue-position-line-left-alignment④">line-left</a>
+      <dt>If the <a data-link-type="dfn" href="#cue-computed-position-alignment" id="ref-for-cue-computed-position-alignment-5">computed position alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-position-line-left-alignment" id="ref-for-webvtt-cue-position-line-left-alignment-5">line-left</a>
       <dd>
-       <p>Let <var>maximum size</var> be the <a data-link-type="dfn" href="#cue-computed-position" id="ref-for-cue-computed-position①">computed position</a> subtracted from
+       <p>Let <var>maximum size</var> be the <a data-link-type="dfn" href="#cue-computed-position" id="ref-for-cue-computed-position-2">computed position</a> subtracted from
     100.</p>
-      <dt>If the <a data-link-type="dfn" href="#cue-computed-position-alignment" id="ref-for-cue-computed-position-alignment⑤">computed position alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-position-line-right-alignment" id="ref-for-webvtt-cue-position-line-right-alignment④">line-right</a>
+      <dt>If the <a data-link-type="dfn" href="#cue-computed-position-alignment" id="ref-for-cue-computed-position-alignment-6">computed position alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-position-line-right-alignment" id="ref-for-webvtt-cue-position-line-right-alignment-5">line-right</a>
       <dd>
-       <p>Let <var>maximum size</var> be the <a data-link-type="dfn" href="#cue-computed-position" id="ref-for-cue-computed-position②">computed position</a>.</p>
-      <dt>If the <a data-link-type="dfn" href="#cue-computed-position-alignment" id="ref-for-cue-computed-position-alignment⑥">computed position alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-position-center-alignment" id="ref-for-webvtt-cue-position-center-alignment③">center</a>, and the <a data-link-type="dfn" href="#cue-computed-position" id="ref-for-cue-computed-position③">computed position</a> is less than or equal to 50
+       <p>Let <var>maximum size</var> be the <a data-link-type="dfn" href="#cue-computed-position" id="ref-for-cue-computed-position-3">computed position</a>.</p>
+      <dt>If the <a data-link-type="dfn" href="#cue-computed-position-alignment" id="ref-for-cue-computed-position-alignment-7">computed position alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-position-center-alignment" id="ref-for-webvtt-cue-position-center-alignment-4">center</a>, and the <a data-link-type="dfn" href="#cue-computed-position" id="ref-for-cue-computed-position-4">computed position</a> is less than or equal to 50
       <dd>
-       <p>Let <var>maximum size</var> be the <a data-link-type="dfn" href="#cue-computed-position" id="ref-for-cue-computed-position④">computed position</a> multiplied by
+       <p>Let <var>maximum size</var> be the <a data-link-type="dfn" href="#cue-computed-position" id="ref-for-cue-computed-position-5">computed position</a> multiplied by
     two.</p>
-      <dt>If the <a data-link-type="dfn" href="#cue-computed-position-alignment" id="ref-for-cue-computed-position-alignment⑦">computed position alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-position-center-alignment" id="ref-for-webvtt-cue-position-center-alignment④">center</a>, and the <a data-link-type="dfn" href="#cue-computed-position" id="ref-for-cue-computed-position⑤">computed position</a> is greater than  50
+      <dt>If the <a data-link-type="dfn" href="#cue-computed-position-alignment" id="ref-for-cue-computed-position-alignment-8">computed position alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-position-center-alignment" id="ref-for-webvtt-cue-position-center-alignment-5">center</a>, and the <a data-link-type="dfn" href="#cue-computed-position" id="ref-for-cue-computed-position-6">computed position</a> is greater than  50
       <dd>
-       <p>Let <var>maximum size</var> be the result of subtracting <a data-link-type="dfn" href="#cue-computed-position" id="ref-for-cue-computed-position⑥">computed
+       <p>Let <var>maximum size</var> be the result of subtracting <a data-link-type="dfn" href="#cue-computed-position" id="ref-for-cue-computed-position-7">computed
     position</a> from 100 and then multiplying the result by two.</p>
      </dl>
     <li>
-     <p>If the <a data-link-type="dfn" href="#webvtt-cue-size" id="ref-for-webvtt-cue-size⑧">WebVTT cue size</a> is less than <var>maximum size</var>, then let <var>size</var> be <a data-link-type="dfn" href="#webvtt-cue-size" id="ref-for-webvtt-cue-size⑨">WebVTT cue
+     <p>If the <a data-link-type="dfn" href="#webvtt-cue-size" id="ref-for-webvtt-cue-size-9">WebVTT cue size</a> is less than <var>maximum size</var>, then let <var>size</var> be <a data-link-type="dfn" href="#webvtt-cue-size" id="ref-for-webvtt-cue-size-10">WebVTT cue
  size</a>. Otherwise, let <var>size</var> be <var>maximum size</var>.</p>
     <li>
-     <p>If the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction①⑧">WebVTT cue writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction①④">horizontal</a>, then let <var>width</var> be <span class="css"><var>size</var> vw</span> and <var>height</var> be <span class="css">auto</span>. Otherwise, let <var>width</var> be <span class="css">auto</span> and <var>height</var> be <span class="css"><var>size</var> vh</span>.
- (These are CSS values used by the next section to set CSS properties for the rendering; <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-values-4/#vw" id="ref-for-vw①">vw</a> and <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-values-4/#vh" id="ref-for-vh①">vh</a> are CSS units.) <a data-link-type="biblio" href="#biblio-css-values">[CSS-VALUES]</a></p>
+     <p>If the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-19">WebVTT cue writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction-15">horizontal</a>, then let <var>width</var> be <span class="css"><var>size</var> vw</span> and <var>height</var> be <span class="css">auto</span>. Otherwise, let <var>width</var> be <span class="css">auto</span> and <var>height</var> be <span class="css"><var>size</var> vh</span>.
+ (These are CSS values used by the next section to set CSS properties for the rendering; <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-values-4/#vw">vw</a> and <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-values-4/#vh">vh</a> are CSS units.) <a data-link-type="biblio" href="#biblio-css-values">[CSS-VALUES]</a></p>
     <li>
      <p>Determine the value of <var>x-position</var> or <var>y-position</var> for <var>cue</var> as per the appropriate rules from
   the following list:</p>
      <dl class="switch">
-      <dt>If the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction①⑨">WebVTT cue writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction①⑤">horizontal</a>
+      <dt>If the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-20">WebVTT cue writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction-16">horizontal</a>
       <dd>
        <dl class="switch">
-        <dt>If the <a data-link-type="dfn" href="#cue-computed-position-alignment" id="ref-for-cue-computed-position-alignment⑧">computed position alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-position-line-left-alignment" id="ref-for-webvtt-cue-position-line-left-alignment⑤">line-left alignment</a>
+        <dt>If the <a data-link-type="dfn" href="#cue-computed-position-alignment" id="ref-for-cue-computed-position-alignment-9">computed position alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-position-line-left-alignment" id="ref-for-webvtt-cue-position-line-left-alignment-6">line-left alignment</a>
         <dd>
-         <p>Let <var>x-position</var> be the <a data-link-type="dfn" href="#cue-computed-position" id="ref-for-cue-computed-position⑦">computed position</a>.</p>
-        <dt>If the <a data-link-type="dfn" href="#cue-computed-position-alignment" id="ref-for-cue-computed-position-alignment⑨">computed position alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-position-center-alignment" id="ref-for-webvtt-cue-position-center-alignment⑤">center alignment</a>
+         <p>Let <var>x-position</var> be the <a data-link-type="dfn" href="#cue-computed-position" id="ref-for-cue-computed-position-8">computed position</a>.</p>
+        <dt>If the <a data-link-type="dfn" href="#cue-computed-position-alignment" id="ref-for-cue-computed-position-alignment-10">computed position alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-position-center-alignment" id="ref-for-webvtt-cue-position-center-alignment-6">center alignment</a>
         <dd>
-         <p>Let <var>x-position</var> be the <a data-link-type="dfn" href="#cue-computed-position" id="ref-for-cue-computed-position⑧">computed position</a> minus half
+         <p>Let <var>x-position</var> be the <a data-link-type="dfn" href="#cue-computed-position" id="ref-for-cue-computed-position-9">computed position</a> minus half
      of <var>size</var>.</p>
-        <dt>If the <a data-link-type="dfn" href="#cue-computed-position-alignment" id="ref-for-cue-computed-position-alignment①⓪">computed position alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-position-line-right-alignment" id="ref-for-webvtt-cue-position-line-right-alignment⑤">line-right alignment</a>
+        <dt>If the <a data-link-type="dfn" href="#cue-computed-position-alignment" id="ref-for-cue-computed-position-alignment-11">computed position alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-position-line-right-alignment" id="ref-for-webvtt-cue-position-line-right-alignment-6">line-right alignment</a>
         <dd>
-         <p>Let <var>x-position</var> be the <a data-link-type="dfn" href="#cue-computed-position" id="ref-for-cue-computed-position⑨">computed position</a> minus <var>size</var>.</p>
+         <p>Let <var>x-position</var> be the <a data-link-type="dfn" href="#cue-computed-position" id="ref-for-cue-computed-position-10">computed position</a> minus <var>size</var>.</p>
        </dl>
-      <dt>If the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction②⓪">WebVTT cue writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-left-writing-direction" id="ref-for-webvtt-cue-vertical-growing-left-writing-direction⑤">vertical growing left</a> or <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-right-writing-direction" id="ref-for-webvtt-cue-vertical-growing-right-writing-direction⑤">vertical growing right</a>
+      <dt>If the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-21">WebVTT cue writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-left-writing-direction" id="ref-for-webvtt-cue-vertical-growing-left-writing-direction-6">vertical growing left</a> or <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-right-writing-direction" id="ref-for-webvtt-cue-vertical-growing-right-writing-direction-6">vertical growing right</a>
       <dd>
        <dl class="switch">
-        <dt>If the <a data-link-type="dfn" href="#cue-computed-position-alignment" id="ref-for-cue-computed-position-alignment①①">computed position alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-position-line-left-alignment" id="ref-for-webvtt-cue-position-line-left-alignment⑥">line-left alignment</a>
+        <dt>If the <a data-link-type="dfn" href="#cue-computed-position-alignment" id="ref-for-cue-computed-position-alignment-12">computed position alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-position-line-left-alignment" id="ref-for-webvtt-cue-position-line-left-alignment-7">line-left alignment</a>
         <dd>
-         <p>Let <var>y-position</var> be the <a data-link-type="dfn" href="#cue-computed-position" id="ref-for-cue-computed-position①⓪">computed position</a>.</p>
-        <dt>If the <a data-link-type="dfn" href="#cue-computed-position-alignment" id="ref-for-cue-computed-position-alignment①②">computed position alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-position-center-alignment" id="ref-for-webvtt-cue-position-center-alignment⑥">center alignment</a>
+         <p>Let <var>y-position</var> be the <a data-link-type="dfn" href="#cue-computed-position" id="ref-for-cue-computed-position-11">computed position</a>.</p>
+        <dt>If the <a data-link-type="dfn" href="#cue-computed-position-alignment" id="ref-for-cue-computed-position-alignment-13">computed position alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-position-center-alignment" id="ref-for-webvtt-cue-position-center-alignment-7">center alignment</a>
         <dd>
-         <p>Let <var>y-position</var> be the <a data-link-type="dfn" href="#cue-computed-position" id="ref-for-cue-computed-position①①">computed position</a> minus half
+         <p>Let <var>y-position</var> be the <a data-link-type="dfn" href="#cue-computed-position" id="ref-for-cue-computed-position-12">computed position</a> minus half
      of <var>size</var>.</p>
-        <dt>If the <a data-link-type="dfn" href="#cue-computed-position-alignment" id="ref-for-cue-computed-position-alignment①③">computed position alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-position-line-right-alignment" id="ref-for-webvtt-cue-position-line-right-alignment⑥">line-right alignment</a>
+        <dt>If the <a data-link-type="dfn" href="#cue-computed-position-alignment" id="ref-for-cue-computed-position-alignment-14">computed position alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-position-line-right-alignment" id="ref-for-webvtt-cue-position-line-right-alignment-7">line-right alignment</a>
         <dd>
-         <p>Let <var>y-position</var> be the <a data-link-type="dfn" href="#cue-computed-position" id="ref-for-cue-computed-position①②">computed position</a> minus <var>size</var>.</p>
+         <p>Let <var>y-position</var> be the <a data-link-type="dfn" href="#cue-computed-position" id="ref-for-cue-computed-position-13">computed position</a> minus <var>size</var>.</p>
        </dl>
      </dl>
     <li>
      <p>Determine the value of whichever of <var>x-position</var> or <var>y-position</var> is not yet calculated for <var>cue</var> as per the appropriate rules from the following list:</p>
      <dl class="switch">
-      <dt>If the <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag①⓪">WebVTT cue snap-to-lines flag</a> is false
+      <dt>If the <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag-11">WebVTT cue snap-to-lines flag</a> is false
       <dd>
        <dl class="switch">
-        <dt>If the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction②①">WebVTT cue writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction①⑥">horizontal</a>
+        <dt>If the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-22">WebVTT cue writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction-17">horizontal</a>
         <dd>
-         <p>Let <var>y-position</var> be the <a data-link-type="dfn" href="#cue-computed-line" id="ref-for-cue-computed-line①">computed line</a>.</p>
-        <dt>If the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction②②">WebVTT cue writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-left-writing-direction" id="ref-for-webvtt-cue-vertical-growing-left-writing-direction⑥">vertical growing left</a> or <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-right-writing-direction" id="ref-for-webvtt-cue-vertical-growing-right-writing-direction⑥">vertical growing right</a>
+         <p>Let <var>y-position</var> be the <a data-link-type="dfn" href="#cue-computed-line" id="ref-for-cue-computed-line-2">computed line</a>.</p>
+        <dt>If the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-23">WebVTT cue writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-left-writing-direction" id="ref-for-webvtt-cue-vertical-growing-left-writing-direction-7">vertical growing left</a> or <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-right-writing-direction" id="ref-for-webvtt-cue-vertical-growing-right-writing-direction-7">vertical growing right</a>
         <dd>
-         <p>Let <var>x-position</var> be the <a data-link-type="dfn" href="#cue-computed-line" id="ref-for-cue-computed-line②">computed line</a>.</p>
+         <p>Let <var>x-position</var> be the <a data-link-type="dfn" href="#cue-computed-line" id="ref-for-cue-computed-line-3">computed line</a>.</p>
        </dl>
-      <dt>If the <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag①①">WebVTT cue snap-to-lines flag</a> is true
+      <dt>If the <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag-12">WebVTT cue snap-to-lines flag</a> is true
       <dd>
        <dl class="switch">
-        <dt>If the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction②③">WebVTT cue writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction①⑦">horizontal</a>
+        <dt>If the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-24">WebVTT cue writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction-18">horizontal</a>
         <dd>
          <p>Let <var>y-position</var> be 0.</p>
-        <dt>If the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction②④">WebVTT cue writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-left-writing-direction" id="ref-for-webvtt-cue-vertical-growing-left-writing-direction⑦">vertical growing left</a> or <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-right-writing-direction" id="ref-for-webvtt-cue-vertical-growing-right-writing-direction⑦">vertical growing right</a>
+        <dt>If the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-25">WebVTT cue writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-left-writing-direction" id="ref-for-webvtt-cue-vertical-growing-left-writing-direction-8">vertical growing left</a> or <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-right-writing-direction" id="ref-for-webvtt-cue-vertical-growing-right-writing-direction-8">vertical growing right</a>
         <dd>
          <p>Let <var>x-position</var> be 0.</p>
        </dl>
@@ -4406,10 +4406,10 @@ algorithm.</p>
      <p class="note" role="note">These are not final positions, they are merely temporary positions used to
   calculate box dimensions below.</p>
     <li>
-     <p>If the <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag①②">WebVTT cue snap-to-lines flag</a> is true, then run the appropriate steps from the
+     <p>If the <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag-13">WebVTT cue snap-to-lines flag</a> is true, then run the appropriate steps from the
   following list:</p>
      <dl class="switch">
-      <dt>If the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction②⑤">WebVTT cue writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction①⑧">horizontal</a>
+      <dt>If the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-26">WebVTT cue writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction-19">horizontal</a>
       <dd>
        <ol>
         <li>
@@ -4428,7 +4428,7 @@ algorithm.</p>
         <li>
          <p>If <var>x-position</var> is less than <var>right margin edge</var>, and the sum of <var>x-position</var> and <var>size</var> is more than <var>right margin edge</var>, then decrease <var>size</var> by <var>edge margin</var>.</p>
        </ol>
-      <dt>If the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction②⑥">WebVTT cue writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-left-writing-direction" id="ref-for-webvtt-cue-vertical-growing-left-writing-direction⑧">vertical growing left</a> or <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-right-writing-direction" id="ref-for-webvtt-cue-vertical-growing-right-writing-direction⑧">vertical growing right</a>
+      <dt>If the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-27">WebVTT cue writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-left-writing-direction" id="ref-for-webvtt-cue-vertical-growing-left-writing-direction-9">vertical growing left</a> or <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-right-writing-direction" id="ref-for-webvtt-cue-vertical-growing-right-writing-direction-9">vertical growing right</a>
       <dd>
        <ol>
         <li>
@@ -4450,28 +4450,28 @@ algorithm.</p>
      </dl>
     <li>
      <p>Let <var>left</var> be <span class="css"><var>x-position</var> vw</span> and <var>top</var> be <span class="css"><var>y-position</var> vh</span>. (These are
- CSS values used by the next section to set CSS properties for the rendering; <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-values-4/#vw" id="ref-for-vw②">vw</a> and <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-values-4/#vh" id="ref-for-vh②">vh</a> are
+ CSS values used by the next section to set CSS properties for the rendering; <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-values-4/#vw">vw</a> and <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-values-4/#vh">vh</a> are
  CSS units.) <a data-link-type="biblio" href="#biblio-css-values">[CSS-VALUES]</a></p>
     <li>
      <p>Apply the terms of the CSS specifications to <var>nodes</var> within the following constraints, thus
   obtaining a set of CSS boxes positioned relative to an initial containing block: <a data-link-type="biblio" href="#biblio-css22">[CSS22]</a></p>
      <ul>
       <li>
-       <p>The <i>document tree</i> is the tree of <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object⑧">WebVTT Node Objects</a> rooted at <var>nodes</var>.</p>
+       <p>The <i>document tree</i> is the tree of <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-9">WebVTT Node Objects</a> rooted at <var>nodes</var>.</p>
       <li>
        <p>For the purpose of selectors in STYLE blocks of a WebVTT file, the style sheet must apply to
     a hypothetical document that contains a single empty element with no explicit name, no
-    namespace, no attributes, no classes, no IDs, and unknown primary language, that acts like the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element" id="ref-for-media-element⑧">media element</a> for the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track" id="ref-for-text-track①①">text tracks</a> that were sourced from the given WebVTT file.
-    The selectors must not match other <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track" id="ref-for-text-track①②">text tracks</a> for the same <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element" id="ref-for-media-element⑨">media element</a>. In this
+    namespace, no attributes, no classes, no IDs, and unknown primary language, that acts like the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media element</a> for the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track">text tracks</a> that were sourced from the given WebVTT file.
+    The selectors must not match other <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track">text tracks</a> for the same <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media element</a>. In this
     hypothetical document, the element must not match any selector that would match the element
     itself.</p>
-       <p class="note" role="note">This element exists only to be the <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#originating-element" id="ref-for-originating-element">originating element</a> for
+       <p class="note" role="note">This element exists only to be the <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#originating-element">originating element</a> for
     the <span class="css">::cue</span>, <span class="css">::cue()</span>, <span class="css">::cue-region</span> and <span class="css">::cue-region()</span> pseudo-elements.</p>
       <li>
-       <p>For the purpose of determining the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-4/#cascade" id="ref-for-cascade">cascade</a> of the declarations in
+       <p>For the purpose of determining the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-4/#cascade">cascade</a> of the declarations in
     STYLE blocks of a WebVTT file, the relative order of appearance of the style sheets must be the
     same order as they were added to the collection, and the order of appearance of the collection
-    must be after any style sheets that apply to the associated <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/media.html#video" id="ref-for-video④">video</a> element’s
+    must be after any style sheets that apply to the associated <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/media.html#video">video</a> element’s
     document.</p>
        <div class="example" id="example-29aea910">
         <a class="self-link" href="#example-29aea910"></a> 
@@ -4494,27 +4494,27 @@ STYLE
 00:00:00.000 --> 00:00:25.000
 Red or green?
 </pre>
-        <p>The <span class="css">color:lime</span> declaration would win, because it is last in the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-4/#cascade" id="ref-for-cascade①">cascade</a>, even though the <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element" id="ref-for-the-style-element①">style</a> element is after the <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/media.html#video" id="ref-for-video⑤">video</a> element in the document order.</p>
+        <p>The <span class="css">color:lime</span> declaration would win, because it is last in the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-4/#cascade">cascade</a>, even though the <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element">style</a> element is after the <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/media.html#video">video</a> element in the document order.</p>
        </div>
       <li>
        <p id="style-no-external-resources">For the purpose of resolving URLs in STYLE blocks of a WebVTT
     file, or any URLs in resources referenced from STYLE blocks of a WebVTT file, if the URL’s
     scheme is not "<code>data</code>", then the user agent must act as if the URL failed to
     resolve.</p>
-       <p><strong class="advisement">Supporting external resources with <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-cascade-4/#at-ruledef-import" id="ref-for-at-ruledef-import">@import</a> or <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image" id="ref-for-propdef-background-image">background-image</a> would be a new ability for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element" id="ref-for-media-element①⓪">media elements</a> and <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/media.html#the-track-element" id="ref-for-the-track-element">track</a> elements to issue
+       <p><strong class="advisement">Supporting external resources with <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-cascade-4/#at-ruledef-import">@import</a> or <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">background-image</a> would be a new ability for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media elements</a> and <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/media.html#the-track-element">track</a> elements to issue
     network requests as the user watches the video, which could be a privacy issue.</strong></p>
       <li>
-       <p>For the purposes of processing by the CSS specification, <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object⑧">WebVTT Internal Node Objects</a> are equivalent to elements with the same
+       <p>For the purposes of processing by the CSS specification, <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-9">WebVTT Internal Node Objects</a> are equivalent to elements with the same
    contents.</p>
-      <li>For the purposes of processing by the CSS specification, <a data-link-type="dfn" href="#webvtt-text-object" id="ref-for-webvtt-text-object⑥">WebVTT
-   Text Objects</a> are equivalent to <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#text" id="ref-for-text①">Text</a></code> nodes.
+      <li>For the purposes of processing by the CSS specification, <a data-link-type="dfn" href="#webvtt-text-object" id="ref-for-webvtt-text-object-7">WebVTT
+   Text Objects</a> are equivalent to <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#text">Text</a></code> nodes.
       <li>No style sheets are associated with <var>nodes</var>. (The nodes are subsequently restyled using style
    sheets after their boxes are generated, as described below.)
-      <li>The children of the <var>nodes</var> must be wrapped in an anonymous box whose <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-display-3/#propdef-display" id="ref-for-propdef-display">display</a> property has
-   the value <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-display-3/#valdef-display-inline" id="ref-for-valdef-display-inline">inline</a>. This is the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue-background-box">WebVTT cue background box</dfn>.
-      <li>Runs of children of <a data-link-type="dfn" href="#webvtt-ruby-object" id="ref-for-webvtt-ruby-object④">WebVTT Ruby Objects</a> that are not <a data-link-type="dfn" href="#webvtt-ruby-text-object" id="ref-for-webvtt-ruby-text-object⑤">WebVTT Ruby Text Objects</a> must be wrapped in anonymous boxes
-   whose <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-display-3/#propdef-display" id="ref-for-propdef-display①">display</a> property has the value <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-ruby-1/#valdef-display-ruby-base" id="ref-for-valdef-display-ruby-base">ruby-base</a>. <a data-link-type="biblio" href="#biblio-css3-ruby">[CSS3-RUBY]</a>
-      <li>Properties on <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object⑨">WebVTT Node Objects</a> have their values set as
+      <li>The children of the <var>nodes</var> must be wrapped in an anonymous box whose <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-display-3/#propdef-display">display</a> property has
+   the value <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-display-3/#valdef-display-inline">inline</a>. This is the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue-background-box">WebVTT cue background box</dfn>.
+      <li>Runs of children of <a data-link-type="dfn" href="#webvtt-ruby-object" id="ref-for-webvtt-ruby-object-5">WebVTT Ruby Objects</a> that are not <a data-link-type="dfn" href="#webvtt-ruby-text-object" id="ref-for-webvtt-ruby-text-object-6">WebVTT Ruby Text Objects</a> must be wrapped in anonymous boxes
+   whose <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-display-3/#propdef-display">display</a> property has the value <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-ruby-1/#valdef-display-ruby-base">ruby-base</a>. <a data-link-type="biblio" href="#biblio-css3-ruby">[CSS3-RUBY]</a>
+      <li>Properties on <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-10">WebVTT Node Objects</a> have their values set as
    defined in the next section. (That section uses some of the variables whose values were
    calculated earlier in this algorithm.)
       <li>Text runs must be wrapped according to the CSS line-wrapping rules.
@@ -4528,12 +4528,12 @@ Red or green?
     <li>
      <p>Adjust the positions of <var>boxes</var> according to the appropriate steps from the following list:</p>
      <dl class="switch">
-      <dt>If <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag①③">WebVTT cue snap-to-lines flag</a> is true
+      <dt>If <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag-14">WebVTT cue snap-to-lines flag</a> is true
       <dd>
-       <p>Many of the steps in this algorithm vary according to the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction②⑦">WebVTT cue writing
-    direction</a>. Steps labeled "<strong>Horizontal</strong>" must be followed only when the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction②⑧">WebVTT cue writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction①⑨">horizontal</a>, steps labeled "<strong>Vertical</strong>" must be followed when the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction②⑨">WebVTT cue writing direction</a> is either <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-left-writing-direction" id="ref-for-webvtt-cue-vertical-growing-left-writing-direction⑨">vertical growing left</a> or <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-right-writing-direction" id="ref-for-webvtt-cue-vertical-growing-right-writing-direction⑨">vertical growing right</a>, steps labeled "<strong>Vertical Growing Left</strong>"
-    must be followed only when the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction③⓪">WebVTT cue writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-left-writing-direction" id="ref-for-webvtt-cue-vertical-growing-left-writing-direction①⓪">vertical growing left</a>, and steps labeled "<strong>Vertical
-    Growing Right</strong>" must be followed only when the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction③①">WebVTT cue writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-right-writing-direction" id="ref-for-webvtt-cue-vertical-growing-right-writing-direction①⓪">vertical growing right</a>.</p>
+       <p>Many of the steps in this algorithm vary according to the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-28">WebVTT cue writing
+    direction</a>. Steps labeled "<strong>Horizontal</strong>" must be followed only when the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-29">WebVTT cue writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction-20">horizontal</a>, steps labeled "<strong>Vertical</strong>" must be followed when the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-30">WebVTT cue writing direction</a> is either <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-left-writing-direction" id="ref-for-webvtt-cue-vertical-growing-left-writing-direction-10">vertical growing left</a> or <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-right-writing-direction" id="ref-for-webvtt-cue-vertical-growing-right-writing-direction-10">vertical growing right</a>, steps labeled "<strong>Vertical Growing Left</strong>"
+    must be followed only when the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-31">WebVTT cue writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-left-writing-direction" id="ref-for-webvtt-cue-vertical-growing-left-writing-direction-11">vertical growing left</a>, and steps labeled "<strong>Vertical
+    Growing Right</strong>" must be followed only when the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-32">WebVTT cue writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-right-writing-direction" id="ref-for-webvtt-cue-vertical-growing-right-writing-direction-11">vertical growing right</a>.</p>
        <ol>
         <li>
          <p><strong>Horizontal</strong>: Let <var>margin</var> be a user-agent-defined vertical length which
@@ -4563,7 +4563,7 @@ Red or green?
         <li>
          <p>If <var>step</var> is zero, then jump to the step labeled <i>done positioning</i> below.</p>
         <li>
-         <p>Let <var>line</var> be <var>cue</var>’s <a data-link-type="dfn" href="#cue-computed-line" id="ref-for-cue-computed-line③">computed line</a>.</p>
+         <p>Let <var>line</var> be <var>cue</var>’s <a data-link-type="dfn" href="#cue-computed-line" id="ref-for-cue-computed-line-4">computed line</a>.</p>
         <li>
          <p>Round <var>line</var> to an integer by adding 0.5 and then flooring it.</p>
         <li>
@@ -4617,7 +4617,7 @@ Red or green?
         <li>
          <p>Jump back to the step labeled <i>step loop</i>.</p>
        </ol>
-      <dt>If <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag①④">WebVTT cue snap-to-lines flag</a> is false
+      <dt>If <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag-15">WebVTT cue snap-to-lines flag</a> is false
       <dd>
        <ol>
         <li>
@@ -4625,24 +4625,24 @@ Red or green?
         <li>
          <p>Run the appropriate steps from the following list:</p>
          <dl class="switch">
-          <dt>If the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction③②">WebVTT cue writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction②⓪">horizontal</a>
+          <dt>If the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-33">WebVTT cue writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction-21">horizontal</a>
           <dd>
            <dl class="switch">
-            <dt>If the <a data-link-type="dfn" href="#webvtt-cue-line-alignment" id="ref-for-webvtt-cue-line-alignment⑨">WebVTT cue line alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-line-center-alignment" id="ref-for-webvtt-cue-line-center-alignment②">center alignment</a>
+            <dt>If the <a data-link-type="dfn" href="#webvtt-cue-line-alignment" id="ref-for-webvtt-cue-line-alignment-10">WebVTT cue line alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-line-center-alignment" id="ref-for-webvtt-cue-line-center-alignment-3">center alignment</a>
             <dd>
              <p>Move all the boxes in <var>boxes</var> up by half of the height of <var>bounding box</var>.</p>
-            <dt>If the <a data-link-type="dfn" href="#webvtt-cue-line-alignment" id="ref-for-webvtt-cue-line-alignment①⓪">WebVTT cue line alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-line-end-alignment" id="ref-for-webvtt-cue-line-end-alignment②">end
+            <dt>If the <a data-link-type="dfn" href="#webvtt-cue-line-alignment" id="ref-for-webvtt-cue-line-alignment-11">WebVTT cue line alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-line-end-alignment" id="ref-for-webvtt-cue-line-end-alignment-3">end
          alignment</a>
             <dd>
              <p>Move all the boxes in <var>boxes</var> up by the height of <var>bounding box</var>.</p>
            </dl>
-          <dt>If the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction③③">WebVTT cue writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-left-writing-direction" id="ref-for-webvtt-cue-vertical-growing-left-writing-direction①①">vertical growing left</a> or <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-right-writing-direction" id="ref-for-webvtt-cue-vertical-growing-right-writing-direction①①">vertical growing right</a>
+          <dt>If the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-34">WebVTT cue writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-left-writing-direction" id="ref-for-webvtt-cue-vertical-growing-left-writing-direction-12">vertical growing left</a> or <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-right-writing-direction" id="ref-for-webvtt-cue-vertical-growing-right-writing-direction-12">vertical growing right</a>
           <dd>
            <dl class="switch">
-            <dt>If the <a data-link-type="dfn" href="#webvtt-cue-line-alignment" id="ref-for-webvtt-cue-line-alignment①①">WebVTT cue line alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-line-center-alignment" id="ref-for-webvtt-cue-line-center-alignment③">center alignment</a>
+            <dt>If the <a data-link-type="dfn" href="#webvtt-cue-line-alignment" id="ref-for-webvtt-cue-line-alignment-12">WebVTT cue line alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-line-center-alignment" id="ref-for-webvtt-cue-line-center-alignment-4">center alignment</a>
             <dd>
              <p>Move all the boxes in <var>boxes</var> left by half of the width of <var>bounding box</var>.</p>
-            <dt>If the <a data-link-type="dfn" href="#webvtt-cue-line-alignment" id="ref-for-webvtt-cue-line-alignment①②">WebVTT cue line alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-line-end-alignment" id="ref-for-webvtt-cue-line-end-alignment③">end
+            <dt>If the <a data-link-type="dfn" href="#webvtt-cue-line-alignment" id="ref-for-webvtt-cue-line-alignment-13">WebVTT cue line alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-line-end-alignment" id="ref-for-webvtt-cue-line-end-alignment-4">end
          alignment</a>
             <dd>
              <p>Move all the boxes in <var>boxes</var> left by the width of <var>bounding box</var>.</p>
@@ -4667,99 +4667,99 @@ Red or green?
     <li>
      <p><i>Done positioning</i>: Return <var>boxes</var>.</p>
    </ol>
-   <h4 class="heading settled algorithm" data-algorithm="Applying CSS properties to WebVTT Node Objects" data-level="6.1.1" id="applying-css-properties"><span class="secno">6.1.1. </span><span class="content">Applying CSS properties to <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object①⓪">WebVTT Node Objects</a></span><a class="self-link" href="#applying-css-properties"></a></h4>
-   <p>When following the <a data-link-type="dfn" href="#rules-for-updating-the-display-of-webvtt-text-tracks" id="ref-for-rules-for-updating-the-display-of-webvtt-text-tracks③">rules for updating the display of WebVTT text tracks</a>, user agents must
-set properties of <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object①①">WebVTT Node Objects</a> at the CSS user agent cascade
+   <h4 class="heading settled algorithm" data-algorithm="Applying CSS properties to WebVTT Node Objects" data-level="6.1.1" id="applying-css-properties"><span class="secno">6.1.1. </span><span class="content">Applying CSS properties to <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-11">WebVTT Node Objects</a></span><a class="self-link" href="#applying-css-properties"></a></h4>
+   <p>When following the <a data-link-type="dfn" href="#rules-for-updating-the-display-of-webvtt-text-tracks" id="ref-for-rules-for-updating-the-display-of-webvtt-text-tracks-4">rules for updating the display of WebVTT text tracks</a>, user agents must
+set properties of <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-12">WebVTT Node Objects</a> at the CSS user agent cascade
 layer as defined in this section. <a data-link-type="biblio" href="#biblio-css22">[CSS22]</a></p>
-   <p>Initialize the (root) <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects⑧">list of WebVTT Node Objects</a> with the following CSS settings:</p>
+   <p>Initialize the (root) <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-9">list of WebVTT Node Objects</a> with the following CSS settings:</p>
    <ul>
-    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-position-3/#propdef-position" id="ref-for-propdef-position">position</a> property must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-position-3/#valdef-position-absolute" id="ref-for-valdef-position-absolute">absolute</a>
-    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi" id="ref-for-propdef-unicode-bidi②">unicode-bidi</a> property must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-writing-modes-4/#valdef-unicode-bidi-plaintext" id="ref-for-valdef-unicode-bidi-plaintext③">plaintext</a>
-    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode" id="ref-for-propdef-writing-mode">writing-mode</a> property must be set to <var>writing-mode</var>
-    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-position-3/#propdef-top" id="ref-for-propdef-top">top</a> property must be set to <var>top</var>
-    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-position-3/#propdef-left" id="ref-for-propdef-left">left</a> property must be set to <var>left</var>
-    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visudet.html#propdef-width" id="ref-for-propdef-width">width</a> property must be set to <var>width</var>
-    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visudet.html#propdef-height" id="ref-for-propdef-height">height</a> property must be set to <var>height</var>
-    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-3/#propdef-overflow-wrap" id="ref-for-propdef-overflow-wrap">overflow-wrap</a> property must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-break-word" id="ref-for-valdef-overflow-wrap-break-word">break-word</a>
+    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-position-3/#propdef-position">position</a> property must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-position-3/#valdef-position-absolute">absolute</a>
+    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi">unicode-bidi</a> property must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-writing-modes-4/#valdef-unicode-bidi-plaintext">plaintext</a>
+    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">writing-mode</a> property must be set to <var>writing-mode</var>
+    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-position-3/#propdef-top">top</a> property must be set to <var>top</var>
+    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-position-3/#propdef-left">left</a> property must be set to <var>left</var>
+    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visudet.html#propdef-width">width</a> property must be set to <var>width</var>
+    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visudet.html#propdef-height">height</a> property must be set to <var>height</var>
+    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-3/#propdef-overflow-wrap">overflow-wrap</a> property must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-break-word">break-word</a>
     <li>the <a class="property" data-link-type="propdesc">text-wrap</a> property must be set to <span class="css">balance</span> <a data-link-type="biblio" href="#biblio-css-text-4">[CSS-TEXT-4]</a>
    </ul>
    <p>The variables <var>writing-mode</var>, <var>top</var>, <var>left</var>, <var>width</var>, and <var>height</var> are the values with those
-names determined by the <a data-link-type="dfn" href="#rules-for-updating-the-display-of-webvtt-text-tracks" id="ref-for-rules-for-updating-the-display-of-webvtt-text-tracks④">rules for updating the display of WebVTT text tracks</a> for the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue②④">WebVTT cue</a> from whose <a data-link-type="dfn" href="#text-track-cue-text" id="ref-for-text-track-cue-text⑤">text</a> the <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects⑨">list of WebVTT Node
+names determined by the <a data-link-type="dfn" href="#rules-for-updating-the-display-of-webvtt-text-tracks" id="ref-for-rules-for-updating-the-display-of-webvtt-text-tracks-5">rules for updating the display of WebVTT text tracks</a> for the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-25">WebVTT cue</a> from whose <a data-link-type="dfn" href="#text-track-cue-text" id="ref-for-text-track-cue-text-6">text</a> the <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-10">list of WebVTT Node
 Objects</a> was constructed.</p>
-   <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-3/#propdef-text-align" id="ref-for-propdef-text-align">text-align</a> property on the (root) <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects①⓪">list of WebVTT Node Objects</a> must be set to the
+   <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-3/#propdef-text-align">text-align</a> property on the (root) <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-11">list of WebVTT Node Objects</a> must be set to the
 value in the second cell of the row of the table below whose first cell is the value of the
-corresponding <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue" id="ref-for-text-track-cue④">cue</a>’s <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment①⑧">WebVTT cue text alignment</a>:</p>
+corresponding <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue">cue</a>’s <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment-19">WebVTT cue text alignment</a>:</p>
    <table class="complex data">
     <thead>
      <tr>
-      <th><a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment①⑨">WebVTT cue text alignment</a>
-      <th><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-3/#propdef-text-align" id="ref-for-propdef-text-align①">text-align</a> value
+      <th><a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment-20">WebVTT cue text alignment</a>
+      <th><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-3/#propdef-text-align">text-align</a> value
     <tbody>
      <tr>
-      <td><a data-link-type="dfn" href="#webvtt-cue-start-alignment" id="ref-for-webvtt-cue-start-alignment⑥">Start alignment</a>
-      <td><a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-text-3/#valdef-text-align-start" id="ref-for-valdef-text-align-start">start</a>
+      <td><a data-link-type="dfn" href="#webvtt-cue-start-alignment" id="ref-for-webvtt-cue-start-alignment-7">Start alignment</a>
+      <td><a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-text-3/#valdef-text-align-start">start</a>
      <tr>
-      <td><a data-link-type="dfn" href="#webvtt-cue-center-alignment" id="ref-for-webvtt-cue-center-alignment⑥">Center alignment</a>
-      <td><a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-text-3/#valdef-text-align-center" id="ref-for-valdef-text-align-center">center</a>
+      <td><a data-link-type="dfn" href="#webvtt-cue-center-alignment" id="ref-for-webvtt-cue-center-alignment-7">Center alignment</a>
+      <td><a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-text-3/#valdef-text-align-center">center</a>
      <tr>
-      <td><a data-link-type="dfn" href="#webvtt-cue-end-alignment" id="ref-for-webvtt-cue-end-alignment⑤">End alignment</a>
-      <td><a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-text-3/#valdef-text-align-end" id="ref-for-valdef-text-align-end">end</a>
+      <td><a data-link-type="dfn" href="#webvtt-cue-end-alignment" id="ref-for-webvtt-cue-end-alignment-6">End alignment</a>
+      <td><a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-text-3/#valdef-text-align-end">end</a>
      <tr>
-      <td><a data-link-type="dfn" href="#webvtt-cue-left-alignment" id="ref-for-webvtt-cue-left-alignment⑤">Left alignment</a>
-      <td><a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-text-3/#valdef-text-align-left" id="ref-for-valdef-text-align-left">left</a>
+      <td><a data-link-type="dfn" href="#webvtt-cue-left-alignment" id="ref-for-webvtt-cue-left-alignment-6">Left alignment</a>
+      <td><a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-text-3/#valdef-text-align-left">left</a>
      <tr>
-      <td><a data-link-type="dfn" href="#webvtt-cue-right-alignment" id="ref-for-webvtt-cue-right-alignment⑤">Right alignment</a>
-      <td><a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-text-3/#valdef-text-align-right" id="ref-for-valdef-text-align-right">right</a>
+      <td><a data-link-type="dfn" href="#webvtt-cue-right-alignment" id="ref-for-webvtt-cue-right-alignment-6">Right alignment</a>
+      <td><a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-text-3/#valdef-text-align-right">right</a>
    </table>
-   <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-fonts-3/#propdef-font" id="ref-for-propdef-font">font</a> shorthand property on the (root) <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects①①">list of WebVTT Node Objects</a> must be set to <span class="css">5vh sans-serif</span>. <a data-link-type="biblio" href="#biblio-css-values">[CSS-VALUES]</a></p>
-   <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-color-4/#propdef-color" id="ref-for-propdef-color">color</a> property on the (root) <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects①②">list of WebVTT Node Objects</a> must be set to <span class="css">rgba(255,255,255,1)</span>. <a data-link-type="biblio" href="#biblio-css3-color">[CSS3-COLOR]</a></p>
-   <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background" id="ref-for-propdef-background">background</a> shorthand property on the <a data-link-type="dfn" href="#webvtt-cue-background-box" id="ref-for-webvtt-cue-background-box">WebVTT cue background box</a> and on <a data-link-type="dfn" href="#webvtt-ruby-text-object" id="ref-for-webvtt-ruby-text-object⑥">WebVTT Ruby
+   <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-fonts-3/#propdef-font">font</a> shorthand property on the (root) <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-12">list of WebVTT Node Objects</a> must be set to <span class="css">5vh sans-serif</span>. <a data-link-type="biblio" href="#biblio-css-values">[CSS-VALUES]</a></p>
+   <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-color-4/#propdef-color">color</a> property on the (root) <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-13">list of WebVTT Node Objects</a> must be set to <span class="css">rgba(255,255,255,1)</span>. <a data-link-type="biblio" href="#biblio-css3-color">[CSS3-COLOR]</a></p>
+   <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">background</a> shorthand property on the <a data-link-type="dfn" href="#webvtt-cue-background-box" id="ref-for-webvtt-cue-background-box-1">WebVTT cue background box</a> and on <a data-link-type="dfn" href="#webvtt-ruby-text-object" id="ref-for-webvtt-ruby-text-object-7">WebVTT Ruby
 Text Objects</a> must be set to <span class="css">rgba(0,0,0,0.8)</span>. <a data-link-type="biblio" href="#biblio-css3-color">[CSS3-COLOR]</a></p>
-   <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-3/#propdef-white-space" id="ref-for-propdef-white-space">white-space</a> property on the (root) <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects①③">list of WebVTT Node Objects</a> must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-text-3/#valdef-white-space-pre-line" id="ref-for-valdef-white-space-pre-line">pre-line</a>. <a data-link-type="biblio" href="#biblio-css22">[CSS22]</a></p>
-   <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-fonts-3/#propdef-font-style" id="ref-for-propdef-font-style">font-style</a> property on <a data-link-type="dfn" href="#webvtt-italic-object" id="ref-for-webvtt-italic-object③">WebVTT Italic Objects</a> must be set
-to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-fonts-4/#valdef-font-style-italic" id="ref-for-valdef-font-style-italic">italic</a>.</p>
-   <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-fonts-3/#propdef-font-weight" id="ref-for-propdef-font-weight">font-weight</a> property on <a data-link-type="dfn" href="#webvtt-bold-object" id="ref-for-webvtt-bold-object④">WebVTT Bold Objects</a> must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-fonts-4/#valdef-font-weight-bold" id="ref-for-valdef-font-weight-bold">bold</a>.</p>
-   <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-decor-3/#propdef-text-decoration" id="ref-for-propdef-text-decoration">text-decoration</a> property on <a data-link-type="dfn" href="#webvtt-underline-object" id="ref-for-webvtt-underline-object③">WebVTT Underline Objects</a> must be set to <span class="css">underline</span>.</p>
-   <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-display-3/#propdef-display" id="ref-for-propdef-display②">display</a> property on <a data-link-type="dfn" href="#webvtt-ruby-object" id="ref-for-webvtt-ruby-object⑤">WebVTT Ruby Objects</a> must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-ruby-1/#valdef-display-ruby" id="ref-for-valdef-display-ruby">ruby</a>. <a data-link-type="biblio" href="#biblio-css3-ruby">[CSS3-RUBY]</a></p>
-   <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-display-3/#propdef-display" id="ref-for-propdef-display③">display</a> property on <a data-link-type="dfn" href="#webvtt-ruby-text-object" id="ref-for-webvtt-ruby-text-object⑦">WebVTT Ruby Text Objects</a> must be
-set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-ruby-1/#valdef-display-ruby-text" id="ref-for-valdef-display-ruby-text">ruby-text</a>. <a data-link-type="biblio" href="#biblio-css3-ruby">[CSS3-RUBY]</a></p>
-   <p>Every <a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object⑤">WebVTT region object</a> is initialized with the following CSS settings:</p>
+   <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-3/#propdef-white-space">white-space</a> property on the (root) <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-14">list of WebVTT Node Objects</a> must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-text-3/#valdef-white-space-pre-line">pre-line</a>. <a data-link-type="biblio" href="#biblio-css22">[CSS22]</a></p>
+   <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-fonts-3/#propdef-font-style">font-style</a> property on <a data-link-type="dfn" href="#webvtt-italic-object" id="ref-for-webvtt-italic-object-4">WebVTT Italic Objects</a> must be set
+to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-fonts-4/#valdef-font-style-italic">italic</a>.</p>
+   <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-fonts-3/#propdef-font-weight">font-weight</a> property on <a data-link-type="dfn" href="#webvtt-bold-object" id="ref-for-webvtt-bold-object-5">WebVTT Bold Objects</a> must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-fonts-4/#valdef-font-weight-bold">bold</a>.</p>
+   <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-decor-3/#propdef-text-decoration">text-decoration</a> property on <a data-link-type="dfn" href="#webvtt-underline-object" id="ref-for-webvtt-underline-object-4">WebVTT Underline Objects</a> must be set to <span class="css">underline</span>.</p>
+   <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-display-3/#propdef-display">display</a> property on <a data-link-type="dfn" href="#webvtt-ruby-object" id="ref-for-webvtt-ruby-object-6">WebVTT Ruby Objects</a> must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-ruby-1/#valdef-display-ruby">ruby</a>. <a data-link-type="biblio" href="#biblio-css3-ruby">[CSS3-RUBY]</a></p>
+   <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-display-3/#propdef-display">display</a> property on <a data-link-type="dfn" href="#webvtt-ruby-text-object" id="ref-for-webvtt-ruby-text-object-8">WebVTT Ruby Text Objects</a> must be
+set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-ruby-1/#valdef-display-ruby-text">ruby-text</a>. <a data-link-type="biblio" href="#biblio-css3-ruby">[CSS3-RUBY]</a></p>
+   <p>Every <a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object-6">WebVTT region object</a> is initialized with the following CSS settings:</p>
    <ul>
-    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-position-3/#propdef-position" id="ref-for-propdef-position①">position</a> property must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-position-3/#valdef-position-absolute" id="ref-for-valdef-position-absolute①">absolute</a>
-    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode" id="ref-for-propdef-writing-mode①">writing-mode</a> property must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-horizontal-tb" id="ref-for-valdef-writing-mode-horizontal-tb">horizontal-tb</a>
-    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background" id="ref-for-propdef-background①">background</a> shorthand property must be set to <span class="css">rgba(0,0,0,0.8)</span>
-    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-3/#propdef-overflow-wrap" id="ref-for-propdef-overflow-wrap①">overflow-wrap</a> property must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-break-word" id="ref-for-valdef-overflow-wrap-break-word①">break-word</a>
-    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-fonts-3/#propdef-font" id="ref-for-propdef-font①">font</a> shorthand property must be set to <span class="css">5vh sans-serif</span>
-    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-color-4/#propdef-color" id="ref-for-propdef-color①">color</a> property must be set to <span class="css">rgba(255,255,255,1)</span>
-    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow" id="ref-for-propdef-overflow">overflow</a> property must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-hidden" id="ref-for-valdef-overflow-hidden">hidden</a>
-    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visudet.html#propdef-width" id="ref-for-propdef-width①">width</a> property must be set to <var>width</var>
-    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visudet.html#propdef-min-height" id="ref-for-propdef-min-height">min-height</a> property must be set to <span class="css">0px</span>
-    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visudet.html#propdef-max-height" id="ref-for-propdef-max-height">max-height</a> property must be set to <var>height</var>
-    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-position-3/#propdef-left" id="ref-for-propdef-left①">left</a> property must be set to <var>left</var>
-    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-position-3/#propdef-top" id="ref-for-propdef-top①">top</a> property must be set to <var>top</var>
-    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-display-3/#propdef-display" id="ref-for-propdef-display④">display</a> property must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-flexbox-1/#valdef-display-inline-flex" id="ref-for-valdef-display-inline-flex">inline-flex</a>
-    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-flow" id="ref-for-propdef-flex-flow">flex-flow</a> property must be set to <span class="css">column</span>
-    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-align-3/#propdef-justify-content" id="ref-for-propdef-justify-content">justify-content</a> property must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-flexbox-1/#valdef-justify-content-flex-end" id="ref-for-valdef-justify-content-flex-end">flex-end</a>
+    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-position-3/#propdef-position">position</a> property must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-position-3/#valdef-position-absolute">absolute</a>
+    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">writing-mode</a> property must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-horizontal-tb">horizontal-tb</a>
+    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">background</a> shorthand property must be set to <span class="css">rgba(0,0,0,0.8)</span>
+    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-3/#propdef-overflow-wrap">overflow-wrap</a> property must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-break-word">break-word</a>
+    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-fonts-3/#propdef-font">font</a> shorthand property must be set to <span class="css">5vh sans-serif</span>
+    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-color-4/#propdef-color">color</a> property must be set to <span class="css">rgba(255,255,255,1)</span>
+    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">overflow</a> property must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-hidden">hidden</a>
+    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visudet.html#propdef-width">width</a> property must be set to <var>width</var>
+    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visudet.html#propdef-min-height">min-height</a> property must be set to <span class="css">0px</span>
+    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visudet.html#propdef-max-height">max-height</a> property must be set to <var>height</var>
+    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-position-3/#propdef-left">left</a> property must be set to <var>left</var>
+    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-position-3/#propdef-top">top</a> property must be set to <var>top</var>
+    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-display-3/#propdef-display">display</a> property must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-flexbox-1/#valdef-display-inline-flex">inline-flex</a>
+    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-flow">flex-flow</a> property must be set to <span class="css">column</span>
+    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-align-3/#propdef-justify-content">justify-content</a> property must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-flexbox-1/#valdef-justify-content-flex-end">flex-end</a>
    </ul>
    <p>The variables <var>width</var>, <var>height</var>, <var>top</var>, and <var>left</var> are the values with those names determined by
-the <a data-link-type="dfn" href="#rules-for-updating-the-display-of-webvtt-text-tracks" id="ref-for-rules-for-updating-the-display-of-webvtt-text-tracks⑤">rules for updating the display of WebVTT text tracks</a> for the <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region①④">WebVTT region</a> from
-which the <a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object⑥">WebVTT region object</a> was constructed.</p>
-   <p>The children of every <a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object⑦">WebVTT region object</a> are further initialized with these CSS
+the <a data-link-type="dfn" href="#rules-for-updating-the-display-of-webvtt-text-tracks" id="ref-for-rules-for-updating-the-display-of-webvtt-text-tracks-6">rules for updating the display of WebVTT text tracks</a> for the <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region-15">WebVTT region</a> from
+which the <a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object-7">WebVTT region object</a> was constructed.</p>
+   <p>The children of every <a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object-8">WebVTT region object</a> are further initialized with these CSS
 settings:</p>
    <ul>
-    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-position-3/#propdef-position" id="ref-for-propdef-position②">position</a> property must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-position-3/#valdef-position-relative" id="ref-for-valdef-position-relative">relative</a>
-    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi" id="ref-for-propdef-unicode-bidi③">unicode-bidi</a> property must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-writing-modes-4/#valdef-unicode-bidi-plaintext" id="ref-for-valdef-unicode-bidi-plaintext④">plaintext</a>
-    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visudet.html#propdef-width" id="ref-for-propdef-width②">width</a> property must be set to <span class="css">auto</span>
-    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visudet.html#propdef-height" id="ref-for-propdef-height①">height</a> property must be set to <var>height</var>
-    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-position-3/#propdef-left" id="ref-for-propdef-left②">left</a> property must be set to <var>left</var>
-    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-3/#propdef-text-align" id="ref-for-propdef-text-align②">text-align</a> property must be set as described for the root <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects①④">List of WebVTT Node
+    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-position-3/#propdef-position">position</a> property must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-position-3/#valdef-position-relative">relative</a>
+    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi">unicode-bidi</a> property must be set to <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-writing-modes-4/#valdef-unicode-bidi-plaintext">plaintext</a>
+    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visudet.html#propdef-width">width</a> property must be set to <span class="css">auto</span>
+    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visudet.html#propdef-height">height</a> property must be set to <var>height</var>
+    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-position-3/#propdef-left">left</a> property must be set to <var>left</var>
+    <li>the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-3/#propdef-text-align">text-align</a> property must be set as described for the root <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-15">List of WebVTT Node
  Objects</a> not part of a region
    </ul>
    <p>All other non-inherited properties must be set to their initial values; inherited properties on
-the root <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects①⑤">list of WebVTT Node Objects</a> must inherit their values from the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element" id="ref-for-media-element①①">media element</a> for which the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue②⑤">WebVTT cue</a> is being rendered, if any. If there is no <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element" id="ref-for-media-element①②">media element</a> (i.e.
-if the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track" id="ref-for-text-track①③">text track</a> is being rendered for another media playback mechanism), then inherited
-properties on the root <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects①⑥">list of WebVTT Node Objects</a> and the <a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object⑧">WebVTT region objects</a> must take their initial values.</p>
-   <p>If there are style sheets that apply to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element" id="ref-for-media-element①③">media element</a> or other playback mechanism,
+the root <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-16">list of WebVTT Node Objects</a> must inherit their values from the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media element</a> for which the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-26">WebVTT cue</a> is being rendered, if any. If there is no <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media element</a> (i.e.
+if the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track">text track</a> is being rendered for another media playback mechanism), then inherited
+properties on the root <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-17">list of WebVTT Node Objects</a> and the <a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object-9">WebVTT region objects</a> must take their initial values.</p>
+   <p>If there are style sheets that apply to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media element</a> or other playback mechanism,
 then they must be interpreted as defined in the next section.</p>
    <h2 class="heading settled" data-level="7" id="css-extensions"><span class="secno">7. </span><span class="content">CSS extensions</span><a class="self-link" href="#css-extensions"></a></h2>
    <p class="note" role="note">This section specifies some CSS pseudo-elements and pseudo-classes and how they
@@ -4773,8 +4773,8 @@ given selector.</p>
    <p>The <span class="css">::cue-region(<var>selector</var>)</span> pseudo-element represents a region or element inside a region
 that match the given selector.</p>
    <p class="note" role="note">Similarly to all other pseudo-elements, these pseudo-elements are not directly
-present in the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/media.html#video" id="ref-for-video⑥">video</a></code> element’s document tree.</p>
-   <p>The <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#past-pseudo" id="ref-for-past-pseudo">:past</a> and <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#future-pseudo" id="ref-for-future-pseudo">:future</a> pseudo-classes can be used in <span class="css">::cue(<var>selector</var>)</span> to match <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object⑨">WebVTT Internal Node Objects</a> based on the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#current-playback-position" id="ref-for-current-playback-position①">current playback position</a>.</p>
+present in the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/media.html#video">video</a></code> element’s document tree.</p>
+   <p>The <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#past-pseudo">:past</a> and <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#future-pseudo">:future</a> pseudo-classes can be used in <span class="css">::cue(<var>selector</var>)</span> to match <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-10">WebVTT Internal Node Objects</a> based on the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#current-playback-position">current playback position</a>.</p>
    <div class="example" id="example-cue-selector">
     <a class="self-link" href="#example-cue-selector"></a> 
     <p>The following table shows examples of what can be selected with a given selector, together with
@@ -4792,7 +4792,7 @@ present in the <code><a data-link-type="element" href="https://html.spec.whatwg.
   color: yellow;
 }</pre>
        <td class="long">
-        <p>Any <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects①⑦">list of WebVTT Node Objects</a>.</p>
+        <p>Any <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-18">list of WebVTT Node Objects</a>.</p>
 <pre>WEBVTT
 
 00:00:00.000 --> 00:00:08.000
@@ -4803,12 +4803,12 @@ Also yellow!
 </pre>
       <tr>
        <td class="long">
-        <p><a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#id-selector" id="ref-for-id-selector">ID selector</a> in <span class="css">::cue()</span></p>
+        <p><a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#id-selector">ID selector</a> in <span class="css">::cue()</span></p>
 <pre>video::cue(#cue1) {
   color: yellow;
 }</pre>
        <td class="long">
-        <p>Any <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects①⑧">list of WebVTT Node Objects</a> with the cue’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-identifier" id="ref-for-text-track-cue-identifier①">text track cue identifier</a> matching the given ID.</p>
+        <p>Any <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-19">list of WebVTT Node Objects</a> with the cue’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-identifier">text track cue identifier</a> matching the given ID.</p>
 <pre>WEBVTT
 
 cue1
@@ -4817,7 +4817,7 @@ Yellow!
 </pre>
       <tr>
        <td class="long">
-        <p><a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#type-selector" id="ref-for-type-selector">Type selector</a> in <span class="css">::cue()</span></p>
+        <p><a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#type-selector">Type selector</a> in <span class="css">::cue()</span></p>
 <pre>video::cue(c),
 video::cue(i),
 video::cue(b),
@@ -4830,7 +4830,7 @@ video::cue(lang) {
 }
 </pre>
        <td class="long">
-        <p><a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object①⓪">WebVTT Internal Node Objects</a> (except the root <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects①⑨">list of WebVTT Node Objects</a>)
+        <p><a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-11">WebVTT Internal Node Objects</a> (except the root <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-20">list of WebVTT Node Objects</a>)
      with the given name.</p>
 <pre>WEBVTT
 
@@ -4846,13 +4846,13 @@ video::cue(lang) {
 </pre>
       <tr>
        <td class="long">
-        <p><a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#class-selector" id="ref-for-class-selector">Class selector</a> in <span class="css">::cue()</span></p>
+        <p><a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#class-selector">Class selector</a> in <span class="css">::cue()</span></p>
 <pre>video::cue(.loud) {
   color: yellow;
 }</pre>
        <td class="long">
-        <p><a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object①①">WebVTT Internal Node Objects</a> (except the root <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects②⓪">list of WebVTT Node Objects</a>)
-     with the given <a data-link-type="dfn" href="#webvtt-node-objects-applicable-classes" id="ref-for-webvtt-node-objects-applicable-classes③">applicable classes</a>.</p>
+        <p><a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-12">WebVTT Internal Node Objects</a> (except the root <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-21">list of WebVTT Node Objects</a>)
+     with the given <a data-link-type="dfn" href="#webvtt-node-objects-applicable-classes" id="ref-for-webvtt-node-objects-applicable-classes-4">applicable classes</a>.</p>
 <pre>WEBVTT
 
 00:00:00.000 --> 00:00:08.000
@@ -4867,7 +4867,7 @@ video::cue(lang) {
 </pre>
       <tr>
        <td class="long">
-        <p><a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#attribute-selector" id="ref-for-attribute-selector">Attribute selector</a> in <span class="css">::cue()</span></p>
+        <p><a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#attribute-selector">Attribute selector</a> in <span class="css">::cue()</span></p>
 <pre>video::cue([lang="en-US"]) {
   color: yellow;
 }
@@ -4879,8 +4879,8 @@ video::cue(v[voice="Kathryn"] {
 }
 </pre>
        <td class="long">
-        <p>For "lang", the root <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects②①">list of WebVTT Node Objects</a> or <a data-link-type="dfn" href="#webvtt-language-object" id="ref-for-webvtt-language-object④">WebVTT Language Object</a> with the given <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language⑤">applicable language</a>; for
-     "voice", the <a data-link-type="dfn" href="#webvtt-voice-object" id="ref-for-webvtt-voice-object⑤">WebVTT Voice Object</a> with the given voice.</p>
+        <p>For "lang", the root <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-22">list of WebVTT Node Objects</a> or <a data-link-type="dfn" href="#webvtt-language-object" id="ref-for-webvtt-language-object-5">WebVTT Language Object</a> with the given <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language-6">applicable language</a>; for
+     "voice", the <a data-link-type="dfn" href="#webvtt-voice-object" id="ref-for-webvtt-voice-object-6">WebVTT Voice Object</a> with the given voice.</p>
 <pre>WEBVTT
 
 00:00:00.000 --> 00:00:08.000
@@ -4892,8 +4892,8 @@ Yellow!
 00:00:16.000 --> 00:00:24.000
 &lt;v Kathryn>I like lime.&lt;/v>
 </pre>
-        <p>The <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language⑥">applicable language</a> for the <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects②②">list
-     of WebVTT Node Objects</a> can be set by the <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/media.html#attr-track-srclang" id="ref-for-attr-track-srclang">srclang</a></code> attribute in HTML.</p>
+        <p>The <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language-7">applicable language</a> for the <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-23">list
+     of WebVTT Node Objects</a> can be set by the <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/media.html#attr-track-srclang">srclang</a></code> attribute in HTML.</p>
 <pre>&lt;video ...>
  &lt;track src="example-attr.vtt"
         <mark>srclang="en-US"</mark> default>
@@ -4901,7 +4901,7 @@ Yellow!
 </pre>
       <tr>
        <td class="long">
-        <p><a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#lang-pseudo" id="ref-for-lang-pseudo">:lang()</a> pseudo-class in <span class="css">::cue()</span></p>
+        <p><a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#lang-pseudo">:lang()</a> pseudo-class in <span class="css">::cue()</span></p>
 <pre>video::cue(:lang(en)) {
   color: yellow;
 }
@@ -4910,7 +4910,7 @@ video::cue(:lang(en-GB)) {
 }
 </pre>
        <td class="long">
-        <p><a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object①②">WebVTT Internal Node Objects</a> with an <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language⑦">applicable language</a> matching the given language range.</p>
+        <p><a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-13">WebVTT Internal Node Objects</a> with an <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language-8">applicable language</a> matching the given language range.</p>
 <pre>WEBVTT
 
 00:00:00.000 --> 00:00:08.000
@@ -4919,12 +4919,12 @@ Yellow!
 00:00:08.000 --> 00:00:16.000
 &lt;lang en-GB>Cyan!&lt;/lang>
 </pre>
-        <p>As above, the <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language⑧">applicable language</a> for
-     the <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects②③">list of WebVTT Node Objects</a> can be set by the <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/media.html#attr-track-srclang" id="ref-for-attr-track-srclang①">srclang</a></code> attribute in
+        <p>As above, the <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language-9">applicable language</a> for
+     the <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-24">list of WebVTT Node Objects</a> can be set by the <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/media.html#attr-track-srclang">srclang</a></code> attribute in
      HTML.</p>
       <tr>
        <td class="long">
-        <p><a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#past-pseudo" id="ref-for-past-pseudo①">:past</a> and <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#future-pseudo" id="ref-for-future-pseudo①">:future</a> pseudo-classes in <span class="css">::cue()</span></p>
+        <p><a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#past-pseudo">:past</a> and <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#future-pseudo">:future</a> pseudo-classes in <span class="css">::cue()</span></p>
 <pre>video::cue(:past) {
   color: yellow;
 }
@@ -4933,8 +4933,8 @@ video::cue(:future) {
 }
 </pre>
        <td class="long">
-        <p>In cues that have <a data-link-type="dfn" href="#webvtt-timestamp-object" id="ref-for-webvtt-timestamp-object④">WebVTT Timestamp Objects</a>, <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object①③">WebVTT Internal Node Objects</a>,
-     depending on the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#current-playback-position" id="ref-for-current-playback-position②">current playback position</a>.</p>
+        <p>In cues that have <a data-link-type="dfn" href="#webvtt-timestamp-object" id="ref-for-webvtt-timestamp-object-5">WebVTT Timestamp Objects</a>, <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-14">WebVTT Internal Node Objects</a>,
+     depending on the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#current-playback-position">current playback position</a>.</p>
 <pre>WEBVTT
 
 00:00:00.000 --> 00:00:08.000
@@ -4957,7 +4957,7 @@ No match &lt;00:00:12.000> (no elements)
   color: yellow;
 }</pre>
        <td class="long">
-        <p>Any region (list of <a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object⑨">WebVTT region objects</a>).</p>
+        <p>Any region (list of <a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object-10">WebVTT region objects</a>).</p>
 <pre>WEBVTT
 
 REGION
@@ -4973,12 +4973,12 @@ Yellow!
 </pre>
       <tr>
        <td class="long">
-        <p><a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#id-selector" id="ref-for-id-selector①">ID selector</a> in <span class="css">::cue-region()</span></p>
+        <p><a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#id-selector">ID selector</a> in <span class="css">::cue-region()</span></p>
 <pre>video::cue-region(#scroll) {
   color: cyan;
 }</pre>
        <td class="long">
-        <p>Any region (list of <a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object①⓪">WebVTT region objects</a>) with a <a data-link-type="dfn" href="#webvtt-region-identifier" id="ref-for-webvtt-region-identifier④">WebVTT region identifier</a> matching the given ID.</p>
+        <p>Any region (list of <a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object-11">WebVTT region objects</a>) with a <a data-link-type="dfn" href="#webvtt-region-identifier" id="ref-for-webvtt-region-identifier-5">WebVTT region identifier</a> matching the given ID.</p>
 <pre>WEBVTT
 
 REGION
@@ -5006,51 +5006,51 @@ Over here it’s Cyan!
     </table>
    </div>
    <h3 class="heading settled" data-level="7.2" id="css-extensions-processing-model"><span class="secno">7.2. </span><span class="content">Processing model</span><a class="self-link" href="#css-extensions-processing-model"></a></h3>
-   <p>When a user agent is rendering one or more <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue②⑥">WebVTT cues</a> according to the <a data-link-type="dfn" href="#rules-for-updating-the-display-of-webvtt-text-tracks" id="ref-for-rules-for-updating-the-display-of-webvtt-text-tracks⑥">rules for updating the display of WebVTT text tracks</a>, <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object①②">WebVTT Node
-Objects</a> in the <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects②④">list of WebVTT Node Objects</a> used in the rendering can be matched by
-certain pseudo-selectors as defined below. These selectors can begin or stop matching individual <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object①③">WebVTT Node Objects</a> while a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue" id="ref-for-text-track-cue⑤">cue</a> is being
-rendered, even in between applications of the <a data-link-type="dfn" href="#rules-for-updating-the-display-of-webvtt-text-tracks" id="ref-for-rules-for-updating-the-display-of-webvtt-text-tracks⑦">rules for updating the display of WebVTT text
+   <p>When a user agent is rendering one or more <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-27">WebVTT cues</a> according to the <a data-link-type="dfn" href="#rules-for-updating-the-display-of-webvtt-text-tracks" id="ref-for-rules-for-updating-the-display-of-webvtt-text-tracks-7">rules for updating the display of WebVTT text tracks</a>, <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-13">WebVTT Node
+Objects</a> in the <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-25">list of WebVTT Node Objects</a> used in the rendering can be matched by
+certain pseudo-selectors as defined below. These selectors can begin or stop matching individual <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-14">WebVTT Node Objects</a> while a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue">cue</a> is being
+rendered, even in between applications of the <a data-link-type="dfn" href="#rules-for-updating-the-display-of-webvtt-text-tracks" id="ref-for-rules-for-updating-the-display-of-webvtt-text-tracks-8">rules for updating the display of WebVTT text
 tracks</a> (which are only run when the set of active cues changes). User agents that support the
-pseudo-element described below must dynamically update renderings accordingly. When either <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-3/#propdef-white-space" id="ref-for-propdef-white-space①">white-space</a> or one of the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-fonts-3/#propdef-font" id="ref-for-propdef-font②">font</a> shorthand (including <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visudet.html#propdef-line-height" id="ref-for-propdef-line-height">line-height</a>) changes value, then the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue②⑦">WebVTT cue</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-display-state" id="ref-for-text-track-cue-display-state④">text track cue display state</a> must
-be emptied and the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track" id="ref-for-text-track①④">text track</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#rules-for-updating-the-text-track-rendering" id="ref-for-rules-for-updating-the-text-track-rendering②">rules for updating the text track rendering</a> must be
+pseudo-element described below must dynamically update renderings accordingly. When either <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-3/#propdef-white-space">white-space</a> or one of the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-fonts-3/#propdef-font">font</a> shorthand (including <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visudet.html#propdef-line-height">line-height</a>) changes value, then the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-28">WebVTT cue</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-display-state">text track cue display state</a> must
+be emptied and the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track">text track</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#rules-for-updating-the-text-track-rendering">rules for updating the text track rendering</a> must be
 immediately rerun.</p>
    <p>Pseudo-elements apply to elements that are matched by selectors. For the purpose of this section,
 that element is the <i>matched element</i>. The pseudo-elements defined in the following sections
-affect the styling of parts of <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue②⑧">WebVTT cues</a> that are being rendered for the <i>matched element</i>.</p>
-   <p class="note" role="note">If the <i>matched element</i> is not a <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/media.html#video" id="ref-for-video⑦">video</a> element, the
+affect the styling of parts of <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-29">WebVTT cues</a> that are being rendered for the <i>matched element</i>.</p>
+   <p class="note" role="note">If the <i>matched element</i> is not a <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/media.html#video">video</a> element, the
 pseudo-elements defined below won’t have any effect according to this specification.</p>
-   <p>A CSS user agent that implements the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track" id="ref-for-text-track①⑤">text tracks</a> model must implement the <span class="css">::cue</span>, <span class="css">::cue(<var>selector</var>)</span>, <span class="css">::cue-region</span> and <span class="css">::cue-region(<var>selector</var>)</span> pseudo-elements, and the <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#past-pseudo" id="ref-for-past-pseudo②">:past</a> and <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#future-pseudo" id="ref-for-future-pseudo②">:future</a> pseudo-classes.</p>
+   <p>A CSS user agent that implements the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track">text tracks</a> model must implement the <span class="css">::cue</span>, <span class="css">::cue(<var>selector</var>)</span>, <span class="css">::cue-region</span> and <span class="css">::cue-region(<var>selector</var>)</span> pseudo-elements, and the <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#past-pseudo">:past</a> and <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#future-pseudo">:future</a> pseudo-classes.</p>
    <h4 class="heading settled" data-level="7.2.1" id="the-cue-pseudo-element"><span class="secno">7.2.1. </span><span class="content">The <span class="css">::cue</span> pseudo-element</span><a class="self-link" href="#the-cue-pseudo-element"></a></h4>
-   <p>The <dfn data-dfn-type="dfn" data-noexport="" id="cue">::cue<a class="self-link" href="#cue"></a></dfn> pseudo-element (with no argument) matches any <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects②⑤">list of WebVTT Node
+   <p>The <dfn data-dfn-type="dfn" data-noexport="" id="cue">::cue<a class="self-link" href="#cue"></a></dfn> pseudo-element (with no argument) matches any <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-26">list of WebVTT Node
 Objects</a> constructed for the <i>matched element</i>, with the exception that the properties
-corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background" id="ref-for-propdef-background②">background</a> shorthand must be applied to the <a data-link-type="dfn" href="#webvtt-cue-background-box" id="ref-for-webvtt-cue-background-box①">WebVTT cue background box</a> rather than the <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects②⑥">list of WebVTT Node Objects</a>.</p>
+corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">background</a> shorthand must be applied to the <a data-link-type="dfn" href="#webvtt-cue-background-box" id="ref-for-webvtt-cue-background-box-2">WebVTT cue background box</a> rather than the <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-27">list of WebVTT Node Objects</a>.</p>
    <p>The following properties apply to the <span class="css">::cue</span> pseudo-element with no argument; other properties
 set on the pseudo-element must be ignored:</p>
    <ul class="brief">
-    <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-color-4/#propdef-color" id="ref-for-propdef-color②">color</a>
-    <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-color-4/#propdef-opacity" id="ref-for-propdef-opacity">opacity</a>
-    <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visufx.html#propdef-visibility" id="ref-for-propdef-visibility">visibility</a>
-    <li>the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-decor-3/#propdef-text-decoration" id="ref-for-propdef-text-decoration①">text-decoration</a> shorthand
-    <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-decor-3/#propdef-text-shadow" id="ref-for-propdef-text-shadow">text-shadow</a>
-    <li>the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background" id="ref-for-propdef-background③">background</a> shorthand
-    <li>the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-ui-3/#propdef-outline" id="ref-for-propdef-outline">outline</a> shorthand
-    <li>the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-fonts-3/#propdef-font" id="ref-for-propdef-font③">font</a> shorthand, including <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visudet.html#propdef-line-height" id="ref-for-propdef-line-height①">line-height</a>
-    <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-3/#propdef-white-space" id="ref-for-propdef-white-space②">white-space</a>
-    <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-writing-modes-4/#propdef-text-combine-upright" id="ref-for-propdef-text-combine-upright">text-combine-upright</a>
-    <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-ruby-1/#propdef-ruby-position" id="ref-for-propdef-ruby-position">ruby-position</a>
+    <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-color-4/#propdef-color">color</a>
+    <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-color-4/#propdef-opacity">opacity</a>
+    <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visufx.html#propdef-visibility">visibility</a>
+    <li>the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-decor-3/#propdef-text-decoration">text-decoration</a> shorthand
+    <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-decor-3/#propdef-text-shadow">text-shadow</a>
+    <li>the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">background</a> shorthand
+    <li>the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-ui-4/#propdef-outline">outline</a> shorthand
+    <li>the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-fonts-3/#propdef-font">font</a> shorthand, including <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visudet.html#propdef-line-height">line-height</a>
+    <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-3/#propdef-white-space">white-space</a>
+    <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-writing-modes-4/#propdef-text-combine-upright">text-combine-upright</a>
+    <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-ruby-1/#propdef-ruby-position">ruby-position</a>
    </ul>
    <p>The <dfn data-dfn-type="dfn" data-noexport="" id="cue-selector">::cue(<var>selector</var>)<a class="self-link" href="#cue-selector"></a></dfn> pseudo-element with an argument must have an argument that
-consists of a CSS selector <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a>. It matches any <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object①④">WebVTT Internal Node Object</a> constructed for the <i>matched element</i> that also matches the given CSS selector, with the nodes
+consists of a CSS selector <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a>. It matches any <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-15">WebVTT Internal Node Object</a> constructed for the <i>matched element</i> that also matches the given CSS selector, with the nodes
 being treated as follows:</p>
    <ul>
     <li>
-     <p>The <i>document tree</i> against which the selectors are matched is the tree of <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object①④">WebVTT Node Objects</a> rooted at the <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects②⑦">list of WebVTT Node Objects</a> for the cue.</p>
+     <p>The <i>document tree</i> against which the selectors are matched is the tree of <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-15">WebVTT Node Objects</a> rooted at the <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-28">list of WebVTT Node Objects</a> for the cue.</p>
     <li>
-     <p><a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object①⑤">WebVTT Internal Node Objects</a> are elements in the
+     <p><a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-16">WebVTT Internal Node Objects</a> are elements in the
  tree.</p>
-    <li><a data-link-type="dfn" href="#webvtt-leaf-node-object" id="ref-for-webvtt-leaf-node-object②">WebVTT Leaf Node Objects</a> cannot be matched.
+    <li><a data-link-type="dfn" href="#webvtt-leaf-node-object" id="ref-for-webvtt-leaf-node-object-3">WebVTT Leaf Node Objects</a> cannot be matched.
     <li>
-     <p>For the purposes of element type selectors, the names of <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object①⑥">WebVTT Internal Node Objects</a> are as given by the following table, where objects having
+     <p>For the purposes of element type selectors, the names of <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-17">WebVTT Internal Node Objects</a> are as given by the following table, where objects having
   the concrete class given in a cell in the first column have the name given by the second column of
   the same row:</p>
      <table class="complex data">
@@ -5060,461 +5060,461 @@ being treated as follows:</p>
         <th>Name
       <tbody>
        <tr>
-        <td><a data-link-type="dfn" href="#webvtt-class-object" id="ref-for-webvtt-class-object③">WebVTT Class Objects</a>
+        <td><a data-link-type="dfn" href="#webvtt-class-object" id="ref-for-webvtt-class-object-4">WebVTT Class Objects</a>
         <td><code>c</code>
        <tr>
-        <td><a data-link-type="dfn" href="#webvtt-italic-object" id="ref-for-webvtt-italic-object④">WebVTT Italic Objects</a>
+        <td><a data-link-type="dfn" href="#webvtt-italic-object" id="ref-for-webvtt-italic-object-5">WebVTT Italic Objects</a>
         <td><code>i</code>
        <tr>
-        <td><a data-link-type="dfn" href="#webvtt-bold-object" id="ref-for-webvtt-bold-object⑤">WebVTT Bold Objects</a>
+        <td><a data-link-type="dfn" href="#webvtt-bold-object" id="ref-for-webvtt-bold-object-6">WebVTT Bold Objects</a>
         <td><code>b</code>
        <tr>
-        <td><a data-link-type="dfn" href="#webvtt-underline-object" id="ref-for-webvtt-underline-object④">WebVTT Underline Objects</a>
+        <td><a data-link-type="dfn" href="#webvtt-underline-object" id="ref-for-webvtt-underline-object-5">WebVTT Underline Objects</a>
         <td><code>u</code>
        <tr>
-        <td><a data-link-type="dfn" href="#webvtt-ruby-object" id="ref-for-webvtt-ruby-object⑥">WebVTT Ruby Objects</a>
+        <td><a data-link-type="dfn" href="#webvtt-ruby-object" id="ref-for-webvtt-ruby-object-7">WebVTT Ruby Objects</a>
         <td><code>ruby</code>
        <tr>
-        <td><a data-link-type="dfn" href="#webvtt-ruby-text-object" id="ref-for-webvtt-ruby-text-object⑧">WebVTT Ruby Text Objects</a>
+        <td><a data-link-type="dfn" href="#webvtt-ruby-text-object" id="ref-for-webvtt-ruby-text-object-9">WebVTT Ruby Text Objects</a>
         <td><code>rt</code>
        <tr>
-        <td><a data-link-type="dfn" href="#webvtt-voice-object" id="ref-for-webvtt-voice-object⑥">WebVTT Voice Objects</a>
+        <td><a data-link-type="dfn" href="#webvtt-voice-object" id="ref-for-webvtt-voice-object-7">WebVTT Voice Objects</a>
         <td><code>v</code>
        <tr>
-        <td><a data-link-type="dfn" href="#webvtt-language-object" id="ref-for-webvtt-language-object⑤">WebVTT Language Objects</a>
+        <td><a data-link-type="dfn" href="#webvtt-language-object" id="ref-for-webvtt-language-object-6">WebVTT Language Objects</a>
         <td><code>lang</code>
        <tr>
-        <td>Other elements (specifically, <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects②⑧">lists of WebVTT Node
+        <td>Other elements (specifically, <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-29">lists of WebVTT Node
      Objects</a>)
         <td>No explicit name.
      </table>
     <li>
-     <p>For the purposes of element type and universal selectors, <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object①⑦">WebVTT Internal Node Objects</a> are considered as being in the namespace expressed as the
+     <p>For the purposes of element type and universal selectors, <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-18">WebVTT Internal Node Objects</a> are considered as being in the namespace expressed as the
  empty string.</p>
     <li>
-     <p>For the purposes of attribute selector matching, <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object①⑧">WebVTT
- Internal Node Objects</a> have no attributes, except for <a data-link-type="dfn" href="#webvtt-voice-object" id="ref-for-webvtt-voice-object⑦">WebVTT Voice
+     <p>For the purposes of attribute selector matching, <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-19">WebVTT
+ Internal Node Objects</a> have no attributes, except for <a data-link-type="dfn" href="#webvtt-voice-object" id="ref-for-webvtt-voice-object-8">WebVTT Voice
  Objects</a>, which have a single attribute named "<code>voice</code>" whose value is the value of
- the <a data-link-type="dfn" href="#webvtt-voice-object" id="ref-for-webvtt-voice-object⑧">WebVTT Voice Object</a>, <a data-link-type="dfn" href="#webvtt-language-object" id="ref-for-webvtt-language-object⑥">WebVTT Language Objects</a>, which
- have a single attribute named "<code>lang</code>" whose value is the object’s <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language⑨">applicable language</a>, and <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects②⑨">lists of WebVTT Node Objects</a> that have a non-empty <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language①⓪">applicable language</a>, which have a single attribute named
- "<code>lang</code>" whose value is the object’s <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language①①">applicable language</a>.</p>
+ the <a data-link-type="dfn" href="#webvtt-voice-object" id="ref-for-webvtt-voice-object-9">WebVTT Voice Object</a>, <a data-link-type="dfn" href="#webvtt-language-object" id="ref-for-webvtt-language-object-7">WebVTT Language Objects</a>, which
+ have a single attribute named "<code>lang</code>" whose value is the object’s <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language-10">applicable language</a>, and <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-30">lists of WebVTT Node Objects</a> that have a non-empty <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language-11">applicable language</a>, which have a single attribute named
+ "<code>lang</code>" whose value is the object’s <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language-12">applicable language</a>.</p>
     <li>
-     <p>For the purposes of class selector matching, <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object①⑨">WebVTT
- Internal Node Objects</a> have the classes described as the <a data-link-type="dfn" href="#webvtt-node-objects-applicable-classes" id="ref-for-webvtt-node-objects-applicable-classes④">WebVTT Node Object’s applicable
+     <p>For the purposes of class selector matching, <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-20">WebVTT
+ Internal Node Objects</a> have the classes described as the <a data-link-type="dfn" href="#webvtt-node-objects-applicable-classes" id="ref-for-webvtt-node-objects-applicable-classes-5">WebVTT Node Object’s applicable
  classes</a>.</p>
     <li>
-     <p>For the purposes of the <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#lang-pseudo" id="ref-for-lang-pseudo①">:lang()</a> pseudo-class, <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object②⓪">WebVTT
- Internal Node Objects</a> have the language described as the <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language①②">WebVTT Node Object’s applicable
+     <p>For the purposes of the <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#lang-pseudo">:lang()</a> pseudo-class, <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-21">WebVTT
+ Internal Node Objects</a> have the language described as the <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language-13">WebVTT Node Object’s applicable
  language</a>.</p>
     <li>
-     <p>For the purposes of ID selector matching, <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects③⓪">lists of
- WebVTT Node Objects</a> have the ID given by the cue’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-identifier" id="ref-for-text-track-cue-identifier②">text track cue identifier</a>, if
+     <p>For the purposes of ID selector matching, <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-31">lists of
+ WebVTT Node Objects</a> have the ID given by the cue’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-identifier">text track cue identifier</a>, if
  any.</p>
    </ul>
    <p>The following properties apply to the <span class="css">::cue()</span> pseudo-element with an argument:</p>
    <ul class="brief">
-    <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-color-4/#propdef-color" id="ref-for-propdef-color③">color</a>
-    <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-color-4/#propdef-opacity" id="ref-for-propdef-opacity①">opacity</a>
-    <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visufx.html#propdef-visibility" id="ref-for-propdef-visibility①">visibility</a>
-    <li>the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-decor-3/#propdef-text-decoration" id="ref-for-propdef-text-decoration②">text-decoration</a> shorthand
-    <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-decor-3/#propdef-text-shadow" id="ref-for-propdef-text-shadow①">text-shadow</a>
-    <li>the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background" id="ref-for-propdef-background④">background</a> shorthand
-    <li>the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-ui-3/#propdef-outline" id="ref-for-propdef-outline①">outline</a> shorthand
+    <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-color-4/#propdef-color">color</a>
+    <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-color-4/#propdef-opacity">opacity</a>
+    <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visufx.html#propdef-visibility">visibility</a>
+    <li>the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-decor-3/#propdef-text-decoration">text-decoration</a> shorthand
+    <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-decor-3/#propdef-text-shadow">text-shadow</a>
+    <li>the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">background</a> shorthand
+    <li>the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-ui-4/#propdef-outline">outline</a> shorthand
     <li>properties relating to the transition and animation features
    </ul>
    <p>In addition, the following properties apply to the <span class="css">::cue()</span> pseudo-element with an argument
-when the selector does not contain the <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#past-pseudo" id="ref-for-past-pseudo③">:past</a> and <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#future-pseudo" id="ref-for-future-pseudo③">:future</a> pseudo-classes:</p>
+when the selector does not contain the <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#past-pseudo">:past</a> and <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#future-pseudo">:future</a> pseudo-classes:</p>
    <ul class="brief">
-    <li>the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-fonts-3/#propdef-font" id="ref-for-propdef-font④">font</a> shorthand, including <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visudet.html#propdef-line-height" id="ref-for-propdef-line-height②">line-height</a>
-    <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-3/#propdef-white-space" id="ref-for-propdef-white-space③">white-space</a>
-    <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-writing-modes-4/#propdef-text-combine-upright" id="ref-for-propdef-text-combine-upright①">text-combine-upright</a>
-    <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-ruby-1/#propdef-ruby-position" id="ref-for-propdef-ruby-position①">ruby-position</a>
+    <li>the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-fonts-3/#propdef-font">font</a> shorthand, including <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visudet.html#propdef-line-height">line-height</a>
+    <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-3/#propdef-white-space">white-space</a>
+    <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-writing-modes-4/#propdef-text-combine-upright">text-combine-upright</a>
+    <li><a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-ruby-1/#propdef-ruby-position">ruby-position</a>
    </ul>
    <p>Properties that do not apply must be ignored.</p>
-   <p>As a special exception, the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background" id="ref-for-propdef-background⑤">background</a> shorthand, when they
-would have been applied to the <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects③①">list of WebVTT Node Objects</a>, must instead be applied to the <a data-link-type="dfn" href="#webvtt-cue-background-box" id="ref-for-webvtt-cue-background-box②">WebVTT cue background box</a>.</p>
-   <h4 class="heading settled" data-level="7.2.2" id="the-past-and-future-pseudo-classes"><span class="secno">7.2.2. </span><span class="content">The <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#past-pseudo" id="ref-for-past-pseudo④">:past</a> and <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#future-pseudo" id="ref-for-future-pseudo④">:future</a> pseudo-classes</span><a class="self-link" href="#the-past-and-future-pseudo-classes"></a></h4>
-   <p>The <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#past-pseudo" id="ref-for-past-pseudo⑤">:past</a> and <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#future-pseudo" id="ref-for-future-pseudo⑤">:future</a> pseudo-classes sometimes match <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object①⑤">WebVTT
+   <p>As a special exception, the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">background</a> shorthand, when they
+would have been applied to the <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-32">list of WebVTT Node Objects</a>, must instead be applied to the <a data-link-type="dfn" href="#webvtt-cue-background-box" id="ref-for-webvtt-cue-background-box-3">WebVTT cue background box</a>.</p>
+   <h4 class="heading settled" data-level="7.2.2" id="the-past-and-future-pseudo-classes"><span class="secno">7.2.2. </span><span class="content">The <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#past-pseudo">:past</a> and <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#future-pseudo">:future</a> pseudo-classes</span><a class="self-link" href="#the-past-and-future-pseudo-classes"></a></h4>
+   <p>The <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#past-pseudo">:past</a> and <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-4/#future-pseudo">:future</a> pseudo-classes sometimes match <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-16">WebVTT
 Node Objects</a>. <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a></p>
-   <p>The <dfn data-dfn-type="dfn" data-noexport="" id="past">:past<a class="self-link" href="#past"></a></dfn> pseudo-class only matches <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object①⑥">WebVTT Node Objects</a> that are <i>in the past</i>.</p>
-   <p class="algorithm" data-algorithm="in the past">A <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object①⑦">WebVTT Node Object</a> <var>c</var> is <dfn data-dfn-type="dfn" data-noexport="" id="in-the-past">in the past<a class="self-link" href="#in-the-past"></a></dfn> if, in a
-pre-order, depth-first traversal of the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue②⑨">WebVTT cue</a>’s <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects③②">list of WebVTT Node Objects</a>,
-there exists a <a data-link-type="dfn" href="#webvtt-timestamp-object" id="ref-for-webvtt-timestamp-object⑤">WebVTT Timestamp Object</a> whose value is less than the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#current-playback-position" id="ref-for-current-playback-position③">current playback
-position</a> of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element" id="ref-for-media-element①④">media element</a> that is the <i>matched element</i>, entirely after the <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object①⑧">WebVTT Node Object</a> <var>c</var>.</p>
-   <p>The <dfn data-dfn-type="dfn" data-noexport="" id="future">:future<a class="self-link" href="#future"></a></dfn> pseudo-class only matches <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object①⑨">WebVTT Node
+   <p>The <dfn data-dfn-type="dfn" data-noexport="" id="past">:past<a class="self-link" href="#past"></a></dfn> pseudo-class only matches <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-17">WebVTT Node Objects</a> that are <i>in the past</i>.</p>
+   <p class="algorithm" data-algorithm="in the past">A <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-18">WebVTT Node Object</a> <var>c</var> is <dfn data-dfn-type="dfn" data-noexport="" id="in-the-past">in the past<a class="self-link" href="#in-the-past"></a></dfn> if, in a
+pre-order, depth-first traversal of the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-30">WebVTT cue</a>’s <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-33">list of WebVTT Node Objects</a>,
+there exists a <a data-link-type="dfn" href="#webvtt-timestamp-object" id="ref-for-webvtt-timestamp-object-6">WebVTT Timestamp Object</a> whose value is less than the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#current-playback-position">current playback
+position</a> of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media element</a> that is the <i>matched element</i>, entirely after the <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-19">WebVTT Node Object</a> <var>c</var>.</p>
+   <p>The <dfn data-dfn-type="dfn" data-noexport="" id="future">:future<a class="self-link" href="#future"></a></dfn> pseudo-class only matches <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-20">WebVTT Node
 Objects</a> that are <i>in the future</i>.</p>
-   <p class="algorithm" data-algorithm="in the future">A <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object②⓪">WebVTT Node Object</a> <var>c</var> is <dfn data-dfn-type="dfn" data-noexport="" id="in-the-future">in the future<a class="self-link" href="#in-the-future"></a></dfn> if, in a
-pre-order, depth-first traversal of the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue③⓪">WebVTT cue</a>’s <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects③③">list of WebVTT Node Objects</a>,
-there exists a <a data-link-type="dfn" href="#webvtt-timestamp-object" id="ref-for-webvtt-timestamp-object⑥">WebVTT Timestamp Object</a> whose value is greater than the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#current-playback-position" id="ref-for-current-playback-position④">current playback
-position</a> of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element" id="ref-for-media-element①⑤">media element</a> that is the <i>matched element</i>, entirely before the <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object②①">WebVTT Node Object</a> <var>c</var>.</p>
+   <p class="algorithm" data-algorithm="in the future">A <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-21">WebVTT Node Object</a> <var>c</var> is <dfn data-dfn-type="dfn" data-noexport="" id="in-the-future">in the future<a class="self-link" href="#in-the-future"></a></dfn> if, in a
+pre-order, depth-first traversal of the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-31">WebVTT cue</a>’s <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-34">list of WebVTT Node Objects</a>,
+there exists a <a data-link-type="dfn" href="#webvtt-timestamp-object" id="ref-for-webvtt-timestamp-object-7">WebVTT Timestamp Object</a> whose value is greater than the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#current-playback-position">current playback
+position</a> of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media element</a> that is the <i>matched element</i>, entirely before the <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-22">WebVTT Node Object</a> <var>c</var>.</p>
    <h4 class="heading settled" data-level="7.2.3" id="the-cue-region-pseudo-element"><span class="secno">7.2.3. </span><span class="content">The <span class="css">::cue-region</span> pseudo-element</span><a class="self-link" href="#the-cue-region-pseudo-element"></a></h4>
    <p>Pseudo-elements apply to elements that are matched by selectors. For the purpose of this section,
 that element is the matched element. The pseudo-element defined below affects the styling of text
 track regions that are being rendered for the matched element.</p>
    <p class="note" role="note">If the matched element is not a video element, the pseudo-element defined below
 won’t have any effect according to this specification.</p>
-   <p>The <dfn data-dfn-type="dfn" data-noexport="" id="cue-region">::cue-region<a class="self-link" href="#cue-region"></a></dfn> pseudo-element (with no argument) matches any list of <a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object①①">WebVTT region objects</a> constructed for the <i>matched element</i>.</p>
+   <p>The <dfn data-dfn-type="dfn" data-noexport="" id="cue-region">::cue-region<a class="self-link" href="#cue-region"></a></dfn> pseudo-element (with no argument) matches any list of <a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object-12">WebVTT region objects</a> constructed for the <i>matched element</i>.</p>
    <p>The <dfn data-dfn-type="dfn" data-noexport="" id="cue-region-selector">::cue-region(selector)<a class="self-link" href="#cue-region-selector"></a></dfn> pseudo-element with an argument must have an argument that
-consists of a CSS selector <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a>. It matches any list of <a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object①②">WebVTT region objects</a> constructed for the <i>matched element</i> that also matches the
+consists of a CSS selector <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a>. It matches any list of <a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object-13">WebVTT region objects</a> constructed for the <i>matched element</i> that also matches the
 given CSS selector as follows:</p>
    <ul>
     <li>
-     <p>Any region (list of <a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object①③">WebVTT region objects</a>) with a <a data-link-type="dfn" href="#webvtt-region-identifier" id="ref-for-webvtt-region-identifier⑤">WebVTT region identifier</a> matching the given ID.</p>
+     <p>Any region (list of <a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object-14">WebVTT region objects</a>) with a <a data-link-type="dfn" href="#webvtt-region-identifier" id="ref-for-webvtt-region-identifier-6">WebVTT region identifier</a> matching the given ID.</p>
    </ul>
    <p>No other selector matching is defined for <span class="css">::cue-region(<var>selector</var>)</span>.</p>
    <p>The same properties that apply to <span class="css">::cue</span> apply to the <span class="css">::cue-region</span> pseudo-element; other
 properties set on the pseudo-element must be ignored.</p>
-   <p>When a user agent is rendering one or more text track regions according to the <a data-link-type="dfn" href="#rules-for-updating-the-display-of-webvtt-text-tracks" id="ref-for-rules-for-updating-the-display-of-webvtt-text-tracks⑧">rules for
-updating the display of WebVTT text tracks</a>, <a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object①④">WebVTT region
+   <p>When a user agent is rendering one or more text track regions according to the <a data-link-type="dfn" href="#rules-for-updating-the-display-of-webvtt-text-tracks" id="ref-for-rules-for-updating-the-display-of-webvtt-text-tracks-9">rules for
+updating the display of WebVTT text tracks</a>, <a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object-15">WebVTT region
 objects</a> used in the rendering can be matched by the above pseudo-element. User agents that
-support the pseudo-element must dynamically update renderings accordingly. When either <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-3/#propdef-white-space" id="ref-for-propdef-white-space④">white-space</a> or one of the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-fonts-3/#propdef-font" id="ref-for-propdef-font⑤">font</a> shorthand (including <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visudet.html#propdef-line-height" id="ref-for-propdef-line-height③">line-height</a>) changes
-value, then the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-display-state" id="ref-for-text-track-cue-display-state⑤">text track cue display state</a> of all the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue③①">WebVTT cues</a> in
-the region must be emptied and the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track" id="ref-for-text-track①⑥">text track</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#rules-for-updating-the-text-track-rendering" id="ref-for-rules-for-updating-the-text-track-rendering③">rules for updating the text track
+support the pseudo-element must dynamically update renderings accordingly. When either <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-text-3/#propdef-white-space">white-space</a> or one of the properties corresponding to the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-fonts-3/#propdef-font">font</a> shorthand (including <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/visudet.html#propdef-line-height">line-height</a>) changes
+value, then the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-display-state">text track cue display state</a> of all the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-32">WebVTT cues</a> in
+the region must be emptied and the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track">text track</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#rules-for-updating-the-text-track-rendering">rules for updating the text track
 rendering</a> must be immediately rerun.</p>
    <h2 class="heading settled" data-level="8" id="api"><span class="secno">8. </span><span class="content">API</span><a class="self-link" href="#api"></a></h2>
-   <h3 class="heading settled algorithm" data-algorithm="The VTTCue interface" data-level="8.1" id="the-vttcue-interface"><span class="secno">8.1. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#vttcue" id="ref-for-vttcue①">VTTCue</a></code> interface</span><a class="self-link" href="#the-vttcue-interface"></a></h3>
+   <h3 class="heading settled algorithm" data-algorithm="The VTTCue interface" data-level="8.1" id="the-vttcue-interface"><span class="secno">8.1. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#vttcue" id="ref-for-vttcue-2">VTTCue</a></code> interface</span><a class="self-link" href="#the-vttcue-interface"></a></h3>
    <p>The following interface is used to expose WebVTT cues in the DOM API:</p>
 <pre class="idl highlight def"><span class="kt">enum</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="enum" data-export="" id="enumdef-autokeyword"><code>AutoKeyword</code></dfn> { <dfn class="s idl-code" data-dfn-for="AutoKeyword" data-dfn-type="enum-value" data-export="" data-lt="&quot;auto&quot;|auto" id="dom-autokeyword-auto"><code>"auto"</code><a class="self-link" href="#dom-autokeyword-auto"></a></dfn> };
-<span class="kt">typedef</span> (<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double"><span class="kt">double</span></a> <span class="kt">or</span> <a class="n" data-link-type="idl-name" href="#enumdef-autokeyword" id="ref-for-enumdef-autokeyword">AutoKeyword</a>) <dfn class="nv dfn-paneled idl-code" data-dfn-type="typedef" data-export="" id="typedefdef-lineandpositionsetting"><code>LineAndPositionSetting</code></dfn>;
+<span class="kt">typedef</span> (<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double"><span class="kt">double</span></a> <span class="kt">or</span> <a class="n" data-link-type="idl-name" href="#enumdef-autokeyword" id="ref-for-enumdef-autokeyword-1">AutoKeyword</a>) <dfn class="nv dfn-paneled idl-code" data-dfn-type="typedef" data-export="" id="typedefdef-lineandpositionsetting"><code>LineAndPositionSetting</code></dfn>;
 <span class="kt">enum</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="enum" data-export="" id="enumdef-directionsetting"><code>DirectionSetting</code></dfn> { <dfn class="s idl-code" data-dfn-for="DirectionSetting" data-dfn-type="enum-value" data-export="" data-lt="&quot;&quot;|" id="dom-directionsetting"><code>""</code><a class="self-link" href="#dom-directionsetting"></a></dfn> /* horizontal */, <dfn class="s idl-code" data-dfn-for="DirectionSetting" data-dfn-type="enum-value" data-export="" data-lt="&quot;rl&quot;|rl" id="dom-directionsetting-rl"><code>"rl"</code><a class="self-link" href="#dom-directionsetting-rl"></a></dfn>, <dfn class="s idl-code" data-dfn-for="DirectionSetting" data-dfn-type="enum-value" data-export="" data-lt="&quot;lr&quot;|lr" id="dom-directionsetting-lr"><code>"lr"</code><a class="self-link" href="#dom-directionsetting-lr"></a></dfn> };
 <span class="kt">enum</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="enum" data-export="" id="enumdef-linealignsetting"><code>LineAlignSetting</code></dfn> { <dfn class="s idl-code" data-dfn-for="LineAlignSetting" data-dfn-type="enum-value" data-export="" data-lt="&quot;start&quot;|start" id="dom-linealignsetting-start"><code>"start"</code><a class="self-link" href="#dom-linealignsetting-start"></a></dfn>, <dfn class="s idl-code" data-dfn-for="LineAlignSetting" data-dfn-type="enum-value" data-export="" data-lt="&quot;center&quot;|center" id="dom-linealignsetting-center"><code>"center"</code><a class="self-link" href="#dom-linealignsetting-center"></a></dfn>, <dfn class="s idl-code" data-dfn-for="LineAlignSetting" data-dfn-type="enum-value" data-export="" data-lt="&quot;end&quot;|end" id="dom-linealignsetting-end"><code>"end"</code><a class="self-link" href="#dom-linealignsetting-end"></a></dfn> };
 <span class="kt">enum</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="enum" data-export="" id="enumdef-positionalignsetting"><code>PositionAlignSetting</code></dfn> { <dfn class="s idl-code" data-dfn-for="PositionAlignSetting" data-dfn-type="enum-value" data-export="" data-lt="&quot;line-left&quot;|line-left" id="dom-positionalignsetting-line-left"><code>"line-left"</code><a class="self-link" href="#dom-positionalignsetting-line-left"></a></dfn>, <dfn class="s idl-code" data-dfn-for="PositionAlignSetting" data-dfn-type="enum-value" data-export="" data-lt="&quot;center&quot;|center" id="dom-positionalignsetting-center"><code>"center"</code><a class="self-link" href="#dom-positionalignsetting-center"></a></dfn>, <dfn class="s idl-code" data-dfn-for="PositionAlignSetting" data-dfn-type="enum-value" data-export="" data-lt="&quot;line-right&quot;|line-right" id="dom-positionalignsetting-line-right"><code>"line-right"</code><a class="self-link" href="#dom-positionalignsetting-line-right"></a></dfn>, <dfn class="s idl-code" data-dfn-for="PositionAlignSetting" data-dfn-type="enum-value" data-export="" data-lt="&quot;auto&quot;|auto" id="dom-positionalignsetting-auto"><code>"auto"</code><a class="self-link" href="#dom-positionalignsetting-auto"></a></dfn> };
 <span class="kt">enum</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="enum" data-export="" id="enumdef-alignsetting"><code>AlignSetting</code></dfn> { <dfn class="s idl-code" data-dfn-for="AlignSetting" data-dfn-type="enum-value" data-export="" data-lt="&quot;start&quot;|start" id="dom-alignsetting-start"><code>"start"</code><a class="self-link" href="#dom-alignsetting-start"></a></dfn>, <dfn class="s idl-code" data-dfn-for="AlignSetting" data-dfn-type="enum-value" data-export="" data-lt="&quot;center&quot;|center" id="dom-alignsetting-center"><code>"center"</code><a class="self-link" href="#dom-alignsetting-center"></a></dfn>, <dfn class="s idl-code" data-dfn-for="AlignSetting" data-dfn-type="enum-value" data-export="" data-lt="&quot;end&quot;|end" id="dom-alignsetting-end"><code>"end"</code><a class="self-link" href="#dom-alignsetting-end"></a></dfn>, <dfn class="s idl-code" data-dfn-for="AlignSetting" data-dfn-type="enum-value" data-export="" data-lt="&quot;left&quot;|left" id="dom-alignsetting-left"><code>"left"</code><a class="self-link" href="#dom-alignsetting-left"></a></dfn>, <dfn class="s idl-code" data-dfn-for="AlignSetting" data-dfn-type="enum-value" data-export="" data-lt="&quot;right&quot;|right" id="dom-alignsetting-right"><code>"right"</code><a class="self-link" href="#dom-alignsetting-right"></a></dfn> };
-[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed">Exposed</a>=<span class="n">Window</span>,
- <a class="nv idl-code" data-link-type="constructor" href="#dom-vttcue-vttcue" id="ref-for-dom-vttcue-vttcue">Constructor</a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①"><span class="kt">double</span></a> <dfn class="nv idl-code" data-dfn-for="VTTCue/VTTCue(startTime, endTime, text)" data-dfn-type="argument" data-export="" id="dom-vttcue-vttcue-starttime-endtime-text-starttime"><code>startTime</code><a class="self-link" href="#dom-vttcue-vttcue-starttime-endtime-text-starttime"></a></dfn>, <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②"><span class="kt">double</span></a> <dfn class="nv idl-code" data-dfn-for="VTTCue/VTTCue(startTime, endTime, text)" data-dfn-type="argument" data-export="" id="dom-vttcue-vttcue-starttime-endtime-text-endtime"><code>endTime</code><a class="self-link" href="#dom-vttcue-vttcue-starttime-endtime-text-endtime"></a></dfn>, <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="VTTCue/VTTCue(startTime, endTime, text)" data-dfn-type="argument" data-export="" id="dom-vttcue-vttcue-starttime-endtime-text-text"><code>text</code><a class="self-link" href="#dom-vttcue-vttcue-starttime-endtime-text-text"></a></dfn>)]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="vttcue"><code>VTTCue</code></dfn> : <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/media.html#texttrackcue" id="ref-for-texttrackcue">TextTrackCue</a> {
-  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#vttregion" id="ref-for-vttregion">VTTRegion</a>? <a class="nv idl-code" data-link-type="attribute" data-type="VTTRegion?" href="#dom-vttcue-region" id="ref-for-dom-vttcue-region">region</a>;
-  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-directionsetting" id="ref-for-enumdef-directionsetting">DirectionSetting</a> <a class="nv idl-code" data-link-type="attribute" data-type="DirectionSetting" href="#dom-vttcue-vertical" id="ref-for-dom-vttcue-vertical">vertical</a>;
-  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="boolean" href="#dom-vttcue-snaptolines" id="ref-for-dom-vttcue-snaptolines①">snapToLines</a>;
-  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#typedefdef-lineandpositionsetting" id="ref-for-typedefdef-lineandpositionsetting">LineAndPositionSetting</a> <a class="nv idl-code" data-link-type="attribute" data-type="LineAndPositionSetting" href="#dom-vttcue-line" id="ref-for-dom-vttcue-line①">line</a>;
-  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-linealignsetting" id="ref-for-enumdef-linealignsetting">LineAlignSetting</a> <a class="nv idl-code" data-link-type="attribute" data-type="LineAlignSetting" href="#dom-vttcue-linealign" id="ref-for-dom-vttcue-linealign">lineAlign</a>;
-  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#typedefdef-lineandpositionsetting" id="ref-for-typedefdef-lineandpositionsetting①">LineAndPositionSetting</a> <a class="nv idl-code" data-link-type="attribute" data-type="LineAndPositionSetting" href="#dom-vttcue-position" id="ref-for-dom-vttcue-position">position</a>;
-  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-positionalignsetting" id="ref-for-enumdef-positionalignsetting">PositionAlignSetting</a> <a class="nv idl-code" data-link-type="attribute" data-type="PositionAlignSetting" href="#dom-vttcue-positionalign" id="ref-for-dom-vttcue-positionalign">positionAlign</a>;
-  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double③"><span class="kt">double</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="double" href="#dom-vttcue-size" id="ref-for-dom-vttcue-size">size</a>;
-  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-alignsetting" id="ref-for-enumdef-alignsetting">AlignSetting</a> <a class="nv idl-code" data-link-type="attribute" data-type="AlignSetting" href="#dom-vttcue-align" id="ref-for-dom-vttcue-align">align</a>;
-  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="DOMString" href="#dom-vttcue-text" id="ref-for-dom-vttcue-text">text</a>;
-  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#documentfragment" id="ref-for-documentfragment③">DocumentFragment</a> <a class="nv idl-code" data-link-type="method" href="#dom-vttcue-getcueashtml" id="ref-for-dom-vttcue-getcueashtml①">getCueAsHTML</a>();
+[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">Window</span>,
+ <a class="nv idl-code" data-link-type="constructor" href="#dom-vttcue-vttcue" id="ref-for-dom-vttcue-vttcue-1">Constructor</a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double"><span class="kt">double</span></a> <dfn class="nv idl-code" data-dfn-for="VTTCue/VTTCue(startTime, endTime, text)" data-dfn-type="argument" data-export="" id="dom-vttcue-vttcue-starttime-endtime-text-starttime"><code>startTime</code><a class="self-link" href="#dom-vttcue-vttcue-starttime-endtime-text-starttime"></a></dfn>, <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double"><span class="kt">double</span></a> <dfn class="nv idl-code" data-dfn-for="VTTCue/VTTCue(startTime, endTime, text)" data-dfn-type="argument" data-export="" id="dom-vttcue-vttcue-starttime-endtime-text-endtime"><code>endTime</code><a class="self-link" href="#dom-vttcue-vttcue-starttime-endtime-text-endtime"></a></dfn>, <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="VTTCue/VTTCue(startTime, endTime, text)" data-dfn-type="argument" data-export="" id="dom-vttcue-vttcue-starttime-endtime-text-text"><code>text</code><a class="self-link" href="#dom-vttcue-vttcue-starttime-endtime-text-text"></a></dfn>)]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="vttcue"><code>VTTCue</code></dfn> : <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/media.html#texttrackcue">TextTrackCue</a> {
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#vttregion" id="ref-for-vttregion-1">VTTRegion</a>? <a class="nv idl-code" data-link-type="attribute" data-type="VTTRegion?" href="#dom-vttcue-region" id="ref-for-dom-vttcue-region-1">region</a>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-directionsetting" id="ref-for-enumdef-directionsetting-1">DirectionSetting</a> <a class="nv idl-code" data-link-type="attribute" data-type="DirectionSetting" href="#dom-vttcue-vertical" id="ref-for-dom-vttcue-vertical-1">vertical</a>;
+  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="boolean" href="#dom-vttcue-snaptolines" id="ref-for-dom-vttcue-snaptolines-2">snapToLines</a>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#typedefdef-lineandpositionsetting" id="ref-for-typedefdef-lineandpositionsetting-1">LineAndPositionSetting</a> <a class="nv idl-code" data-link-type="attribute" data-type="LineAndPositionSetting" href="#dom-vttcue-line" id="ref-for-dom-vttcue-line-2">line</a>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-linealignsetting" id="ref-for-enumdef-linealignsetting-1">LineAlignSetting</a> <a class="nv idl-code" data-link-type="attribute" data-type="LineAlignSetting" href="#dom-vttcue-linealign" id="ref-for-dom-vttcue-linealign-1">lineAlign</a>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#typedefdef-lineandpositionsetting" id="ref-for-typedefdef-lineandpositionsetting-2">LineAndPositionSetting</a> <a class="nv idl-code" data-link-type="attribute" data-type="LineAndPositionSetting" href="#dom-vttcue-position" id="ref-for-dom-vttcue-position-1">position</a>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-positionalignsetting" id="ref-for-enumdef-positionalignsetting-1">PositionAlignSetting</a> <a class="nv idl-code" data-link-type="attribute" data-type="PositionAlignSetting" href="#dom-vttcue-positionalign" id="ref-for-dom-vttcue-positionalign-1">positionAlign</a>;
+  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double"><span class="kt">double</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="double" href="#dom-vttcue-size" id="ref-for-dom-vttcue-size-1">size</a>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-alignsetting" id="ref-for-enumdef-alignsetting-1">AlignSetting</a> <a class="nv idl-code" data-link-type="attribute" data-type="AlignSetting" href="#dom-vttcue-align" id="ref-for-dom-vttcue-align-1">align</a>;
+  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="DOMString" href="#dom-vttcue-text" id="ref-for-dom-vttcue-text-1">text</a>;
+  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#documentfragment">DocumentFragment</a> <a class="nv idl-code" data-link-type="method" href="#dom-vttcue-getcueashtml" id="ref-for-dom-vttcue-getcueashtml-2">getCueAsHTML</a>();
 };
 </pre>
    <dl class="note">
-    <dt><var>cue</var> = new <a class="idl-code" data-link-type="constructor" href="#dom-vttcue-vttcue" id="ref-for-dom-vttcue-vttcue①">VTTCue</a>( <var>startTime</var>, <var>endTime</var>, <var>text</var> )
+    <dt><var>cue</var> = new <a class="idl-code" data-link-type="constructor" href="#dom-vttcue-vttcue" id="ref-for-dom-vttcue-vttcue-2">VTTCue</a>( <var>startTime</var>, <var>endTime</var>, <var>text</var> )
     <dd>
-     <p>Returns a new <code class="idl"><a data-link-type="idl" href="#vttcue" id="ref-for-vttcue②">VTTCue</a></code> object, for use with the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/media.html#dom-texttrack-addcue" id="ref-for-dom-texttrack-addcue">addCue()</a></code> method.</p>
-     <p>The <var>startTime</var> argument sets the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-start-time" id="ref-for-text-track-cue-start-time①">text track cue start time</a>.</p>
-     <p>The <var>endTime</var> argument sets the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-end-time" id="ref-for-text-track-cue-end-time①">text track cue end time</a>.</p>
-     <p>The <var>text</var> argument sets the <a data-link-type="dfn" href="#text-track-cue-text" id="ref-for-text-track-cue-text⑥">text track cue text</a>.</p>
-    <dt><var>cue</var> . <code class="idl"><a data-link-type="idl" href="#dom-vttcue-region" id="ref-for-dom-vttcue-region①">region</a></code>
+     <p>Returns a new <code class="idl"><a data-link-type="idl" href="#vttcue" id="ref-for-vttcue-3">VTTCue</a></code> object, for use with the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/media.html#dom-texttrack-addcue">addCue()</a></code> method.</p>
+     <p>The <var>startTime</var> argument sets the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-start-time">text track cue start time</a>.</p>
+     <p>The <var>endTime</var> argument sets the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-end-time">text track cue end time</a>.</p>
+     <p>The <var>text</var> argument sets the <a data-link-type="dfn" href="#text-track-cue-text" id="ref-for-text-track-cue-text-7">text track cue text</a>.</p>
+    <dt><var>cue</var> . <code class="idl"><a data-link-type="idl" href="#dom-vttcue-region" id="ref-for-dom-vttcue-region-2">region</a></code>
     <dd>
-     <p>Returns the <code class="idl"><a data-link-type="idl" href="#vttregion" id="ref-for-vttregion①">VTTRegion</a></code> object to which this cue belongs, if any, or null otherwise.</p>
+     <p>Returns the <code class="idl"><a data-link-type="idl" href="#vttregion" id="ref-for-vttregion-2">VTTRegion</a></code> object to which this cue belongs, if any, or null otherwise.</p>
      <p>Can be set.</p>
-    <dt><var>cue</var> . <code class="idl"><a data-link-type="idl" href="#dom-vttcue-vertical" id="ref-for-dom-vttcue-vertical①">vertical</a></code> [ = <var>value</var> ]
+    <dt><var>cue</var> . <code class="idl"><a data-link-type="idl" href="#dom-vttcue-vertical" id="ref-for-dom-vttcue-vertical-2">vertical</a></code> [ = <var>value</var> ]
     <dd>
-     <p>Returns a string representing the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction③④">WebVTT cue writing direction</a>, as follows:</p>
+     <p>Returns a string representing the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-35">WebVTT cue writing direction</a>, as follows:</p>
      <dl class="switch">
-      <dt>If it is <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction②①">horizontal</a>
+      <dt>If it is <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction-22">horizontal</a>
       <dd>
        <p>The empty string.</p>
-      <dt>If it is <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-left-writing-direction" id="ref-for-webvtt-cue-vertical-growing-left-writing-direction①②">vertical growing
+      <dt>If it is <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-left-writing-direction" id="ref-for-webvtt-cue-vertical-growing-left-writing-direction-13">vertical growing
    left</a>
       <dd>
        <p>The string "<code>rl</code>".</p>
-      <dt>If it is <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-right-writing-direction" id="ref-for-webvtt-cue-vertical-growing-right-writing-direction①②">vertical growing
+      <dt>If it is <a data-link-type="dfn" href="#webvtt-cue-vertical-growing-right-writing-direction" id="ref-for-webvtt-cue-vertical-growing-right-writing-direction-13">vertical growing
    right</a>
       <dd>
        <p>The string "<code>lr</code>".</p>
      </dl>
      <p>Can be set.</p>
-    <dt><var>cue</var> . <code class="idl"><a data-link-type="idl" href="#dom-vttcue-snaptolines" id="ref-for-dom-vttcue-snaptolines②">snapToLines</a></code> [ = <var>value</var> ]
+    <dt><var>cue</var> . <code class="idl"><a data-link-type="idl" href="#dom-vttcue-snaptolines" id="ref-for-dom-vttcue-snaptolines-3">snapToLines</a></code> [ = <var>value</var> ]
     <dd>
-     <p>Returns true if the <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag①⑤">WebVTT cue snap-to-lines flag</a> is true, false otherwise.</p>
+     <p>Returns true if the <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag-16">WebVTT cue snap-to-lines flag</a> is true, false otherwise.</p>
      <p>Can be set.</p>
-    <dt><var>cue</var> . <code class="idl"><a data-link-type="idl" href="#dom-vttcue-line" id="ref-for-dom-vttcue-line②">line</a></code> [ = <var>value</var> ]
+    <dt><var>cue</var> . <code class="idl"><a data-link-type="idl" href="#dom-vttcue-line" id="ref-for-dom-vttcue-line-3">line</a></code> [ = <var>value</var> ]
     <dd>
-     <p>Returns the <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line②②">WebVTT cue line</a>. In the case of the value being <a data-link-type="dfn" href="#webvtt-cue-line-automatic" id="ref-for-webvtt-cue-line-automatic④">auto</a>, the string "<code>auto</code>" is returned.</p>
+     <p>Returns the <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line-23">WebVTT cue line</a>. In the case of the value being <a data-link-type="dfn" href="#webvtt-cue-line-automatic" id="ref-for-webvtt-cue-line-automatic-5">auto</a>, the string "<code>auto</code>" is returned.</p>
      <p>Can be set.</p>
-    <dt><var>cue</var> . <code class="idl"><a data-link-type="idl" href="#dom-vttcue-linealign" id="ref-for-dom-vttcue-linealign①">lineAlign</a></code> [ = <var>value</var> ]
+    <dt><var>cue</var> . <code class="idl"><a data-link-type="idl" href="#dom-vttcue-linealign" id="ref-for-dom-vttcue-linealign-2">lineAlign</a></code> [ = <var>value</var> ]
     <dd>
-     <p>Returns a string representing the <a data-link-type="dfn" href="#webvtt-cue-line-alignment" id="ref-for-webvtt-cue-line-alignment①③">WebVTT cue line alignment</a>, as follows:</p>
+     <p>Returns a string representing the <a data-link-type="dfn" href="#webvtt-cue-line-alignment" id="ref-for-webvtt-cue-line-alignment-14">WebVTT cue line alignment</a>, as follows:</p>
      <dl class="switch">
-      <dt>If it is <a data-link-type="dfn" href="#webvtt-cue-line-start-alignment" id="ref-for-webvtt-cue-line-start-alignment⑤">start alignment</a>
+      <dt>If it is <a data-link-type="dfn" href="#webvtt-cue-line-start-alignment" id="ref-for-webvtt-cue-line-start-alignment-6">start alignment</a>
       <dd>
        <p>The string "<code>start</code>".</p>
-      <dt>If it is <a data-link-type="dfn" href="#webvtt-cue-line-center-alignment" id="ref-for-webvtt-cue-line-center-alignment④">center alignment</a>
+      <dt>If it is <a data-link-type="dfn" href="#webvtt-cue-line-center-alignment" id="ref-for-webvtt-cue-line-center-alignment-5">center alignment</a>
       <dd>
        <p>The string "<code>center</code>".</p>
-      <dt>If it is <a data-link-type="dfn" href="#webvtt-cue-line-end-alignment" id="ref-for-webvtt-cue-line-end-alignment④">end alignment</a>
+      <dt>If it is <a data-link-type="dfn" href="#webvtt-cue-line-end-alignment" id="ref-for-webvtt-cue-line-end-alignment-5">end alignment</a>
       <dd>
        <p>The string "<code>end</code>".</p>
      </dl>
      <p>Can be set.</p>
-    <dt><var>cue</var> . <code class="idl"><a data-link-type="idl" href="#dom-vttcue-position" id="ref-for-dom-vttcue-position①">position</a></code> [ = <var>value</var> ]
+    <dt><var>cue</var> . <code class="idl"><a data-link-type="idl" href="#dom-vttcue-position" id="ref-for-dom-vttcue-position-2">position</a></code> [ = <var>value</var> ]
     <dd>
-     <p>Returns the <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position②②">WebVTT cue position</a>. In the case of the value being <a data-link-type="dfn" href="#webvtt-cue-automatic-position" id="ref-for-webvtt-cue-automatic-position⑦">auto</a>, the string "<code>auto</code>" is returned.</p>
+     <p>Returns the <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position-23">WebVTT cue position</a>. In the case of the value being <a data-link-type="dfn" href="#webvtt-cue-automatic-position" id="ref-for-webvtt-cue-automatic-position-8">auto</a>, the string "<code>auto</code>" is returned.</p>
      <p>Can be set.</p>
-    <dt><var>cue</var> . <code class="idl"><a data-link-type="idl" href="#dom-vttcue-positionalign" id="ref-for-dom-vttcue-positionalign①">positionAlign</a></code> [ = <var>value</var> ]
+    <dt><var>cue</var> . <code class="idl"><a data-link-type="idl" href="#dom-vttcue-positionalign" id="ref-for-dom-vttcue-positionalign-2">positionAlign</a></code> [ = <var>value</var> ]
     <dd>
-     <p>Returns a string representing the <a data-link-type="dfn" href="#webvtt-cue-position-alignment" id="ref-for-webvtt-cue-position-alignment①⓪">WebVTT cue position alignment</a>, as follows:</p>
+     <p>Returns a string representing the <a data-link-type="dfn" href="#webvtt-cue-position-alignment" id="ref-for-webvtt-cue-position-alignment-11">WebVTT cue position alignment</a>, as follows:</p>
      <dl class="switch">
-      <dt>If it is <a data-link-type="dfn" href="#webvtt-cue-position-line-left-alignment" id="ref-for-webvtt-cue-position-line-left-alignment⑦">line-left alignment</a>
+      <dt>If it is <a data-link-type="dfn" href="#webvtt-cue-position-line-left-alignment" id="ref-for-webvtt-cue-position-line-left-alignment-8">line-left alignment</a>
       <dd>
        <p>The string "<code>line-left</code>".</p>
-      <dt>If it is <a data-link-type="dfn" href="#webvtt-cue-position-center-alignment" id="ref-for-webvtt-cue-position-center-alignment⑦">center alignment</a>
+      <dt>If it is <a data-link-type="dfn" href="#webvtt-cue-position-center-alignment" id="ref-for-webvtt-cue-position-center-alignment-8">center alignment</a>
       <dd>
        <p>The string "<code>center</code>".</p>
-      <dt>If it is <a data-link-type="dfn" href="#webvtt-cue-position-line-right-alignment" id="ref-for-webvtt-cue-position-line-right-alignment⑦">line-right alignment</a>
+      <dt>If it is <a data-link-type="dfn" href="#webvtt-cue-position-line-right-alignment" id="ref-for-webvtt-cue-position-line-right-alignment-8">line-right alignment</a>
       <dd>
        <p>The string "<code>line-right</code>".</p>
-      <dt>If it is <a data-link-type="dfn" href="#webvtt-cue-position-automatic-alignment" id="ref-for-webvtt-cue-position-automatic-alignment③">automatic alignment</a>
+      <dt>If it is <a data-link-type="dfn" href="#webvtt-cue-position-automatic-alignment" id="ref-for-webvtt-cue-position-automatic-alignment-4">automatic alignment</a>
       <dd>
        <p>The string "<code>auto</code>".</p>
      </dl>
      <p>Can be set.</p>
-    <dt><var>cue</var> . <code class="idl"><a data-link-type="idl" href="#dom-vttcue-size" id="ref-for-dom-vttcue-size①">size</a></code> [ = <var>value</var> ]
+    <dt><var>cue</var> . <code class="idl"><a data-link-type="idl" href="#dom-vttcue-size" id="ref-for-dom-vttcue-size-2">size</a></code> [ = <var>value</var> ]
     <dd>
-     <p>Returns the <a data-link-type="dfn" href="#webvtt-cue-size" id="ref-for-webvtt-cue-size①⓪">WebVTT cue size</a>.</p>
+     <p>Returns the <a data-link-type="dfn" href="#webvtt-cue-size" id="ref-for-webvtt-cue-size-11">WebVTT cue size</a>.</p>
      <p>Can be set.</p>
-    <dt><var>cue</var> . <code class="idl"><a data-link-type="idl" href="#dom-vttcue-align" id="ref-for-dom-vttcue-align①">align</a></code> [ = <var>value</var> ]
+    <dt><var>cue</var> . <code class="idl"><a data-link-type="idl" href="#dom-vttcue-align" id="ref-for-dom-vttcue-align-2">align</a></code> [ = <var>value</var> ]
     <dd>
-     <p>Returns a string representing the <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment②⓪">WebVTT cue text alignment</a>, as follows:</p>
+     <p>Returns a string representing the <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment-21">WebVTT cue text alignment</a>, as follows:</p>
      <dl class="switch">
-      <dt>If it is <a data-link-type="dfn" href="#webvtt-cue-start-alignment" id="ref-for-webvtt-cue-start-alignment⑦">start alignment</a>
+      <dt>If it is <a data-link-type="dfn" href="#webvtt-cue-start-alignment" id="ref-for-webvtt-cue-start-alignment-8">start alignment</a>
       <dd>
        <p>The string "<code>start</code>".</p>
-      <dt>If it is <a data-link-type="dfn" href="#webvtt-cue-center-alignment" id="ref-for-webvtt-cue-center-alignment⑦">center alignment</a>
+      <dt>If it is <a data-link-type="dfn" href="#webvtt-cue-center-alignment" id="ref-for-webvtt-cue-center-alignment-8">center alignment</a>
       <dd>
        <p>The string "<code>center</code>".</p>
-      <dt>If it is <a data-link-type="dfn" href="#webvtt-cue-end-alignment" id="ref-for-webvtt-cue-end-alignment⑥">end alignment</a>
+      <dt>If it is <a data-link-type="dfn" href="#webvtt-cue-end-alignment" id="ref-for-webvtt-cue-end-alignment-7">end alignment</a>
       <dd>
        <p>The string "<code>end</code>".</p>
-      <dt>If it is <a data-link-type="dfn" href="#webvtt-cue-left-alignment" id="ref-for-webvtt-cue-left-alignment⑥">left alignment</a>
+      <dt>If it is <a data-link-type="dfn" href="#webvtt-cue-left-alignment" id="ref-for-webvtt-cue-left-alignment-7">left alignment</a>
       <dd>
        <p>The string "<code>left</code>".</p>
-      <dt>If it is <a data-link-type="dfn" href="#webvtt-cue-right-alignment" id="ref-for-webvtt-cue-right-alignment⑥">right alignment</a>
+      <dt>If it is <a data-link-type="dfn" href="#webvtt-cue-right-alignment" id="ref-for-webvtt-cue-right-alignment-7">right alignment</a>
       <dd>
        <p>The string "<code>right</code>".</p>
      </dl>
      <p>Can be set.</p>
-    <dt><var>cue</var> . <code class="idl"><a data-link-type="idl" href="#dom-vttcue-text" id="ref-for-dom-vttcue-text①">text</a></code> [ = <var>value</var> ]
+    <dt><var>cue</var> . <code class="idl"><a data-link-type="idl" href="#dom-vttcue-text" id="ref-for-dom-vttcue-text-2">text</a></code> [ = <var>value</var> ]
     <dd>
-     <p>Returns the <a data-link-type="dfn" href="#text-track-cue-text" id="ref-for-text-track-cue-text⑦">text track cue text</a> in raw unparsed form.</p>
+     <p>Returns the <a data-link-type="dfn" href="#text-track-cue-text" id="ref-for-text-track-cue-text-8">text track cue text</a> in raw unparsed form.</p>
      <p>Can be set.</p>
-    <dt><var>fragment</var> = <var>cue</var> . <a class="idl-code" data-link-type="method" href="#dom-vttcue-getcueashtml" id="ref-for-dom-vttcue-getcueashtml②">getCueAsHTML</a>()
+    <dt><var>fragment</var> = <var>cue</var> . <a class="idl-code" data-link-type="method" href="#dom-vttcue-getcueashtml" id="ref-for-dom-vttcue-getcueashtml-3">getCueAsHTML</a>()
     <dd>
-     <p>Returns the <a data-link-type="dfn" href="#text-track-cue-text" id="ref-for-text-track-cue-text⑧">text track cue text</a> as a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#documentfragment" id="ref-for-documentfragment④">DocumentFragment</a></code> of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#html-elements" id="ref-for-html-elements">HTML elements</a> and
+     <p>Returns the <a data-link-type="dfn" href="#text-track-cue-text" id="ref-for-text-track-cue-text-9">text track cue text</a> as a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#documentfragment">DocumentFragment</a></code> of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#html-elements">HTML elements</a> and
   other DOM nodes.</p>
    </dl>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="VTTCue" data-dfn-type="constructor" data-export="" data-lt="VTTCue(startTime, endTime, text)" id="dom-vttcue-vttcue"><code>VTTCue(<var>startTime</var>, <var>endTime</var>, <var>text</var>)</code></dfn> constructor, when invoked, must run the following steps:</p>
    <ol class="algorithm">
     <li>
-     <p>Create a new <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue③②">WebVTT cue</a>. Let <var>cue</var> be that <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue③③">WebVTT cue</a>.</p>
+     <p>Create a new <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-33">WebVTT cue</a>. Let <var>cue</var> be that <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-34">WebVTT cue</a>.</p>
     <li>
-     <p>Let <var>cue</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-start-time" id="ref-for-text-track-cue-start-time②">text track cue start time</a> be the value of the <var>startTime</var> argument,
+     <p>Let <var>cue</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-start-time">text track cue start time</a> be the value of the <var>startTime</var> argument,
  interpreted as a time in seconds.</p>
     <li>
-     <p>Let <var>cue</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-end-time" id="ref-for-text-track-cue-end-time②">text track cue end time</a> be the value of the <var>endTime</var> argument,
+     <p>Let <var>cue</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-end-time">text track cue end time</a> be the value of the <var>endTime</var> argument,
  interpreted as a time in seconds.</p>
     <li>
-     <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#text-track-cue-text" id="ref-for-text-track-cue-text⑨">text track cue text</a> be the value of the <var>text</var> argument, and let the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#rules-for-extracting-the-chapter-title" id="ref-for-rules-for-extracting-the-chapter-title">rules for extracting the chapter title</a> be the <a data-link-type="dfn" href="#webvtt-rules-for-extracting-the-chapter-title" id="ref-for-webvtt-rules-for-extracting-the-chapter-title">WebVTT rules for extracting the chapter
+     <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#text-track-cue-text" id="ref-for-text-track-cue-text-10">text track cue text</a> be the value of the <var>text</var> argument, and let the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#rules-for-extracting-the-chapter-title">rules for extracting the chapter title</a> be the <a data-link-type="dfn" href="#webvtt-rules-for-extracting-the-chapter-title" id="ref-for-webvtt-rules-for-extracting-the-chapter-title-1">WebVTT rules for extracting the chapter
  title</a>.</p>
     <li>
-     <p>Let <var>cue</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-identifier" id="ref-for-text-track-cue-identifier③">text track cue identifier</a> be the empty string.</p>
+     <p>Let <var>cue</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-identifier">text track cue identifier</a> be the empty string.</p>
     <li>
-     <p>Let <var>cue</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-pause-on-exit-flag" id="ref-for-text-track-cue-pause-on-exit-flag①">text track cue pause-on-exit flag</a> be false.</p>
+     <p>Let <var>cue</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-pause-on-exit-flag">text track cue pause-on-exit flag</a> be false.</p>
     <li>
-     <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-region" id="ref-for-webvtt-cue-region⑥">WebVTT cue region</a> be null.</p>
+     <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-region" id="ref-for-webvtt-cue-region-7">WebVTT cue region</a> be null.</p>
     <li>
-     <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction③⑤">WebVTT cue writing direction</a> be <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction②②">horizontal</a>.</p>
+     <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-36">WebVTT cue writing direction</a> be <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction-23">horizontal</a>.</p>
     <li>
-     <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag①⑥">WebVTT cue snap-to-lines flag</a> be true.</p>
+     <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag-17">WebVTT cue snap-to-lines flag</a> be true.</p>
     <li>
-     <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line②③">WebVTT cue line</a> be <a data-link-type="dfn" href="#webvtt-cue-line-automatic" id="ref-for-webvtt-cue-line-automatic⑤">auto</a>.</p>
+     <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line-24">WebVTT cue line</a> be <a data-link-type="dfn" href="#webvtt-cue-line-automatic" id="ref-for-webvtt-cue-line-automatic-6">auto</a>.</p>
     <li>
-     <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-line-alignment" id="ref-for-webvtt-cue-line-alignment①④">WebVTT cue line alignment</a> be <a data-link-type="dfn" href="#webvtt-cue-line-start-alignment" id="ref-for-webvtt-cue-line-start-alignment⑥">start alignment</a>.</p>
+     <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-line-alignment" id="ref-for-webvtt-cue-line-alignment-15">WebVTT cue line alignment</a> be <a data-link-type="dfn" href="#webvtt-cue-line-start-alignment" id="ref-for-webvtt-cue-line-start-alignment-7">start alignment</a>.</p>
     <li>
-     <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position②③">WebVTT cue position</a> be <a data-link-type="dfn" href="#webvtt-cue-automatic-position" id="ref-for-webvtt-cue-automatic-position⑧">auto</a>.</p>
+     <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position-24">WebVTT cue position</a> be <a data-link-type="dfn" href="#webvtt-cue-automatic-position" id="ref-for-webvtt-cue-automatic-position-9">auto</a>.</p>
     <li>
-     <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-position-alignment" id="ref-for-webvtt-cue-position-alignment①①">WebVTT cue position alignment</a> be <a data-link-type="dfn" href="#webvtt-cue-position-automatic-alignment" id="ref-for-webvtt-cue-position-automatic-alignment④">auto</a>.</p>
+     <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-position-alignment" id="ref-for-webvtt-cue-position-alignment-12">WebVTT cue position alignment</a> be <a data-link-type="dfn" href="#webvtt-cue-position-automatic-alignment" id="ref-for-webvtt-cue-position-automatic-alignment-5">auto</a>.</p>
     <li>
-     <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-size" id="ref-for-webvtt-cue-size①①">WebVTT cue size</a> be 100.</p>
+     <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-size" id="ref-for-webvtt-cue-size-12">WebVTT cue size</a> be 100.</p>
     <li>
-     <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment②①">WebVTT cue text alignment</a> be <a data-link-type="dfn" href="#webvtt-cue-center-alignment" id="ref-for-webvtt-cue-center-alignment⑧">center
+     <p>Let <var>cue</var>’s <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment-22">WebVTT cue text alignment</a> be <a data-link-type="dfn" href="#webvtt-cue-center-alignment" id="ref-for-webvtt-cue-center-alignment-9">center
  alignment</a>.</p>
     <li>
-     <p>Return the <code class="idl"><a data-link-type="idl" href="#vttcue" id="ref-for-vttcue③">VTTCue</a></code> object representing <var>cue</var>.</p>
+     <p>Return the <code class="idl"><a data-link-type="idl" href="#vttcue" id="ref-for-vttcue-4">VTTCue</a></code> object representing <var>cue</var>.</p>
    </ol>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="VTTCue" data-dfn-type="attribute" data-export="" id="dom-vttcue-region"><code>region</code></dfn> attribute, on getting, must return the <code class="idl"><a data-link-type="idl" href="#vttregion" id="ref-for-vttregion②">VTTRegion</a></code> object representing the <a data-link-type="dfn" href="#webvtt-cue-region" id="ref-for-webvtt-cue-region⑦">WebVTT cue region</a> of the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue③④">WebVTT cue</a> that the <code class="idl"><a data-link-type="idl" href="#vttcue" id="ref-for-vttcue④">VTTCue</a></code> object
-represents, if any; or null otherwise. On setting, the <a data-link-type="dfn" href="#webvtt-cue-region" id="ref-for-webvtt-cue-region⑧">WebVTT cue region</a> must be set to the
+   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="VTTCue" data-dfn-type="attribute" data-export="" id="dom-vttcue-region"><code>region</code></dfn> attribute, on getting, must return the <code class="idl"><a data-link-type="idl" href="#vttregion" id="ref-for-vttregion-3">VTTRegion</a></code> object representing the <a data-link-type="dfn" href="#webvtt-cue-region" id="ref-for-webvtt-cue-region-8">WebVTT cue region</a> of the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-35">WebVTT cue</a> that the <code class="idl"><a data-link-type="idl" href="#vttcue" id="ref-for-vttcue-5">VTTCue</a></code> object
+represents, if any; or null otherwise. On setting, the <a data-link-type="dfn" href="#webvtt-cue-region" id="ref-for-webvtt-cue-region-9">WebVTT cue region</a> must be set to the
 new value.</p>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="VTTCue" data-dfn-type="attribute" data-export="" id="dom-vttcue-vertical"><code>vertical</code></dfn> attribute, on getting, must return the string from
-the second cell of the row in the table below whose first cell is the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction③⑥">WebVTT cue writing
-direction</a> of the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue③⑤">WebVTT cue</a> that the <code class="idl"><a data-link-type="idl" href="#vttcue" id="ref-for-vttcue⑤">VTTCue</a></code> object represents:</p>
+the second cell of the row in the table below whose first cell is the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-37">WebVTT cue writing
+direction</a> of the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-36">WebVTT cue</a> that the <code class="idl"><a data-link-type="idl" href="#vttcue" id="ref-for-vttcue-6">VTTCue</a></code> object represents:</p>
    <table class="complex data">
     <thead>
      <tr>
-      <th><a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction③⑦">WebVTT cue writing direction</a>
-      <th><code class="idl"><a data-link-type="idl" href="#dom-vttcue-vertical" id="ref-for-dom-vttcue-vertical②">vertical</a></code> value
+      <th><a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-38">WebVTT cue writing direction</a>
+      <th><code class="idl"><a data-link-type="idl" href="#dom-vttcue-vertical" id="ref-for-dom-vttcue-vertical-3">vertical</a></code> value
     <tbody>
      <tr>
-      <td><a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction②③">Horizontal</a>
+      <td><a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction-24">Horizontal</a>
       <td>"<code></code>" (the empty string)
      <tr>
-      <td><a data-link-type="dfn" href="#webvtt-cue-vertical-growing-left-writing-direction" id="ref-for-webvtt-cue-vertical-growing-left-writing-direction①③">Vertical growing left</a>
+      <td><a data-link-type="dfn" href="#webvtt-cue-vertical-growing-left-writing-direction" id="ref-for-webvtt-cue-vertical-growing-left-writing-direction-14">Vertical growing left</a>
       <td>"<code>rl</code>"
      <tr>
-      <td><a data-link-type="dfn" href="#webvtt-cue-vertical-growing-right-writing-direction" id="ref-for-webvtt-cue-vertical-growing-right-writing-direction①③">Vertical growing right</a>
+      <td><a data-link-type="dfn" href="#webvtt-cue-vertical-growing-right-writing-direction" id="ref-for-webvtt-cue-vertical-growing-right-writing-direction-14">Vertical growing right</a>
       <td>"<code>lr</code>"
    </table>
-   <p>On setting, the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction③⑧">WebVTT cue writing direction</a> must be set to the value given in the first
-cell of the row in the table above whose second cell is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive②⑥">case-sensitive</a> match for the new
+   <p>On setting, the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction-39">WebVTT cue writing direction</a> must be set to the value given in the first
+cell of the row in the table above whose second cell is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">case-sensitive</a> match for the new
 value.</p>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="VTTCue" data-dfn-type="attribute" data-export="" id="dom-vttcue-snaptolines"><code>snapToLines</code></dfn> attribute, on getting, must return true if the <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag①⑦">WebVTT cue snap-to-lines flag</a> of the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue③⑥">WebVTT cue</a> that the <code class="idl"><a data-link-type="idl" href="#vttcue" id="ref-for-vttcue⑥">VTTCue</a></code> object represents
-is true; or false otherwise. On setting, the <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag①⑧">WebVTT cue snap-to-lines flag</a> must be set to the
+   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="VTTCue" data-dfn-type="attribute" data-export="" id="dom-vttcue-snaptolines"><code>snapToLines</code></dfn> attribute, on getting, must return true if the <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag-18">WebVTT cue snap-to-lines flag</a> of the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-37">WebVTT cue</a> that the <code class="idl"><a data-link-type="idl" href="#vttcue" id="ref-for-vttcue-7">VTTCue</a></code> object represents
+is true; or false otherwise. On setting, the <a data-link-type="dfn" href="#webvtt-cue-snap-to-lines-flag" id="ref-for-webvtt-cue-snap-to-lines-flag-19">WebVTT cue snap-to-lines flag</a> must be set to the
 new value.</p>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="VTTCue" data-dfn-type="attribute" data-export="" id="dom-vttcue-line"><code>line</code></dfn> attribute, on getting, must return the <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line②④">WebVTT cue
-line</a> of the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue③⑦">WebVTT cue</a> that the <code class="idl"><a data-link-type="idl" href="#vttcue" id="ref-for-vttcue⑦">VTTCue</a></code> object represents. The special value <a data-link-type="dfn" href="#webvtt-cue-line-automatic" id="ref-for-webvtt-cue-line-automatic⑥">auto</a> must be represented as the string "<code>auto</code>". On
-setting, the <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line②⑤">WebVTT cue line</a> must be set to the new value; if the new value is the string
-"<code>auto</code>", then it must be interpreted as the special value <a data-link-type="dfn" href="#webvtt-cue-line-automatic" id="ref-for-webvtt-cue-line-automatic⑦">auto</a>.</p>
-   <p class="note" role="note">In order to be able to set the <code class="idl"><a data-link-type="idl" href="#dom-vttcue-snaptolines" id="ref-for-dom-vttcue-snaptolines③">snapToLines</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-vttcue-line" id="ref-for-dom-vttcue-line③">line</a></code> attributes
-in any order, the API does not reject setting <code class="idl"><a data-link-type="idl" href="#dom-vttcue-snaptolines" id="ref-for-dom-vttcue-snaptolines④">snapToLines</a></code> to false when <code class="idl"><a data-link-type="idl" href="#dom-vttcue-line" id="ref-for-dom-vttcue-line④">line</a></code> has a value outside the range 0..100, or vice versa.</p>
+   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="VTTCue" data-dfn-type="attribute" data-export="" id="dom-vttcue-line"><code>line</code></dfn> attribute, on getting, must return the <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line-25">WebVTT cue
+line</a> of the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-38">WebVTT cue</a> that the <code class="idl"><a data-link-type="idl" href="#vttcue" id="ref-for-vttcue-8">VTTCue</a></code> object represents. The special value <a data-link-type="dfn" href="#webvtt-cue-line-automatic" id="ref-for-webvtt-cue-line-automatic-7">auto</a> must be represented as the string "<code>auto</code>". On
+setting, the <a data-link-type="dfn" href="#webvtt-cue-line" id="ref-for-webvtt-cue-line-26">WebVTT cue line</a> must be set to the new value; if the new value is the string
+"<code>auto</code>", then it must be interpreted as the special value <a data-link-type="dfn" href="#webvtt-cue-line-automatic" id="ref-for-webvtt-cue-line-automatic-8">auto</a>.</p>
+   <p class="note" role="note">In order to be able to set the <code class="idl"><a data-link-type="idl" href="#dom-vttcue-snaptolines" id="ref-for-dom-vttcue-snaptolines-4">snapToLines</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-vttcue-line" id="ref-for-dom-vttcue-line-4">line</a></code> attributes
+in any order, the API does not reject setting <code class="idl"><a data-link-type="idl" href="#dom-vttcue-snaptolines" id="ref-for-dom-vttcue-snaptolines-5">snapToLines</a></code> to false when <code class="idl"><a data-link-type="idl" href="#dom-vttcue-line" id="ref-for-dom-vttcue-line-5">line</a></code> has a value outside the range 0..100, or vice versa.</p>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="VTTCue" data-dfn-type="attribute" data-export="" id="dom-vttcue-linealign"><code>lineAlign</code></dfn> attribute, on getting, must return the string from
-the second cell of the row in the table below whose first cell is the <a data-link-type="dfn" href="#webvtt-cue-line-alignment" id="ref-for-webvtt-cue-line-alignment①⑤">WebVTT cue line
-alignment</a> of the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue③⑧">WebVTT cue</a> that the <code class="idl"><a data-link-type="idl" href="#vttcue" id="ref-for-vttcue⑧">VTTCue</a></code> object represents:</p>
+the second cell of the row in the table below whose first cell is the <a data-link-type="dfn" href="#webvtt-cue-line-alignment" id="ref-for-webvtt-cue-line-alignment-16">WebVTT cue line
+alignment</a> of the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-39">WebVTT cue</a> that the <code class="idl"><a data-link-type="idl" href="#vttcue" id="ref-for-vttcue-9">VTTCue</a></code> object represents:</p>
    <table class="complex data">
     <thead>
      <tr>
-      <th><a data-link-type="dfn" href="#webvtt-cue-line-alignment" id="ref-for-webvtt-cue-line-alignment①⑥">WebVTT cue line alignment</a>
-      <th><code class="idl"><a data-link-type="idl" href="#dom-vttcue-linealign" id="ref-for-dom-vttcue-linealign②">lineAlign</a></code> value
+      <th><a data-link-type="dfn" href="#webvtt-cue-line-alignment" id="ref-for-webvtt-cue-line-alignment-17">WebVTT cue line alignment</a>
+      <th><code class="idl"><a data-link-type="idl" href="#dom-vttcue-linealign" id="ref-for-dom-vttcue-linealign-3">lineAlign</a></code> value
     <tbody>
      <tr>
-      <td><a data-link-type="dfn" href="#webvtt-cue-line-start-alignment" id="ref-for-webvtt-cue-line-start-alignment⑦">Start alignment</a>
+      <td><a data-link-type="dfn" href="#webvtt-cue-line-start-alignment" id="ref-for-webvtt-cue-line-start-alignment-8">Start alignment</a>
       <td>"<code>start</code>"
      <tr>
-      <td><a data-link-type="dfn" href="#webvtt-cue-line-center-alignment" id="ref-for-webvtt-cue-line-center-alignment⑤">Center alignment</a>
+      <td><a data-link-type="dfn" href="#webvtt-cue-line-center-alignment" id="ref-for-webvtt-cue-line-center-alignment-6">Center alignment</a>
       <td>"<code>center</code>"
      <tr>
-      <td><a data-link-type="dfn" href="#webvtt-cue-line-end-alignment" id="ref-for-webvtt-cue-line-end-alignment⑤">End alignment</a>
+      <td><a data-link-type="dfn" href="#webvtt-cue-line-end-alignment" id="ref-for-webvtt-cue-line-end-alignment-6">End alignment</a>
       <td>"<code>end</code>"
    </table>
-   <p>On setting, the <a data-link-type="dfn" href="#webvtt-cue-line-alignment" id="ref-for-webvtt-cue-line-alignment①⑦">WebVTT cue line alignment</a> must be set to the value given in the first cell
-of the row in the table above whose second cell is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive②⑦">case-sensitive</a> match for the new
+   <p>On setting, the <a data-link-type="dfn" href="#webvtt-cue-line-alignment" id="ref-for-webvtt-cue-line-alignment-18">WebVTT cue line alignment</a> must be set to the value given in the first cell
+of the row in the table above whose second cell is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">case-sensitive</a> match for the new
 value.</p>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="VTTCue" data-dfn-type="attribute" data-export="" id="dom-vttcue-position"><code>position</code></dfn> attribute, on getting, must return the <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position②④">WebVTT cue
-position</a> of the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue③⑨">WebVTT cue</a> that the <code class="idl"><a data-link-type="idl" href="#vttcue" id="ref-for-vttcue⑨">VTTCue</a></code> object represents. The special value <a data-link-type="dfn" href="#webvtt-cue-automatic-position" id="ref-for-webvtt-cue-automatic-position⑨">auto</a> must be represented as the string "<code>auto</code>".
-On setting, if the new value is negative or greater than 100, then an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror" id="ref-for-indexsizeerror">IndexSizeError</a></code> exception
-must be thrown. Otherwise, the <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position②⑤">WebVTT cue position</a> must be set to the new value; if the new
-value is the string "<code>auto</code>", then it must be interpreted as the special value <a data-link-type="dfn" href="#webvtt-cue-automatic-position" id="ref-for-webvtt-cue-automatic-position①⓪">auto</a>.</p>
+   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="VTTCue" data-dfn-type="attribute" data-export="" id="dom-vttcue-position"><code>position</code></dfn> attribute, on getting, must return the <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position-25">WebVTT cue
+position</a> of the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-40">WebVTT cue</a> that the <code class="idl"><a data-link-type="idl" href="#vttcue" id="ref-for-vttcue-10">VTTCue</a></code> object represents. The special value <a data-link-type="dfn" href="#webvtt-cue-automatic-position" id="ref-for-webvtt-cue-automatic-position-10">auto</a> must be represented as the string "<code>auto</code>".
+On setting, if the new value is negative or greater than 100, then an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror">IndexSizeError</a></code> exception
+must be thrown. Otherwise, the <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position-26">WebVTT cue position</a> must be set to the new value; if the new
+value is the string "<code>auto</code>", then it must be interpreted as the special value <a data-link-type="dfn" href="#webvtt-cue-automatic-position" id="ref-for-webvtt-cue-automatic-position-11">auto</a>.</p>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="VTTCue" data-dfn-type="attribute" data-export="" id="dom-vttcue-positionalign"><code>positionAlign</code></dfn> attribute, on getting, must return the string
-from the second cell of the row in the table below whose first cell is the <a data-link-type="dfn" href="#webvtt-cue-position-alignment" id="ref-for-webvtt-cue-position-alignment①②">WebVTT cue position
-alignment</a> of the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue④⓪">WebVTT cue</a> that the <code class="idl"><a data-link-type="idl" href="#vttcue" id="ref-for-vttcue①⓪">VTTCue</a></code> object represents:</p>
+from the second cell of the row in the table below whose first cell is the <a data-link-type="dfn" href="#webvtt-cue-position-alignment" id="ref-for-webvtt-cue-position-alignment-13">WebVTT cue position
+alignment</a> of the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-41">WebVTT cue</a> that the <code class="idl"><a data-link-type="idl" href="#vttcue" id="ref-for-vttcue-11">VTTCue</a></code> object represents:</p>
    <table class="complex data">
     <thead>
      <tr>
-      <th><a data-link-type="dfn" href="#webvtt-cue-position-alignment" id="ref-for-webvtt-cue-position-alignment①③">WebVTT cue position alignment</a>
-      <th><code class="idl"><a data-link-type="idl" href="#dom-vttcue-positionalign" id="ref-for-dom-vttcue-positionalign②">positionAlign</a></code> value
+      <th><a data-link-type="dfn" href="#webvtt-cue-position-alignment" id="ref-for-webvtt-cue-position-alignment-14">WebVTT cue position alignment</a>
+      <th><code class="idl"><a data-link-type="idl" href="#dom-vttcue-positionalign" id="ref-for-dom-vttcue-positionalign-3">positionAlign</a></code> value
     <tbody>
      <tr>
-      <td><a data-link-type="dfn" href="#webvtt-cue-position-line-left-alignment" id="ref-for-webvtt-cue-position-line-left-alignment⑧">Line-left alignment</a>
+      <td><a data-link-type="dfn" href="#webvtt-cue-position-line-left-alignment" id="ref-for-webvtt-cue-position-line-left-alignment-9">Line-left alignment</a>
       <td>"<code>line-left</code>"
      <tr>
-      <td><a data-link-type="dfn" href="#webvtt-cue-position-center-alignment" id="ref-for-webvtt-cue-position-center-alignment⑧">Center alignment</a>
+      <td><a data-link-type="dfn" href="#webvtt-cue-position-center-alignment" id="ref-for-webvtt-cue-position-center-alignment-9">Center alignment</a>
       <td>"<code>center</code>"
      <tr>
-      <td><a data-link-type="dfn" href="#webvtt-cue-position-line-right-alignment" id="ref-for-webvtt-cue-position-line-right-alignment⑧">Line-right alignment</a>
+      <td><a data-link-type="dfn" href="#webvtt-cue-position-line-right-alignment" id="ref-for-webvtt-cue-position-line-right-alignment-9">Line-right alignment</a>
       <td>"<code>line-right</code>"
      <tr>
-      <td><a data-link-type="dfn" href="#webvtt-cue-position-automatic-alignment" id="ref-for-webvtt-cue-position-automatic-alignment⑤">Automatic alignment</a>
+      <td><a data-link-type="dfn" href="#webvtt-cue-position-automatic-alignment" id="ref-for-webvtt-cue-position-automatic-alignment-6">Automatic alignment</a>
       <td>"<code>auto</code>"
    </table>
-   <p>On setting, the <a data-link-type="dfn" href="#webvtt-cue-position-alignment" id="ref-for-webvtt-cue-position-alignment①④">WebVTT cue position alignment</a> must be set to the value given in the first
-cell of the row in the table above whose second cell is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive②⑧">case-sensitive</a> match for the new
+   <p>On setting, the <a data-link-type="dfn" href="#webvtt-cue-position-alignment" id="ref-for-webvtt-cue-position-alignment-15">WebVTT cue position alignment</a> must be set to the value given in the first
+cell of the row in the table above whose second cell is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">case-sensitive</a> match for the new
 value.</p>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="VTTCue" data-dfn-type="attribute" data-export="" id="dom-vttcue-size"><code>size</code></dfn> attribute, on getting, must return the <a data-link-type="dfn" href="#webvtt-cue-size" id="ref-for-webvtt-cue-size①②">WebVTT cue
-size</a> of the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue④①">WebVTT cue</a> that the <code class="idl"><a data-link-type="idl" href="#vttcue" id="ref-for-vttcue①①">VTTCue</a></code> object represents. On setting, if the new
-value is negative or greater than 100, then an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror" id="ref-for-indexsizeerror①">IndexSizeError</a></code> exception must be thrown.
-Otherwise, the <a data-link-type="dfn" href="#webvtt-cue-size" id="ref-for-webvtt-cue-size①③">WebVTT cue size</a> must be set to the new value.</p>
+   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="VTTCue" data-dfn-type="attribute" data-export="" id="dom-vttcue-size"><code>size</code></dfn> attribute, on getting, must return the <a data-link-type="dfn" href="#webvtt-cue-size" id="ref-for-webvtt-cue-size-13">WebVTT cue
+size</a> of the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-42">WebVTT cue</a> that the <code class="idl"><a data-link-type="idl" href="#vttcue" id="ref-for-vttcue-12">VTTCue</a></code> object represents. On setting, if the new
+value is negative or greater than 100, then an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror">IndexSizeError</a></code> exception must be thrown.
+Otherwise, the <a data-link-type="dfn" href="#webvtt-cue-size" id="ref-for-webvtt-cue-size-14">WebVTT cue size</a> must be set to the new value.</p>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="VTTCue" data-dfn-type="attribute" data-export="" id="dom-vttcue-align"><code>align</code></dfn> attribute, on getting, must return the string from the
-second cell of the row in the table below whose first cell is the <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment②②">WebVTT cue text alignment</a> of the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue④②">WebVTT cue</a> that the <code class="idl"><a data-link-type="idl" href="#vttcue" id="ref-for-vttcue①②">VTTCue</a></code> object represents:</p>
+second cell of the row in the table below whose first cell is the <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment-23">WebVTT cue text alignment</a> of the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-43">WebVTT cue</a> that the <code class="idl"><a data-link-type="idl" href="#vttcue" id="ref-for-vttcue-13">VTTCue</a></code> object represents:</p>
    <table class="complex data">
     <thead>
      <tr>
-      <th><a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment②③">WebVTT cue text alignment</a>
-      <th><code class="idl"><a data-link-type="idl" href="#dom-vttcue-align" id="ref-for-dom-vttcue-align②">align</a></code> value
+      <th><a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment-24">WebVTT cue text alignment</a>
+      <th><code class="idl"><a data-link-type="idl" href="#dom-vttcue-align" id="ref-for-dom-vttcue-align-3">align</a></code> value
     <tbody>
      <tr>
-      <td><a data-link-type="dfn" href="#webvtt-cue-start-alignment" id="ref-for-webvtt-cue-start-alignment⑧">Start alignment</a>
+      <td><a data-link-type="dfn" href="#webvtt-cue-start-alignment" id="ref-for-webvtt-cue-start-alignment-9">Start alignment</a>
       <td>"<code>start</code>"
      <tr>
-      <td><a data-link-type="dfn" href="#webvtt-cue-center-alignment" id="ref-for-webvtt-cue-center-alignment⑨">Center alignment</a>
+      <td><a data-link-type="dfn" href="#webvtt-cue-center-alignment" id="ref-for-webvtt-cue-center-alignment-10">Center alignment</a>
       <td>"<code>center</code>"
      <tr>
-      <td><a data-link-type="dfn" href="#webvtt-cue-end-alignment" id="ref-for-webvtt-cue-end-alignment⑦">End alignment</a>
+      <td><a data-link-type="dfn" href="#webvtt-cue-end-alignment" id="ref-for-webvtt-cue-end-alignment-8">End alignment</a>
       <td>"<code>end</code>"
      <tr>
-      <td><a data-link-type="dfn" href="#webvtt-cue-left-alignment" id="ref-for-webvtt-cue-left-alignment⑦">Left alignment</a>
+      <td><a data-link-type="dfn" href="#webvtt-cue-left-alignment" id="ref-for-webvtt-cue-left-alignment-8">Left alignment</a>
       <td>"<code>left</code>"
      <tr>
-      <td><a data-link-type="dfn" href="#webvtt-cue-right-alignment" id="ref-for-webvtt-cue-right-alignment⑦">Right alignment</a>
+      <td><a data-link-type="dfn" href="#webvtt-cue-right-alignment" id="ref-for-webvtt-cue-right-alignment-8">Right alignment</a>
       <td>"<code>right</code>"
    </table>
-   <p>On setting, the <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment②④">WebVTT cue text alignment</a> must be set to the value given in the first cell
-of the row in the table above whose second cell is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive②⑨">case-sensitive</a> match for the new
+   <p>On setting, the <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment-25">WebVTT cue text alignment</a> must be set to the value given in the first cell
+of the row in the table above whose second cell is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">case-sensitive</a> match for the new
 value.</p>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="VTTCue" data-dfn-type="attribute" data-export="" id="dom-vttcue-text"><code>text</code></dfn> attribute, on getting, must return the raw <a data-link-type="dfn" href="#text-track-cue-text" id="ref-for-text-track-cue-text①⓪">text track
-cue text</a> of the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue④③">WebVTT cue</a> that the <code class="idl"><a data-link-type="idl" href="#vttcue" id="ref-for-vttcue①③">VTTCue</a></code> object represents. On setting, the <a data-link-type="dfn" href="#text-track-cue-text" id="ref-for-text-track-cue-text①①">text
+   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="VTTCue" data-dfn-type="attribute" data-export="" id="dom-vttcue-text"><code>text</code></dfn> attribute, on getting, must return the raw <a data-link-type="dfn" href="#text-track-cue-text" id="ref-for-text-track-cue-text-11">text track
+cue text</a> of the <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-44">WebVTT cue</a> that the <code class="idl"><a data-link-type="idl" href="#vttcue" id="ref-for-vttcue-14">VTTCue</a></code> object represents. On setting, the <a data-link-type="dfn" href="#text-track-cue-text" id="ref-for-text-track-cue-text-12">text
 track cue text</a> must be set to the new value.</p>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="VTTCue" data-dfn-type="method" data-export="" id="dom-vttcue-getcueashtml"><code>getCueAsHTML()</code></dfn> method must convert the <a data-link-type="dfn" href="#text-track-cue-text" id="ref-for-text-track-cue-text①②">text track cue
-text</a> to a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#documentfragment" id="ref-for-documentfragment⑤">DocumentFragment</a></code> for the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document" id="ref-for-responsible-document">responsible document</a> specified by the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#entry-settings-object" id="ref-for-entry-settings-object">entry
-settings object</a> by applying the <a data-link-type="dfn" href="#webvtt-cue-text-dom-construction-rules" id="ref-for-webvtt-cue-text-dom-construction-rules">WebVTT cue text DOM construction rules</a> to the result of
-applying the <a data-link-type="dfn" href="#webvtt-cue-text-parsing-rules" id="ref-for-webvtt-cue-text-parsing-rules②">WebVTT cue text parsing rules</a> to the <a data-link-type="dfn" href="#text-track-cue-text" id="ref-for-text-track-cue-text①③">text track cue text</a>.</p>
-   <p class="note" role="note">A fallback language is not provided for <code class="idl"><a data-link-type="idl" href="#dom-vttcue-getcueashtml" id="ref-for-dom-vttcue-getcueashtml③">getCueAsHTML()</a></code> since a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#documentfragment" id="ref-for-documentfragment⑥">DocumentFragment</a></code> cannot expose language information.</p>
-   <h3 class="heading settled algorithm" data-algorithm="The VTTRegion interface" data-level="8.2" id="the-vttregion-interface"><span class="secno">8.2. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#vttregion" id="ref-for-vttregion③">VTTRegion</a></code> interface</span><a class="self-link" href="#the-vttregion-interface"></a></h3>
+   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="VTTCue" data-dfn-type="method" data-export="" id="dom-vttcue-getcueashtml"><code>getCueAsHTML()</code></dfn> method must convert the <a data-link-type="dfn" href="#text-track-cue-text" id="ref-for-text-track-cue-text-13">text track cue
+text</a> to a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#documentfragment">DocumentFragment</a></code> for the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document">responsible document</a> specified by the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#entry-settings-object">entry
+settings object</a> by applying the <a data-link-type="dfn" href="#webvtt-cue-text-dom-construction-rules" id="ref-for-webvtt-cue-text-dom-construction-rules-1">WebVTT cue text DOM construction rules</a> to the result of
+applying the <a data-link-type="dfn" href="#webvtt-cue-text-parsing-rules" id="ref-for-webvtt-cue-text-parsing-rules-3">WebVTT cue text parsing rules</a> to the <a data-link-type="dfn" href="#text-track-cue-text" id="ref-for-text-track-cue-text-14">text track cue text</a>.</p>
+   <p class="note" role="note">A fallback language is not provided for <code class="idl"><a data-link-type="idl" href="#dom-vttcue-getcueashtml" id="ref-for-dom-vttcue-getcueashtml-4">getCueAsHTML()</a></code> since a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#documentfragment">DocumentFragment</a></code> cannot expose language information.</p>
+   <h3 class="heading settled algorithm" data-algorithm="The VTTRegion interface" data-level="8.2" id="the-vttregion-interface"><span class="secno">8.2. </span><span class="content">The <code class="idl"><a data-link-type="idl" href="#vttregion" id="ref-for-vttregion-4">VTTRegion</a></code> interface</span><a class="self-link" href="#the-vttregion-interface"></a></h3>
    <p>The following interface is used to expose WebVTT regions in the DOM API:</p>
 <pre class="idl highlight def"><span class="kt">enum</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="enum" data-export="" id="enumdef-scrollsetting"><code>ScrollSetting</code></dfn> { <dfn class="s idl-code" data-dfn-for="ScrollSetting" data-dfn-type="enum-value" data-export="" data-lt="&quot;&quot;|" id="dom-scrollsetting"><code>""</code><a class="self-link" href="#dom-scrollsetting"></a></dfn> /* none */, <dfn class="s idl-code" data-dfn-for="ScrollSetting" data-dfn-type="enum-value" data-export="" data-lt="&quot;up&quot;|up" id="dom-scrollsetting-up"><code>"up"</code><a class="self-link" href="#dom-scrollsetting-up"></a></dfn> };
-[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①">Exposed</a>=<span class="n">Window</span>,
- <a class="nv idl-code" data-link-type="constructor" href="#dom-vttregion-vttregion" id="ref-for-dom-vttregion-vttregion">Constructor</a>]
+[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">Window</span>,
+ <a class="nv idl-code" data-link-type="constructor" href="#dom-vttregion-vttregion" id="ref-for-dom-vttregion-vttregion-1">Constructor</a>]
 <span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="vttregion"><code>VTTRegion</code></dfn> {
-  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="DOMString" href="#dom-vttregion-id" id="ref-for-dom-vttregion-id">id</a>;
-  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double④"><span class="kt">double</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="double" href="#dom-vttregion-width" id="ref-for-dom-vttregion-width">width</a>;
-  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long"><span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="long" href="#dom-vttregion-lines" id="ref-for-dom-vttregion-lines">lines</a>;
-  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑤"><span class="kt">double</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="double" href="#dom-vttregion-regionanchorx" id="ref-for-dom-vttregion-regionanchorx">regionAnchorX</a>;
-  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑥"><span class="kt">double</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="double" href="#dom-vttregion-regionanchory" id="ref-for-dom-vttregion-regionanchory">regionAnchorY</a>;
-  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑦"><span class="kt">double</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="double" href="#dom-vttregion-viewportanchorx" id="ref-for-dom-vttregion-viewportanchorx">viewportAnchorX</a>;
-  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑧"><span class="kt">double</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="double" href="#dom-vttregion-viewportanchory" id="ref-for-dom-vttregion-viewportanchory">viewportAnchorY</a>;
-  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-scrollsetting" id="ref-for-enumdef-scrollsetting">ScrollSetting</a> <a class="nv idl-code" data-link-type="attribute" data-type="ScrollSetting" href="#dom-vttregion-scroll" id="ref-for-dom-vttregion-scroll">scroll</a>;
+  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="DOMString" href="#dom-vttregion-id" id="ref-for-dom-vttregion-id-1">id</a>;
+  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double"><span class="kt">double</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="double" href="#dom-vttregion-width" id="ref-for-dom-vttregion-width-1">width</a>;
+  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long"><span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="long" href="#dom-vttregion-lines" id="ref-for-dom-vttregion-lines-1">lines</a>;
+  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double"><span class="kt">double</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="double" href="#dom-vttregion-regionanchorx" id="ref-for-dom-vttregion-regionanchorx-1">regionAnchorX</a>;
+  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double"><span class="kt">double</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="double" href="#dom-vttregion-regionanchory" id="ref-for-dom-vttregion-regionanchory-1">regionAnchorY</a>;
+  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double"><span class="kt">double</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="double" href="#dom-vttregion-viewportanchorx" id="ref-for-dom-vttregion-viewportanchorx-1">viewportAnchorX</a>;
+  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double"><span class="kt">double</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="double" href="#dom-vttregion-viewportanchory" id="ref-for-dom-vttregion-viewportanchory-1">viewportAnchorY</a>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-scrollsetting" id="ref-for-enumdef-scrollsetting-1">ScrollSetting</a> <a class="nv idl-code" data-link-type="attribute" data-type="ScrollSetting" href="#dom-vttregion-scroll" id="ref-for-dom-vttregion-scroll-1">scroll</a>;
 };
 </pre>
    <dl class="note">
-    <dt><var>region</var> = new <a class="idl-code" data-link-type="constructor" href="#dom-vttregion-vttregion" id="ref-for-dom-vttregion-vttregion①">VTTRegion</a>()
+    <dt><var>region</var> = new <a class="idl-code" data-link-type="constructor" href="#dom-vttregion-vttregion" id="ref-for-dom-vttregion-vttregion-2">VTTRegion</a>()
     <dd>
-     <p>Returns a new <code class="idl"><a data-link-type="idl" href="#vttregion" id="ref-for-vttregion④">VTTRegion</a></code> object.</p>
-    <dt><var>region</var> . <code class="idl"><a data-link-type="idl" href="#dom-vttregion-id" id="ref-for-dom-vttregion-id①">id</a></code>
+     <p>Returns a new <code class="idl"><a data-link-type="idl" href="#vttregion" id="ref-for-vttregion-5">VTTRegion</a></code> object.</p>
+    <dt><var>region</var> . <code class="idl"><a data-link-type="idl" href="#dom-vttregion-id" id="ref-for-dom-vttregion-id-2">id</a></code>
     <dd>
      <p>Returns the text track region identifier. Can be set.</p>
-    <dt><var>region</var> . <code class="idl"><a data-link-type="idl" href="#dom-vttregion-width" id="ref-for-dom-vttregion-width①">width</a></code>
+    <dt><var>region</var> . <code class="idl"><a data-link-type="idl" href="#dom-vttregion-width" id="ref-for-dom-vttregion-width-2">width</a></code>
     <dd>
-     <p>Returns the WebVTT region width as a percentage of the video width. Can be set. Throws an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror" id="ref-for-indexsizeerror②">IndexSizeError</a></code> if the new value is not in the range 0..100.</p>
-    <dt><var>region</var> . <code class="idl"><a data-link-type="idl" href="#dom-vttregion-lines" id="ref-for-dom-vttregion-lines①">lines</a></code>
+     <p>Returns the WebVTT region width as a percentage of the video width. Can be set. Throws an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror">IndexSizeError</a></code> if the new value is not in the range 0..100.</p>
+    <dt><var>region</var> . <code class="idl"><a data-link-type="idl" href="#dom-vttregion-lines" id="ref-for-dom-vttregion-lines-2">lines</a></code>
     <dd>
-     <p>Returns the text track region height as a number of lines. Can be set. Throws an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror" id="ref-for-indexsizeerror③">IndexSizeError</a></code> if the new value is negative.</p>
-    <dt><var>region</var> . <code class="idl"><a data-link-type="idl" href="#dom-vttregion-regionanchorx" id="ref-for-dom-vttregion-regionanchorx①">regionAnchorX</a></code>
+     <p>Returns the text track region height as a number of lines. Can be set. Throws an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror">IndexSizeError</a></code> if the new value is negative.</p>
+    <dt><var>region</var> . <code class="idl"><a data-link-type="idl" href="#dom-vttregion-regionanchorx" id="ref-for-dom-vttregion-regionanchorx-2">regionAnchorX</a></code>
     <dd>
      <p>Returns the WebVTT region anchor X offset as a percentage of the region width. Can be set.
-  Throws an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror" id="ref-for-indexsizeerror④">IndexSizeError</a></code> if the new value is not in the range 0..100.</p>
-    <dt><var>region</var> . <code class="idl"><a data-link-type="idl" href="#dom-vttregion-regionanchory" id="ref-for-dom-vttregion-regionanchory①">regionAnchorY</a></code>
+  Throws an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror">IndexSizeError</a></code> if the new value is not in the range 0..100.</p>
+    <dt><var>region</var> . <code class="idl"><a data-link-type="idl" href="#dom-vttregion-regionanchory" id="ref-for-dom-vttregion-regionanchory-2">regionAnchorY</a></code>
     <dd>
      <p>Returns the WebVTT region anchor Y offset as a percentage of the region height. Can be set.
-  Throws an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror" id="ref-for-indexsizeerror⑤">IndexSizeError</a></code> if the new value is not in the range 0..100.</p>
-    <dt><var>region</var> . <code class="idl"><a data-link-type="idl" href="#dom-vttregion-viewportanchorx" id="ref-for-dom-vttregion-viewportanchorx①">viewportAnchorX</a></code>
+  Throws an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror">IndexSizeError</a></code> if the new value is not in the range 0..100.</p>
+    <dt><var>region</var> . <code class="idl"><a data-link-type="idl" href="#dom-vttregion-viewportanchorx" id="ref-for-dom-vttregion-viewportanchorx-2">viewportAnchorX</a></code>
     <dd>
      <p>Returns the WebVTT region viewport anchor X offset as a percentage of the video width. Can be
-  set. Throws an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror" id="ref-for-indexsizeerror⑥">IndexSizeError</a></code> if the new value is not in the range 0..100.</p>
-    <dt><var>region</var> . <code class="idl"><a data-link-type="idl" href="#dom-vttregion-viewportanchory" id="ref-for-dom-vttregion-viewportanchory①">viewportAnchorY</a></code>
+  set. Throws an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror">IndexSizeError</a></code> if the new value is not in the range 0..100.</p>
+    <dt><var>region</var> . <code class="idl"><a data-link-type="idl" href="#dom-vttregion-viewportanchory" id="ref-for-dom-vttregion-viewportanchory-2">viewportAnchorY</a></code>
     <dd>
      <p>Returns the WebVTT region viewport anchor Y offset as a percentage of the video height. Can be
-  set. Throws an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror" id="ref-for-indexsizeerror⑦">IndexSizeError</a></code> if the new value is not in the range 0..100.</p>
-    <dt><var>region</var> . <code class="idl"><a data-link-type="idl" href="#dom-vttregion-scroll" id="ref-for-dom-vttregion-scroll①">scroll</a></code>
+  set. Throws an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror">IndexSizeError</a></code> if the new value is not in the range 0..100.</p>
+    <dt><var>region</var> . <code class="idl"><a data-link-type="idl" href="#dom-vttregion-scroll" id="ref-for-dom-vttregion-scroll-2">scroll</a></code>
     <dd>
-     <p>Returns a string representing the <a data-link-type="dfn" href="#webvtt-region-scroll" id="ref-for-webvtt-region-scroll③">WebVTT region scroll</a> as follows:</p>
+     <p>Returns a string representing the <a data-link-type="dfn" href="#webvtt-region-scroll" id="ref-for-webvtt-region-scroll-4">WebVTT region scroll</a> as follows:</p>
      <dl class="switch">
       <dt>If it is unset
       <dd>
@@ -5529,64 +5529,64 @@ applying the <a data-link-type="dfn" href="#webvtt-cue-text-parsing-rules" id="r
 following steps:</p>
    <ol class="algorithm">
     <li>
-     <p>Create a new <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region①⑤">WebVTT region</a>. Let <var>region</var> be that <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region①⑥">WebVTT region</a>.</p>
+     <p>Create a new <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region-16">WebVTT region</a>. Let <var>region</var> be that <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region-17">WebVTT region</a>.</p>
     <li>
-     <p>Let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-identifier" id="ref-for-webvtt-region-identifier⑥">WebVTT region identifier</a> be the empty string.</p>
+     <p>Let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-identifier" id="ref-for-webvtt-region-identifier-7">WebVTT region identifier</a> be the empty string.</p>
     <li>
-     <p>Let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-width" id="ref-for-webvtt-region-width⑥">WebVTT region width</a> be 100.</p>
+     <p>Let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-width" id="ref-for-webvtt-region-width-7">WebVTT region width</a> be 100.</p>
     <li>
-     <p>Let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-lines" id="ref-for-webvtt-region-lines③">WebVTT region lines</a> be 3.</p>
+     <p>Let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-lines" id="ref-for-webvtt-region-lines-4">WebVTT region lines</a> be 3.</p>
     <li>
-     <p>Let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-anchor" id="ref-for-webvtt-region-anchor⑥">text track region regionAnchorX</a> be
+     <p>Let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-anchor" id="ref-for-webvtt-region-anchor-7">text track region regionAnchorX</a> be
  0.</p>
     <li>
-     <p>Let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-anchor" id="ref-for-webvtt-region-anchor⑦">text track region regionAnchorY</a> be
+     <p>Let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-anchor" id="ref-for-webvtt-region-anchor-8">text track region regionAnchorY</a> be
  100.</p>
     <li>
-     <p>Let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-viewport-anchor" id="ref-for-webvtt-region-viewport-anchor②">text track region viewportAnchorX</a> be 0.</p>
+     <p>Let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-viewport-anchor" id="ref-for-webvtt-region-viewport-anchor-3">text track region viewportAnchorX</a> be 0.</p>
     <li>
-     <p>Let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-viewport-anchor" id="ref-for-webvtt-region-viewport-anchor③">text track region viewportAnchorY</a> be 100.</p>
+     <p>Let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-viewport-anchor" id="ref-for-webvtt-region-viewport-anchor-4">text track region viewportAnchorY</a> be 100.</p>
     <li>
-     <p>Let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-scroll" id="ref-for-webvtt-region-scroll④">WebVTT region scroll</a> be the empty string.</p>
+     <p>Let <var>region</var>’s <a data-link-type="dfn" href="#webvtt-region-scroll" id="ref-for-webvtt-region-scroll-5">WebVTT region scroll</a> be the empty string.</p>
     <li>
-     <p>Return the <code class="idl"><a data-link-type="idl" href="#vttregion" id="ref-for-vttregion⑤">VTTRegion</a></code> object representing <var>region</var>.</p>
+     <p>Return the <code class="idl"><a data-link-type="idl" href="#vttregion" id="ref-for-vttregion-6">VTTRegion</a></code> object representing <var>region</var>.</p>
    </ol>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="VTTRegion" data-dfn-type="attribute" data-export="" id="dom-vttregion-id"><code>id</code></dfn> attribute, on getting, must return the <a data-link-type="dfn" href="#webvtt-region-identifier" id="ref-for-webvtt-region-identifier⑦">WebVTT region
-identifier</a> of the <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region①⑦">WebVTT region</a> that the <code class="idl"><a data-link-type="idl" href="#vttregion" id="ref-for-vttregion⑥">VTTRegion</a></code> object represents. On setting, the <a data-link-type="dfn" href="#webvtt-region-identifier" id="ref-for-webvtt-region-identifier⑧">WebVTT region identifier</a> must be set to the new value.</p>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="VTTRegion" data-dfn-type="attribute" data-export="" id="dom-vttregion-width"><code>width</code></dfn> attribute, on getting, must return the <a data-link-type="dfn" href="#webvtt-region-width" id="ref-for-webvtt-region-width⑦">WebVTT
-region width</a> of the <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region①⑧">WebVTT region</a> that the <code class="idl"><a data-link-type="idl" href="#vttregion" id="ref-for-vttregion⑦">VTTRegion</a></code> object represents. On setting,
-if the new value is negative or greater than 100, then an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror" id="ref-for-indexsizeerror⑧">IndexSizeError</a></code> exception must be
-thrown. Otherwise, the <a data-link-type="dfn" href="#webvtt-region-width" id="ref-for-webvtt-region-width⑧">WebVTT region width</a> must be set to the new value.</p>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="VTTRegion" data-dfn-type="attribute" data-export="" id="dom-vttregion-lines"><code>lines</code></dfn> attribute, on getting, must return the <a data-link-type="dfn" href="#webvtt-region-lines" id="ref-for-webvtt-region-lines④">WebVTT
-region lines</a> of the <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region①⑨">WebVTT region</a> that the <code class="idl"><a data-link-type="idl" href="#vttregion" id="ref-for-vttregion⑧">VTTRegion</a></code> object represents. On setting,
-if the new value is negative, then an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror" id="ref-for-indexsizeerror⑨">IndexSizeError</a></code> exception must be thrown. Otherwise, the <a data-link-type="dfn" href="#webvtt-region-lines" id="ref-for-webvtt-region-lines⑤">WebVTT region lines</a> must be set to the new value.</p>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="VTTRegion" data-dfn-type="attribute" data-export="" id="dom-vttregion-regionanchorx"><code>regionAnchorX</code></dfn> attribute, on getting, must return the <a data-link-type="dfn" href="#webvtt-region-anchor" id="ref-for-webvtt-region-anchor⑧">WebVTT region anchor</a> X offset of the <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region②⓪">WebVTT region</a> that the <code class="idl"><a data-link-type="idl" href="#vttregion" id="ref-for-vttregion⑨">VTTRegion</a></code> object
-represents. On setting, if the new value is negative or greater than 100, then an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror" id="ref-for-indexsizeerror①⓪">IndexSizeError</a></code> exception must be thrown. Otherwise, the <a data-link-type="dfn" href="#webvtt-region-anchor" id="ref-for-webvtt-region-anchor⑨">WebVTT region anchor</a> X distance must be set to the
+   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="VTTRegion" data-dfn-type="attribute" data-export="" id="dom-vttregion-id"><code>id</code></dfn> attribute, on getting, must return the <a data-link-type="dfn" href="#webvtt-region-identifier" id="ref-for-webvtt-region-identifier-8">WebVTT region
+identifier</a> of the <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region-18">WebVTT region</a> that the <code class="idl"><a data-link-type="idl" href="#vttregion" id="ref-for-vttregion-7">VTTRegion</a></code> object represents. On setting, the <a data-link-type="dfn" href="#webvtt-region-identifier" id="ref-for-webvtt-region-identifier-9">WebVTT region identifier</a> must be set to the new value.</p>
+   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="VTTRegion" data-dfn-type="attribute" data-export="" id="dom-vttregion-width"><code>width</code></dfn> attribute, on getting, must return the <a data-link-type="dfn" href="#webvtt-region-width" id="ref-for-webvtt-region-width-8">WebVTT
+region width</a> of the <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region-19">WebVTT region</a> that the <code class="idl"><a data-link-type="idl" href="#vttregion" id="ref-for-vttregion-8">VTTRegion</a></code> object represents. On setting,
+if the new value is negative or greater than 100, then an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror">IndexSizeError</a></code> exception must be
+thrown. Otherwise, the <a data-link-type="dfn" href="#webvtt-region-width" id="ref-for-webvtt-region-width-9">WebVTT region width</a> must be set to the new value.</p>
+   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="VTTRegion" data-dfn-type="attribute" data-export="" id="dom-vttregion-lines"><code>lines</code></dfn> attribute, on getting, must return the <a data-link-type="dfn" href="#webvtt-region-lines" id="ref-for-webvtt-region-lines-5">WebVTT
+region lines</a> of the <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region-20">WebVTT region</a> that the <code class="idl"><a data-link-type="idl" href="#vttregion" id="ref-for-vttregion-9">VTTRegion</a></code> object represents. On setting,
+if the new value is negative, then an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror">IndexSizeError</a></code> exception must be thrown. Otherwise, the <a data-link-type="dfn" href="#webvtt-region-lines" id="ref-for-webvtt-region-lines-6">WebVTT region lines</a> must be set to the new value.</p>
+   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="VTTRegion" data-dfn-type="attribute" data-export="" id="dom-vttregion-regionanchorx"><code>regionAnchorX</code></dfn> attribute, on getting, must return the <a data-link-type="dfn" href="#webvtt-region-anchor" id="ref-for-webvtt-region-anchor-9">WebVTT region anchor</a> X offset of the <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region-21">WebVTT region</a> that the <code class="idl"><a data-link-type="idl" href="#vttregion" id="ref-for-vttregion-10">VTTRegion</a></code> object
+represents. On setting, if the new value is negative or greater than 100, then an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror">IndexSizeError</a></code> exception must be thrown. Otherwise, the <a data-link-type="dfn" href="#webvtt-region-anchor" id="ref-for-webvtt-region-anchor-10">WebVTT region anchor</a> X distance must be set to the
 new value.</p>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="VTTRegion" data-dfn-type="attribute" data-export="" id="dom-vttregion-regionanchory"><code>regionAnchorY</code></dfn> attribute, on getting, must return the <a data-link-type="dfn" href="#webvtt-region-anchor" id="ref-for-webvtt-region-anchor①⓪">WebVTT region anchor</a> Y offset of the <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region②①">WebVTT region</a> that the <code class="idl"><a data-link-type="idl" href="#vttregion" id="ref-for-vttregion①⓪">VTTRegion</a></code> object
-represents. On setting, if the new value is negative or greater than 100, then an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror" id="ref-for-indexsizeerror①①">IndexSizeError</a></code> exception must be thrown. Otherwise, the <a data-link-type="dfn" href="#webvtt-region-anchor" id="ref-for-webvtt-region-anchor①①">WebVTT region anchor</a> Y distance must be set to the
+   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="VTTRegion" data-dfn-type="attribute" data-export="" id="dom-vttregion-regionanchory"><code>regionAnchorY</code></dfn> attribute, on getting, must return the <a data-link-type="dfn" href="#webvtt-region-anchor" id="ref-for-webvtt-region-anchor-11">WebVTT region anchor</a> Y offset of the <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region-22">WebVTT region</a> that the <code class="idl"><a data-link-type="idl" href="#vttregion" id="ref-for-vttregion-11">VTTRegion</a></code> object
+represents. On setting, if the new value is negative or greater than 100, then an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror">IndexSizeError</a></code> exception must be thrown. Otherwise, the <a data-link-type="dfn" href="#webvtt-region-anchor" id="ref-for-webvtt-region-anchor-12">WebVTT region anchor</a> Y distance must be set to the
 new value.</p>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="VTTRegion" data-dfn-type="attribute" data-export="" id="dom-vttregion-viewportanchorx"><code>viewportAnchorX</code></dfn> attribute, on getting, must return the <a data-link-type="dfn" href="#webvtt-region-viewport-anchor" id="ref-for-webvtt-region-viewport-anchor④">WebVTT region viewport anchor</a> X offset of the <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region②②">WebVTT region</a> that the <code class="idl"><a data-link-type="idl" href="#vttregion" id="ref-for-vttregion①①">VTTRegion</a></code> object represents. On setting, if the new value is negative or greater than 100, then an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror" id="ref-for-indexsizeerror①②">IndexSizeError</a></code> exception must be thrown. Otherwise, the <a data-link-type="dfn" href="#webvtt-region-viewport-anchor" id="ref-for-webvtt-region-viewport-anchor⑤">WebVTT region viewport anchor</a> X
+   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="VTTRegion" data-dfn-type="attribute" data-export="" id="dom-vttregion-viewportanchorx"><code>viewportAnchorX</code></dfn> attribute, on getting, must return the <a data-link-type="dfn" href="#webvtt-region-viewport-anchor" id="ref-for-webvtt-region-viewport-anchor-5">WebVTT region viewport anchor</a> X offset of the <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region-23">WebVTT region</a> that the <code class="idl"><a data-link-type="idl" href="#vttregion" id="ref-for-vttregion-12">VTTRegion</a></code> object represents. On setting, if the new value is negative or greater than 100, then an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror">IndexSizeError</a></code> exception must be thrown. Otherwise, the <a data-link-type="dfn" href="#webvtt-region-viewport-anchor" id="ref-for-webvtt-region-viewport-anchor-6">WebVTT region viewport anchor</a> X
 distance must be set to the new value.</p>
-   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="VTTRegion" data-dfn-type="attribute" data-export="" id="dom-vttregion-viewportanchory"><code>viewportAnchorY</code></dfn> attribute, on getting, must return the <a data-link-type="dfn" href="#webvtt-region-viewport-anchor" id="ref-for-webvtt-region-viewport-anchor⑥">WebVTT region viewport anchor</a> Y offset of the <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region②③">WebVTT region</a> that the <code class="idl"><a data-link-type="idl" href="#vttregion" id="ref-for-vttregion①②">VTTRegion</a></code> object represents. On setting, if the new value is negative or greater than 100, then an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror" id="ref-for-indexsizeerror①③">IndexSizeError</a></code> exception must be thrown. Otherwise, the <a data-link-type="dfn" href="#webvtt-region-viewport-anchor" id="ref-for-webvtt-region-viewport-anchor⑦">WebVTT region viewport anchor</a> Y
+   <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="VTTRegion" data-dfn-type="attribute" data-export="" id="dom-vttregion-viewportanchory"><code>viewportAnchorY</code></dfn> attribute, on getting, must return the <a data-link-type="dfn" href="#webvtt-region-viewport-anchor" id="ref-for-webvtt-region-viewport-anchor-7">WebVTT region viewport anchor</a> Y offset of the <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region-24">WebVTT region</a> that the <code class="idl"><a data-link-type="idl" href="#vttregion" id="ref-for-vttregion-13">VTTRegion</a></code> object represents. On setting, if the new value is negative or greater than 100, then an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror">IndexSizeError</a></code> exception must be thrown. Otherwise, the <a data-link-type="dfn" href="#webvtt-region-viewport-anchor" id="ref-for-webvtt-region-viewport-anchor-8">WebVTT region viewport anchor</a> Y
 distance must be set to the new value.</p>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="VTTRegion" data-dfn-type="attribute" data-export="" id="dom-vttregion-scroll"><code>scroll</code></dfn> attribute, on getting, must return the string from
-the second cell of the row in the table below whose first cell is the <a data-link-type="dfn" href="#webvtt-region-scroll" id="ref-for-webvtt-region-scroll⑤">WebVTT region scroll</a> setting of the <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region②④">WebVTT region</a> that the <code class="idl"><a data-link-type="idl" href="#vttregion" id="ref-for-vttregion①③">VTTRegion</a></code> object represents:</p>
+the second cell of the row in the table below whose first cell is the <a data-link-type="dfn" href="#webvtt-region-scroll" id="ref-for-webvtt-region-scroll-6">WebVTT region scroll</a> setting of the <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region-25">WebVTT region</a> that the <code class="idl"><a data-link-type="idl" href="#vttregion" id="ref-for-vttregion-14">VTTRegion</a></code> object represents:</p>
    <table class="complex data">
     <thead>
      <tr>
-      <th><a data-link-type="dfn" href="#webvtt-region-scroll" id="ref-for-webvtt-region-scroll⑥">WebVTT region scroll</a>
-      <th><code class="idl"><a data-link-type="idl" href="#dom-vttregion-scroll" id="ref-for-dom-vttregion-scroll②">scroll</a></code> value
+      <th><a data-link-type="dfn" href="#webvtt-region-scroll" id="ref-for-webvtt-region-scroll-7">WebVTT region scroll</a>
+      <th><code class="idl"><a data-link-type="idl" href="#dom-vttregion-scroll" id="ref-for-dom-vttregion-scroll-3">scroll</a></code> value
     <tbody>
      <tr>
-      <td><a data-link-type="dfn" href="#webvtt-region-scroll-none" id="ref-for-webvtt-region-scroll-none①">None</a>
+      <td><a data-link-type="dfn" href="#webvtt-region-scroll-none" id="ref-for-webvtt-region-scroll-none-2">None</a>
       <td>"<code></code>" (the empty string)
      <tr>
-      <td><a data-link-type="dfn" href="#webvtt-region-scroll-up" id="ref-for-webvtt-region-scroll-up②">Up</a>
+      <td><a data-link-type="dfn" href="#webvtt-region-scroll-up" id="ref-for-webvtt-region-scroll-up-3">Up</a>
       <td>"<code>up</code>"
    </table>
-   <p>On setting, the <a data-link-type="dfn" href="#webvtt-region-scroll" id="ref-for-webvtt-region-scroll⑦">WebVTT region scroll</a> must be set to the value given on the first cell of
-the row in the table above whose second cell is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive" id="ref-for-case-sensitive③⓪">case-sensitive</a> match for the new value.</p>
+   <p>On setting, the <a data-link-type="dfn" href="#webvtt-region-scroll" id="ref-for-webvtt-region-scroll-8">WebVTT region scroll</a> must be set to the value given on the first cell of
+the row in the table above whose second cell is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#case-sensitive">case-sensitive</a> match for the new value.</p>
    <h2 class="heading settled" data-level="9" id="iana"><span class="secno">9. </span><span class="content">IANA considerations</span><a class="self-link" href="#iana"></a></h2>
    <h3 class="heading settled" data-level="9.1" id="iana-text-vtt"><span class="secno">9.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="text-vtt"><code>text/vtt</code></dfn></span><a class="self-link" href="#iana-text-vtt"></a></h3>
    <p>This registration is for community review and will be submitted to the IESG for review, approval,
@@ -5673,7 +5673,7 @@ current time in that video.</p>
    <p>It is possible for a user agent to offer user style sheets, but their presence and nature will
 not be detectable by scripts running in the same user agent (e.g. browser) since the CSS object
 model for such style sheets is not exposed to script and there is no way to get the computed style
-for pseudo-elements other than <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-3/#sel-before" id="ref-for-sel-before">::before</a> and <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-3/#sel-after" id="ref-for-sel-after">::after</a> with the <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle" id="ref-for-dom-window-getcomputedstyle">getComputedStyle()</a></code> API. <a data-link-type="biblio" href="#biblio-cssom">[CSSOM]</a></p>
+for pseudo-elements other than <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-3/#sel-before">::before</a> and <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/selectors-3/#sel-after">::after</a> with the <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle">getComputedStyle()</a></code> API. <a data-link-type="biblio" href="#biblio-cssom">[CSSOM]</a></p>
    <h3 class="heading settled" id="scripting-security"><span class="content">Scripting-related security</span><a class="self-link" href="#scripting-security"></a></h3>
    <p>WebVTT does not include or enable scripting. It is important that user agents do not support a
 way to execute script embedded in a WebVTT file.</p>
@@ -5685,7 +5685,7 @@ triggers at their timestamps, a malicious file might present such triggers very 
 causing undue resource consumption.</p>
    <h3 class="heading settled" id="privacy-of-preference"><span class="content">Privacy of preference</span><a class="self-link" href="#privacy-of-preference"></a></h3>
    <p>A user agent that selects, and causes to download or interpret a WebVTT file, might indicate to
-the origin server that the user has a need for captions or subtitles, and also the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#honor-user-preferences-for-automatic-text-track-selection" id="ref-for-honor-user-preferences-for-automatic-text-track-selection">language preference</a> of the user for captions or
+the origin server that the user has a need for captions or subtitles, and also the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#honor-user-preferences-for-automatic-text-track-selection">language preference</a> of the user for captions or
 subtitles. That is a (small) piece of information about the user. However, the offering of a caption
 file, and the choice whether to retrieve and consume it, are really characteristics of the format or
 protocol which does the offer (e.g. the HTML element), rather than of the caption format itself. <a data-link-type="biblio" href="#biblio-html">[HTML]</a></p>
@@ -5987,6 +5987,12 @@ originally specified. <a data-link-type="biblio" href="#biblio-html">[HTML]</a><
      <li><a href="https://drafts.csswg.org/css-align-3/#propdef-justify-content">justify-content</a>
     </ul>
    <li>
+    <a data-link-type="biblio">[css-backgrounds-3]</a> defines the following terms:
+    <ul>
+     <li><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">background</a>
+     <li><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">background-image</a>
+    </ul>
+   <li>
     <a data-link-type="biblio">[css-cascade-4]</a> defines the following terms:
     <ul>
      <li><a href="https://drafts.csswg.org/css-cascade-4/#at-ruledef-import">@import</a>
@@ -6065,12 +6071,12 @@ originally specified. <a data-link-type="biblio" href="#biblio-html">[HTML]</a><
      <li><a href="https://drafts.csswg.org/css-text-decor-3/#propdef-text-shadow">text-shadow</a>
     </ul>
    <li>
-    <a data-link-type="biblio">[css-ui-3]</a> defines the following terms:
+    <a data-link-type="biblio">[css-ui-4]</a> defines the following terms:
     <ul>
-     <li><a href="https://drafts.csswg.org/css-ui-3/#propdef-outline">outline</a>
+     <li><a href="https://drafts.csswg.org/css-ui-4/#propdef-outline">outline</a>
     </ul>
    <li>
-    <a data-link-type="biblio">[css-values-4]</a> defines the following terms:
+    <a data-link-type="biblio">[CSS-VALUES]</a> defines the following terms:
     <ul>
      <li><a href="https://drafts.csswg.org/css-values-4/#vh">vh</a>
      <li><a href="https://drafts.csswg.org/css-values-4/#vw">vw</a>
@@ -6097,12 +6103,6 @@ originally specified. <a data-link-type="biblio" href="#biblio-html">[HTML]</a><
      <li><a href="https://drafts.csswg.org/css2/visudet.html#propdef-min-height">min-height</a>
      <li><a href="https://drafts.csswg.org/css2/visufx.html#propdef-visibility">visibility</a>
      <li><a href="https://drafts.csswg.org/css2/visudet.html#propdef-width">width</a>
-    </ul>
-   <li>
-    <a data-link-type="biblio">[css3-background]</a> defines the following terms:
-    <ul>
-     <li><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">background</a>
-     <li><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">background-image</a>
     </ul>
    <li>
     <a data-link-type="biblio">[CSS3-RUBY]</a> defines the following terms:
@@ -6217,8 +6217,10 @@ originally specified. <a data-link-type="biblio" href="#biblio-html">[HTML]</a><
    <dd>Mark Davis; Aharon Lanin; Andrew Glass. <a href="https://www.unicode.org/reports/tr9/tr9-37.html">Unicode Bidirectional Algorithm</a>. 14 May 2017. Unicode Standard Annex #9. URL: <a href="https://www.unicode.org/reports/tr9/tr9-37.html">https://www.unicode.org/reports/tr9/tr9-37.html</a>
    <dt id="biblio-css-align-3">[CSS-ALIGN-3]
    <dd>Elika Etemad; Tab Atkins Jr.. <a href="https://drafts.csswg.org/css-align/">CSS Box Alignment Module Level 3</a>. URL: <a href="https://drafts.csswg.org/css-align/">https://drafts.csswg.org/css-align/</a>
+   <dt id="biblio-css-backgrounds-3">[CSS-BACKGROUNDS-3]
+   <dd>Bert Bos; Elika Etemad; Brad Kemper. <a href="https://drafts.csswg.org/css-backgrounds/">CSS Backgrounds and Borders Module Level 3</a>. URL: <a href="https://drafts.csswg.org/css-backgrounds/">https://drafts.csswg.org/css-backgrounds/</a>
    <dt id="biblio-css-cascade-4">[CSS-CASCADE-4]
-   <dd>Elika Etemad; Tab Atkins Jr.. <a href="http://dev.w3.org/csswg/css-cascade/">CSS Cascading and Inheritance Level 4</a>. URL: <a href="http://dev.w3.org/csswg/css-cascade/">http://dev.w3.org/csswg/css-cascade/</a>
+   <dd>Elika Etemad; Tab Atkins Jr.. <a href="https://drafts.csswg.org/css-cascade/">CSS Cascading and Inheritance Level 4</a>. URL: <a href="https://drafts.csswg.org/css-cascade/">https://drafts.csswg.org/css-cascade/</a>
    <dt id="biblio-css-color-4">[CSS-COLOR-4]
    <dd>Tab Atkins Jr.; Chris Lilley. <a href="https://drafts.csswg.org/css-color/">CSS Color Module Level 4</a>. URL: <a href="https://drafts.csswg.org/css-color/">https://drafts.csswg.org/css-color/</a>
    <dt id="biblio-css-display-3">[CSS-DISPLAY-3]
@@ -6226,7 +6228,7 @@ originally specified. <a data-link-type="biblio" href="#biblio-html">[HTML]</a><
    <dt id="biblio-css-flexbox-1">[CSS-FLEXBOX-1]
    <dd>Tab Atkins Jr.; Elika Etemad; Rossen Atanassov. <a href="https://drafts.csswg.org/css-flexbox/">CSS Flexible Box Layout Module Level 1</a>. URL: <a href="https://drafts.csswg.org/css-flexbox/">https://drafts.csswg.org/css-flexbox/</a>
    <dt id="biblio-css-fonts-3">[CSS-FONTS-3]
-   <dd>John Daggett. <a href="http://dev.w3.org/csswg/css-fonts/">CSS Fonts Module Level 3</a>. URL: <a href="http://dev.w3.org/csswg/css-fonts/">http://dev.w3.org/csswg/css-fonts/</a>
+   <dd>John Daggett. <a href="https://drafts.csswg.org/css-fonts/">CSS Fonts Module Level 3</a>. URL: <a href="https://drafts.csswg.org/css-fonts/">https://drafts.csswg.org/css-fonts/</a>
    <dt id="biblio-css-fonts-4">[CSS-FONTS-4]
    <dd>John Daggett; Myles Maxfield. <a href="https://drafts.csswg.org/css-fonts-4/">CSS Fonts Module Level 4</a>. URL: <a href="https://drafts.csswg.org/css-fonts-4/">https://drafts.csswg.org/css-fonts-4/</a>
    <dt id="biblio-css-overflow-3">[CSS-OVERFLOW-3]
@@ -6234,31 +6236,31 @@ originally specified. <a data-link-type="biblio" href="#biblio-html">[HTML]</a><
    <dt id="biblio-css-position-3">[CSS-POSITION-3]
    <dd>Rossen Atanassov; Arron Eicholz. <a href="https://drafts.csswg.org/css-position/">CSS Positioned Layout Module Level 3</a>. URL: <a href="https://drafts.csswg.org/css-position/">https://drafts.csswg.org/css-position/</a>
    <dt id="biblio-css-syntax-3">[CSS-SYNTAX-3]
-   <dd>Tab Atkins Jr.; Simon Sapin. <a href="http://dev.w3.org/csswg/css-syntax/">CSS Syntax Module Level 3</a>. URL: <a href="http://dev.w3.org/csswg/css-syntax/">http://dev.w3.org/csswg/css-syntax/</a>
+   <dd>Tab Atkins Jr.; Simon Sapin. <a href="https://drafts.csswg.org/css-syntax/">CSS Syntax Module Level 3</a>. URL: <a href="https://drafts.csswg.org/css-syntax/">https://drafts.csswg.org/css-syntax/</a>
    <dt id="biblio-css-text-3">[CSS-TEXT-3]
    <dd>Elika Etemad; Koji Ishii. <a href="https://drafts.csswg.org/css-text-3/">CSS Text Module Level 3</a>. URL: <a href="https://drafts.csswg.org/css-text-3/">https://drafts.csswg.org/css-text-3/</a>
    <dt id="biblio-css-text-4">[CSS-TEXT-4]
-   <dd>Elika Etemad; Koji Ishii; Alan Stearns. <a href="http://dev.w3.org/csswg/css-text-4/">CSS Text Module Level 4</a>. URL: <a href="http://dev.w3.org/csswg/css-text-4/">http://dev.w3.org/csswg/css-text-4/</a>
+   <dd>Elika Etemad; Koji Ishii; Alan Stearns. <a href="https://drafts.csswg.org/css-text-4/">CSS Text Module Level 4</a>. URL: <a href="https://drafts.csswg.org/css-text-4/">https://drafts.csswg.org/css-text-4/</a>
    <dt id="biblio-css-text-decor-3">[CSS-TEXT-DECOR-3]
-   <dd>Elika Etemad; Koji Ishii. <a href="http://dev.w3.org/csswg/css-text-decor-3/">CSS Text Decoration Module Level 3</a>. URL: <a href="http://dev.w3.org/csswg/css-text-decor-3/">http://dev.w3.org/csswg/css-text-decor-3/</a>
-   <dt id="biblio-css-ui-3">[CSS-UI-3]
-   <dd>Tantek Çelik; Florian Rivoal. <a href="https://drafts.csswg.org/css-ui/">CSS Basic User Interface Module Level 3 (CSS3 UI)</a>. URL: <a href="https://drafts.csswg.org/css-ui/">https://drafts.csswg.org/css-ui/</a>
+   <dd>Elika Etemad; Koji Ishii. <a href="https://drafts.csswg.org/css-text-decor-3/">CSS Text Decoration Module Level 3</a>. URL: <a href="https://drafts.csswg.org/css-text-decor-3/">https://drafts.csswg.org/css-text-decor-3/</a>
+   <dt id="biblio-css-ui-4">[CSS-UI-4]
+   <dd>Florian Rivoal. <a href="https://drafts.csswg.org/css-ui-4/">CSS Basic User Interface Module Level 4</a>. URL: <a href="https://drafts.csswg.org/css-ui-4/">https://drafts.csswg.org/css-ui-4/</a>
    <dt id="biblio-css-values">[CSS-VALUES]
    <dd>Tab Atkins Jr.; Elika Etemad. <a href="https://drafts.csswg.org/css-values/">CSS Values and Units Module Level 3</a>. URL: <a href="https://drafts.csswg.org/css-values/">https://drafts.csswg.org/css-values/</a>
    <dt id="biblio-css-writing-modes-3">[CSS-WRITING-MODES-3]
-   <dd>Elika Etemad; Koji Ishii. <a href="http://dev.w3.org/csswg/css-writing-modes-3/">CSS Writing Modes Level 3</a>. URL: <a href="http://dev.w3.org/csswg/css-writing-modes-3/">http://dev.w3.org/csswg/css-writing-modes-3/</a>
+   <dd>Elika Etemad; Koji Ishii. <a href="https://drafts.csswg.org/css-writing-modes-3/">CSS Writing Modes Level 3</a>. URL: <a href="https://drafts.csswg.org/css-writing-modes-3/">https://drafts.csswg.org/css-writing-modes-3/</a>
+   <dt id="biblio-css-writing-modes-4">[CSS-WRITING-MODES-4]
+   <dd>CSS Writing Modes Module Level 4 URL: <a href="https://drafts.csswg.org/css-writing-modes-4/">https://drafts.csswg.org/css-writing-modes-4/</a>
    <dt id="biblio-css22">[CSS22]
-   <dd>Bert Bos. <a href="http://dev.w3.org/csswg/css2/">Cascading Style Sheets Level 2 Revision 2 (CSS 2.2) Specification</a>. URL: <a href="http://dev.w3.org/csswg/css2/">http://dev.w3.org/csswg/css2/</a>
-   <dt id="biblio-css3-background">[CSS3-BACKGROUND]
-   <dd>Bert Bos; Elika Etemad; Brad Kemper. <a href="http://dev.w3.org/csswg/css3-background/">CSS Backgrounds and Borders Module Level 3</a>. URL: <a href="http://dev.w3.org/csswg/css3-background/">http://dev.w3.org/csswg/css3-background/</a>
+   <dd>Bert Bos. <a href="https://drafts.csswg.org/css2/">Cascading Style Sheets Level 2 Revision 2 (CSS 2.2) Specification</a>. URL: <a href="https://drafts.csswg.org/css2/">https://drafts.csswg.org/css2/</a>
    <dt id="biblio-css3-color">[CSS3-COLOR]
    <dd>Tantek Çelik; Chris Lilley; David Baron. <a href="https://www.w3.org/TR/css3-color">CSS Color Module Level 3</a>. 7 June 2011. REC. URL: <a href="https://www.w3.org/TR/css3-color">https://www.w3.org/TR/css3-color</a>
    <dt id="biblio-css3-ruby">[CSS3-RUBY]
-   <dd>Elika Etemad; Koji Ishii. <a href="http://dev.w3.org/csswg/css-ruby-1/">CSS Ruby Layout Module Level 1</a>. URL: <a href="http://dev.w3.org/csswg/css-ruby-1/">http://dev.w3.org/csswg/css-ruby-1/</a>
+   <dd>Elika Etemad; Koji Ishii. <a href="https://drafts.csswg.org/css-ruby-1/">CSS Ruby Layout Module Level 1</a>. URL: <a href="https://drafts.csswg.org/css-ruby-1/">https://drafts.csswg.org/css-ruby-1/</a>
    <dt id="biblio-css3-selectors">[CSS3-SELECTORS]
-   <dd>Tantek Çelik; et al. <a href="https://www.w3.org/TR/css3-selectors/">Selectors Level 3</a>. 29 September 2011. REC. URL: <a href="https://www.w3.org/TR/css3-selectors/">https://www.w3.org/TR/css3-selectors/</a>
+   <dd>Tantek Çelik; et al. <a href="https://drafts.csswg.org/selectors-3/">Selectors Level 3</a>. URL: <a href="https://drafts.csswg.org/selectors-3/">https://drafts.csswg.org/selectors-3/</a>
    <dt id="biblio-css3-transitions">[CSS3-TRANSITIONS]
-   <dd>Dean Jackson; et al. <a href="http://dev.w3.org/csswg/css-transitions/">CSS Transitions</a>. URL: <a href="http://dev.w3.org/csswg/css-transitions/">http://dev.w3.org/csswg/css-transitions/</a>
+   <dd>Dean Jackson; et al. <a href="https://drafts.csswg.org/css-transitions/">CSS Transitions</a>. URL: <a href="https://drafts.csswg.org/css-transitions/">https://drafts.csswg.org/css-transitions/</a>
    <dt id="biblio-cssom">[CSSOM]
    <dd>Simon Pieters; Glenn Adams. <a href="https://drafts.csswg.org/cssom/">CSS Object Model (CSSOM)</a>. URL: <a href="https://drafts.csswg.org/cssom/">https://drafts.csswg.org/cssom/</a>
    <dt id="biblio-dom">[DOM]
@@ -6285,1309 +6287,1309 @@ originally specified. <a data-link-type="biblio" href="#biblio-html">[HTML]</a><
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
 <pre class="idl highlight def"><span class="kt">enum</span> <a class="nv" href="#enumdef-autokeyword"><code>AutoKeyword</code></a> { <a class="s" href="#dom-autokeyword-auto"><code>"auto"</code></a> };
-<span class="kt">typedef</span> (<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑨"><span class="kt">double</span></a> <span class="kt">or</span> <a class="n" data-link-type="idl-name" href="#enumdef-autokeyword" id="ref-for-enumdef-autokeyword①">AutoKeyword</a>) <a class="nv" href="#typedefdef-lineandpositionsetting"><code>LineAndPositionSetting</code></a>;
+<span class="kt">typedef</span> (<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double"><span class="kt">double</span></a> <span class="kt">or</span> <a class="n" data-link-type="idl-name" href="#enumdef-autokeyword">AutoKeyword</a>) <a class="nv" href="#typedefdef-lineandpositionsetting"><code>LineAndPositionSetting</code></a>;
 <span class="kt">enum</span> <a class="nv" href="#enumdef-directionsetting"><code>DirectionSetting</code></a> { <a class="s" href="#dom-directionsetting"><code>""</code></a> /* horizontal */, <a class="s" href="#dom-directionsetting-rl"><code>"rl"</code></a>, <a class="s" href="#dom-directionsetting-lr"><code>"lr"</code></a> };
 <span class="kt">enum</span> <a class="nv" href="#enumdef-linealignsetting"><code>LineAlignSetting</code></a> { <a class="s" href="#dom-linealignsetting-start"><code>"start"</code></a>, <a class="s" href="#dom-linealignsetting-center"><code>"center"</code></a>, <a class="s" href="#dom-linealignsetting-end"><code>"end"</code></a> };
 <span class="kt">enum</span> <a class="nv" href="#enumdef-positionalignsetting"><code>PositionAlignSetting</code></a> { <a class="s" href="#dom-positionalignsetting-line-left"><code>"line-left"</code></a>, <a class="s" href="#dom-positionalignsetting-center"><code>"center"</code></a>, <a class="s" href="#dom-positionalignsetting-line-right"><code>"line-right"</code></a>, <a class="s" href="#dom-positionalignsetting-auto"><code>"auto"</code></a> };
 <span class="kt">enum</span> <a class="nv" href="#enumdef-alignsetting"><code>AlignSetting</code></a> { <a class="s" href="#dom-alignsetting-start"><code>"start"</code></a>, <a class="s" href="#dom-alignsetting-center"><code>"center"</code></a>, <a class="s" href="#dom-alignsetting-end"><code>"end"</code></a>, <a class="s" href="#dom-alignsetting-left"><code>"left"</code></a>, <a class="s" href="#dom-alignsetting-right"><code>"right"</code></a> };
-[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed②">Exposed</a>=<span class="n">Window</span>,
- <a class="nv idl-code" data-link-type="constructor" href="#dom-vttcue-vttcue" id="ref-for-dom-vttcue-vttcue②">Constructor</a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①①"><span class="kt">double</span></a> <a class="nv" href="#dom-vttcue-vttcue-starttime-endtime-text-starttime"><code>startTime</code></a>, <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②①"><span class="kt">double</span></a> <a class="nv" href="#dom-vttcue-vttcue-starttime-endtime-text-endtime"><code>endTime</code></a>, <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString③"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-vttcue-vttcue-starttime-endtime-text-text"><code>text</code></a>)]
-<span class="kt">interface</span> <a class="nv" href="#vttcue"><code>VTTCue</code></a> : <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/media.html#texttrackcue" id="ref-for-texttrackcue①">TextTrackCue</a> {
-  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#vttregion" id="ref-for-vttregion①④">VTTRegion</a>? <a class="nv idl-code" data-link-type="attribute" data-type="VTTRegion?" href="#dom-vttcue-region" id="ref-for-dom-vttcue-region②">region</a>;
-  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-directionsetting" id="ref-for-enumdef-directionsetting①">DirectionSetting</a> <a class="nv idl-code" data-link-type="attribute" data-type="DirectionSetting" href="#dom-vttcue-vertical" id="ref-for-dom-vttcue-vertical③">vertical</a>;
-  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="boolean" href="#dom-vttcue-snaptolines" id="ref-for-dom-vttcue-snaptolines①①">snapToLines</a>;
-  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#typedefdef-lineandpositionsetting" id="ref-for-typedefdef-lineandpositionsetting②">LineAndPositionSetting</a> <a class="nv idl-code" data-link-type="attribute" data-type="LineAndPositionSetting" href="#dom-vttcue-line" id="ref-for-dom-vttcue-line①①">line</a>;
-  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-linealignsetting" id="ref-for-enumdef-linealignsetting①">LineAlignSetting</a> <a class="nv idl-code" data-link-type="attribute" data-type="LineAlignSetting" href="#dom-vttcue-linealign" id="ref-for-dom-vttcue-linealign③">lineAlign</a>;
-  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#typedefdef-lineandpositionsetting" id="ref-for-typedefdef-lineandpositionsetting①①">LineAndPositionSetting</a> <a class="nv idl-code" data-link-type="attribute" data-type="LineAndPositionSetting" href="#dom-vttcue-position" id="ref-for-dom-vttcue-position②">position</a>;
-  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-positionalignsetting" id="ref-for-enumdef-positionalignsetting①">PositionAlignSetting</a> <a class="nv idl-code" data-link-type="attribute" data-type="PositionAlignSetting" href="#dom-vttcue-positionalign" id="ref-for-dom-vttcue-positionalign③">positionAlign</a>;
-  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double③①"><span class="kt">double</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="double" href="#dom-vttcue-size" id="ref-for-dom-vttcue-size②">size</a>;
-  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-alignsetting" id="ref-for-enumdef-alignsetting①">AlignSetting</a> <a class="nv idl-code" data-link-type="attribute" data-type="AlignSetting" href="#dom-vttcue-align" id="ref-for-dom-vttcue-align③">align</a>;
-  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①①"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="DOMString" href="#dom-vttcue-text" id="ref-for-dom-vttcue-text②">text</a>;
-  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#documentfragment" id="ref-for-documentfragment③①">DocumentFragment</a> <a class="nv idl-code" data-link-type="method" href="#dom-vttcue-getcueashtml" id="ref-for-dom-vttcue-getcueashtml①①">getCueAsHTML</a>();
+[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">Window</span>,
+ <a class="nv idl-code" data-link-type="constructor" href="#dom-vttcue-vttcue">Constructor</a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double"><span class="kt">double</span></a> <a class="nv" href="#dom-vttcue-vttcue-starttime-endtime-text-starttime"><code>startTime</code></a>, <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double"><span class="kt">double</span></a> <a class="nv" href="#dom-vttcue-vttcue-starttime-endtime-text-endtime"><code>endTime</code></a>, <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-vttcue-vttcue-starttime-endtime-text-text"><code>text</code></a>)]
+<span class="kt">interface</span> <a class="nv" href="#vttcue"><code>VTTCue</code></a> : <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/media.html#texttrackcue">TextTrackCue</a> {
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#vttregion">VTTRegion</a>? <a class="nv idl-code" data-link-type="attribute" data-type="VTTRegion?" href="#dom-vttcue-region">region</a>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-directionsetting">DirectionSetting</a> <a class="nv idl-code" data-link-type="attribute" data-type="DirectionSetting" href="#dom-vttcue-vertical">vertical</a>;
+  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="boolean" href="#dom-vttcue-snaptolines">snapToLines</a>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#typedefdef-lineandpositionsetting">LineAndPositionSetting</a> <a class="nv idl-code" data-link-type="attribute" data-type="LineAndPositionSetting" href="#dom-vttcue-line">line</a>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-linealignsetting">LineAlignSetting</a> <a class="nv idl-code" data-link-type="attribute" data-type="LineAlignSetting" href="#dom-vttcue-linealign">lineAlign</a>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#typedefdef-lineandpositionsetting">LineAndPositionSetting</a> <a class="nv idl-code" data-link-type="attribute" data-type="LineAndPositionSetting" href="#dom-vttcue-position">position</a>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-positionalignsetting">PositionAlignSetting</a> <a class="nv idl-code" data-link-type="attribute" data-type="PositionAlignSetting" href="#dom-vttcue-positionalign">positionAlign</a>;
+  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double"><span class="kt">double</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="double" href="#dom-vttcue-size">size</a>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-alignsetting">AlignSetting</a> <a class="nv idl-code" data-link-type="attribute" data-type="AlignSetting" href="#dom-vttcue-align">align</a>;
+  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="DOMString" href="#dom-vttcue-text">text</a>;
+  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#documentfragment">DocumentFragment</a> <a class="nv idl-code" data-link-type="method" href="#dom-vttcue-getcueashtml">getCueAsHTML</a>();
 };
 
 <span class="kt">enum</span> <a class="nv" href="#enumdef-scrollsetting"><code>ScrollSetting</code></a> { <a class="s" href="#dom-scrollsetting"><code>""</code></a> /* none */, <a class="s" href="#dom-scrollsetting-up"><code>"up"</code></a> };
-[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①①">Exposed</a>=<span class="n">Window</span>,
- <a class="nv idl-code" data-link-type="constructor" href="#dom-vttregion-vttregion" id="ref-for-dom-vttregion-vttregion②">Constructor</a>]
+[<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">Window</span>,
+ <a class="nv idl-code" data-link-type="constructor" href="#dom-vttregion-vttregion">Constructor</a>]
 <span class="kt">interface</span> <a class="nv" href="#vttregion"><code>VTTRegion</code></a> {
-  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②①"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="DOMString" href="#dom-vttregion-id" id="ref-for-dom-vttregion-id②">id</a>;
-  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double④①"><span class="kt">double</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="double" href="#dom-vttregion-width" id="ref-for-dom-vttregion-width②">width</a>;
-  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①"><span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="long" href="#dom-vttregion-lines" id="ref-for-dom-vttregion-lines②">lines</a>;
-  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑤①"><span class="kt">double</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="double" href="#dom-vttregion-regionanchorx" id="ref-for-dom-vttregion-regionanchorx②">regionAnchorX</a>;
-  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑥①"><span class="kt">double</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="double" href="#dom-vttregion-regionanchory" id="ref-for-dom-vttregion-regionanchory②">regionAnchorY</a>;
-  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑦①"><span class="kt">double</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="double" href="#dom-vttregion-viewportanchorx" id="ref-for-dom-vttregion-viewportanchorx②">viewportAnchorX</a>;
-  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑧①"><span class="kt">double</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="double" href="#dom-vttregion-viewportanchory" id="ref-for-dom-vttregion-viewportanchory②">viewportAnchorY</a>;
-  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-scrollsetting" id="ref-for-enumdef-scrollsetting①">ScrollSetting</a> <a class="nv idl-code" data-link-type="attribute" data-type="ScrollSetting" href="#dom-vttregion-scroll" id="ref-for-dom-vttregion-scroll③">scroll</a>;
+  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="DOMString" href="#dom-vttregion-id">id</a>;
+  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double"><span class="kt">double</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="double" href="#dom-vttregion-width">width</a>;
+  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long"><span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="long" href="#dom-vttregion-lines">lines</a>;
+  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double"><span class="kt">double</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="double" href="#dom-vttregion-regionanchorx">regionAnchorX</a>;
+  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double"><span class="kt">double</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="double" href="#dom-vttregion-regionanchory">regionAnchorY</a>;
+  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double"><span class="kt">double</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="double" href="#dom-vttregion-viewportanchorx">viewportAnchorX</a>;
+  <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double"><span class="kt">double</span></a> <a class="nv idl-code" data-link-type="attribute" data-type="double" href="#dom-vttregion-viewportanchory">viewportAnchorY</a>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-scrollsetting">ScrollSetting</a> <a class="nv idl-code" data-link-type="attribute" data-type="ScrollSetting" href="#dom-vttregion-scroll">scroll</a>;
 };
 
 </pre>
   <aside class="dfn-panel" data-for="webvtt">
    <b><a href="#webvtt">#webvtt</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt">2.1. Conformance classes</a>
+    <li><a href="#ref-for-webvtt-1">2.1. Conformance classes</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue">
    <b><a href="#webvtt-cue">#webvtt-cue</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue①">(2)</a> <a href="#ref-for-webvtt-cue②">(3)</a> <a href="#ref-for-webvtt-cue③">(4)</a> <a href="#ref-for-webvtt-cue④">(5)</a> <a href="#ref-for-webvtt-cue⑤">(6)</a> <a href="#ref-for-webvtt-cue⑥">(7)</a> <a href="#ref-for-webvtt-cue⑦">(8)</a> <a href="#ref-for-webvtt-cue⑧">(9)</a> <a href="#ref-for-webvtt-cue⑨">(10)</a> <a href="#ref-for-webvtt-cue①⓪">(11)</a>
-    <li><a href="#ref-for-webvtt-cue①①">3.2. WebVTT regions</a>
-    <li><a href="#ref-for-webvtt-cue①②">4.1. WebVTT file structure</a>
-    <li><a href="#ref-for-webvtt-cue①③">4.3. WebVTT region settings</a>
-    <li><a href="#ref-for-webvtt-cue①④">5.1. WebVTT file parsing</a> <a href="#ref-for-webvtt-cue①⑤">(2)</a> <a href="#ref-for-webvtt-cue①⑥">(3)</a> <a href="#ref-for-webvtt-cue①⑦">(4)</a> <a href="#ref-for-webvtt-cue①⑧">(5)</a>
-    <li><a href="#ref-for-webvtt-cue①⑨">5.3. WebVTT cue timings and settings parsing</a>
-    <li><a href="#ref-for-webvtt-cue②⓪">5.5. WebVTT cue text DOM construction rules</a>
-    <li><a href="#ref-for-webvtt-cue②①">5.6. WebVTT rules for extracting the chapter
+    <li><a href="#ref-for-webvtt-cue-1">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-2">(2)</a> <a href="#ref-for-webvtt-cue-3">(3)</a> <a href="#ref-for-webvtt-cue-4">(4)</a> <a href="#ref-for-webvtt-cue-5">(5)</a> <a href="#ref-for-webvtt-cue-6">(6)</a> <a href="#ref-for-webvtt-cue-7">(7)</a> <a href="#ref-for-webvtt-cue-8">(8)</a> <a href="#ref-for-webvtt-cue-9">(9)</a> <a href="#ref-for-webvtt-cue-10">(10)</a> <a href="#ref-for-webvtt-cue-11">(11)</a>
+    <li><a href="#ref-for-webvtt-cue-12">3.2. WebVTT regions</a>
+    <li><a href="#ref-for-webvtt-cue-13">4.1. WebVTT file structure</a>
+    <li><a href="#ref-for-webvtt-cue-14">4.3. WebVTT region settings</a>
+    <li><a href="#ref-for-webvtt-cue-15">5.1. WebVTT file parsing</a> <a href="#ref-for-webvtt-cue-16">(2)</a> <a href="#ref-for-webvtt-cue-17">(3)</a> <a href="#ref-for-webvtt-cue-18">(4)</a> <a href="#ref-for-webvtt-cue-19">(5)</a>
+    <li><a href="#ref-for-webvtt-cue-20">5.3. WebVTT cue timings and settings parsing</a>
+    <li><a href="#ref-for-webvtt-cue-21">5.5. WebVTT cue text DOM construction rules</a>
+    <li><a href="#ref-for-webvtt-cue-22">5.6. WebVTT rules for extracting the chapter
 title</a>
-    <li><a href="#ref-for-webvtt-cue②②">6.1. Processing model</a> <a href="#ref-for-webvtt-cue②③">(2)</a>
-    <li><a href="#ref-for-webvtt-cue②④">6.1.1. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-webvtt-cue②⑤">(2)</a>
-    <li><a href="#ref-for-webvtt-cue②⑥">7.2. Processing model</a> <a href="#ref-for-webvtt-cue②⑦">(2)</a> <a href="#ref-for-webvtt-cue②⑧">(3)</a>
-    <li><a href="#ref-for-webvtt-cue②⑨">7.2.2. The :past and :future pseudo-classes</a> <a href="#ref-for-webvtt-cue③⓪">(2)</a>
-    <li><a href="#ref-for-webvtt-cue③①">7.2.3. The ::cue-region pseudo-element</a>
-    <li><a href="#ref-for-webvtt-cue③②">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue③③">(2)</a> <a href="#ref-for-webvtt-cue③④">(3)</a> <a href="#ref-for-webvtt-cue③⑤">(4)</a> <a href="#ref-for-webvtt-cue③⑥">(5)</a> <a href="#ref-for-webvtt-cue③⑦">(6)</a> <a href="#ref-for-webvtt-cue③⑧">(7)</a> <a href="#ref-for-webvtt-cue③⑨">(8)</a> <a href="#ref-for-webvtt-cue④⓪">(9)</a> <a href="#ref-for-webvtt-cue④①">(10)</a> <a href="#ref-for-webvtt-cue④②">(11)</a> <a href="#ref-for-webvtt-cue④③">(12)</a>
+    <li><a href="#ref-for-webvtt-cue-23">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-24">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-25">6.1.1. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-webvtt-cue-26">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-27">7.2. Processing model</a> <a href="#ref-for-webvtt-cue-28">(2)</a> <a href="#ref-for-webvtt-cue-29">(3)</a>
+    <li><a href="#ref-for-webvtt-cue-30">7.2.2. The :past and :future pseudo-classes</a> <a href="#ref-for-webvtt-cue-31">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-32">7.2.3. The ::cue-region pseudo-element</a>
+    <li><a href="#ref-for-webvtt-cue-33">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-34">(2)</a> <a href="#ref-for-webvtt-cue-35">(3)</a> <a href="#ref-for-webvtt-cue-36">(4)</a> <a href="#ref-for-webvtt-cue-37">(5)</a> <a href="#ref-for-webvtt-cue-38">(6)</a> <a href="#ref-for-webvtt-cue-39">(7)</a> <a href="#ref-for-webvtt-cue-40">(8)</a> <a href="#ref-for-webvtt-cue-41">(9)</a> <a href="#ref-for-webvtt-cue-42">(10)</a> <a href="#ref-for-webvtt-cue-43">(11)</a> <a href="#ref-for-webvtt-cue-44">(12)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="text-track-cue-text">
    <b><a href="#text-track-cue-text">#text-track-cue-text</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-text-track-cue-text">3.1. WebVTT cues</a>
-    <li><a href="#ref-for-text-track-cue-text①">5.1. WebVTT file parsing</a> <a href="#ref-for-text-track-cue-text②">(2)</a>
-    <li><a href="#ref-for-text-track-cue-text③">5.6. WebVTT rules for extracting the chapter
+    <li><a href="#ref-for-text-track-cue-text-1">3.1. WebVTT cues</a>
+    <li><a href="#ref-for-text-track-cue-text-2">5.1. WebVTT file parsing</a> <a href="#ref-for-text-track-cue-text-3">(2)</a>
+    <li><a href="#ref-for-text-track-cue-text-4">5.6. WebVTT rules for extracting the chapter
 title</a>
-    <li><a href="#ref-for-text-track-cue-text④">6.1. Processing model</a>
-    <li><a href="#ref-for-text-track-cue-text⑤">6.1.1. Applying CSS properties to WebVTT Node Objects</a>
-    <li><a href="#ref-for-text-track-cue-text⑥">8.1. The VTTCue interface</a> <a href="#ref-for-text-track-cue-text⑦">(2)</a> <a href="#ref-for-text-track-cue-text⑧">(3)</a> <a href="#ref-for-text-track-cue-text⑨">(4)</a> <a href="#ref-for-text-track-cue-text①⓪">(5)</a> <a href="#ref-for-text-track-cue-text①①">(6)</a> <a href="#ref-for-text-track-cue-text①②">(7)</a> <a href="#ref-for-text-track-cue-text①③">(8)</a>
+    <li><a href="#ref-for-text-track-cue-text-5">6.1. Processing model</a>
+    <li><a href="#ref-for-text-track-cue-text-6">6.1.1. Applying CSS properties to WebVTT Node Objects</a>
+    <li><a href="#ref-for-text-track-cue-text-7">8.1. The VTTCue interface</a> <a href="#ref-for-text-track-cue-text-8">(2)</a> <a href="#ref-for-text-track-cue-text-9">(3)</a> <a href="#ref-for-text-track-cue-text-10">(4)</a> <a href="#ref-for-text-track-cue-text-11">(5)</a> <a href="#ref-for-text-track-cue-text-12">(6)</a> <a href="#ref-for-text-track-cue-text-13">(7)</a> <a href="#ref-for-text-track-cue-text-14">(8)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-box">
    <b><a href="#webvtt-cue-box">#webvtt-cue-box</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-box">1.4. Other features</a> <a href="#ref-for-webvtt-cue-box①">(2)</a> <a href="#ref-for-webvtt-cue-box②">(3)</a> <a href="#ref-for-webvtt-cue-box③">(4)</a> <a href="#ref-for-webvtt-cue-box④">(5)</a>
-    <li><a href="#ref-for-webvtt-cue-box⑤">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-box⑥">(2)</a> <a href="#ref-for-webvtt-cue-box⑦">(3)</a> <a href="#ref-for-webvtt-cue-box⑧">(4)</a> <a href="#ref-for-webvtt-cue-box⑨">(5)</a> <a href="#ref-for-webvtt-cue-box①⓪">(6)</a> <a href="#ref-for-webvtt-cue-box①①">(7)</a> <a href="#ref-for-webvtt-cue-box①②">(8)</a> <a href="#ref-for-webvtt-cue-box①③">(9)</a> <a href="#ref-for-webvtt-cue-box①④">(10)</a> <a href="#ref-for-webvtt-cue-box①⑤">(11)</a> <a href="#ref-for-webvtt-cue-box①⑥">(12)</a> <a href="#ref-for-webvtt-cue-box①⑦">(13)</a> <a href="#ref-for-webvtt-cue-box①⑧">(14)</a> <a href="#ref-for-webvtt-cue-box①⑨">(15)</a> <a href="#ref-for-webvtt-cue-box②⓪">(16)</a> <a href="#ref-for-webvtt-cue-box②①">(17)</a> <a href="#ref-for-webvtt-cue-box②②">(18)</a>
-    <li><a href="#ref-for-webvtt-cue-box②③">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-cue-box②④">(2)</a> <a href="#ref-for-webvtt-cue-box②⑤">(3)</a>
+    <li><a href="#ref-for-webvtt-cue-box-1">1.4. Other features</a> <a href="#ref-for-webvtt-cue-box-2">(2)</a> <a href="#ref-for-webvtt-cue-box-3">(3)</a> <a href="#ref-for-webvtt-cue-box-4">(4)</a> <a href="#ref-for-webvtt-cue-box-5">(5)</a>
+    <li><a href="#ref-for-webvtt-cue-box-6">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-box-7">(2)</a> <a href="#ref-for-webvtt-cue-box-8">(3)</a> <a href="#ref-for-webvtt-cue-box-9">(4)</a> <a href="#ref-for-webvtt-cue-box-10">(5)</a> <a href="#ref-for-webvtt-cue-box-11">(6)</a> <a href="#ref-for-webvtt-cue-box-12">(7)</a> <a href="#ref-for-webvtt-cue-box-13">(8)</a> <a href="#ref-for-webvtt-cue-box-14">(9)</a> <a href="#ref-for-webvtt-cue-box-15">(10)</a> <a href="#ref-for-webvtt-cue-box-16">(11)</a> <a href="#ref-for-webvtt-cue-box-17">(12)</a> <a href="#ref-for-webvtt-cue-box-18">(13)</a> <a href="#ref-for-webvtt-cue-box-19">(14)</a> <a href="#ref-for-webvtt-cue-box-20">(15)</a> <a href="#ref-for-webvtt-cue-box-21">(16)</a> <a href="#ref-for-webvtt-cue-box-22">(17)</a> <a href="#ref-for-webvtt-cue-box-23">(18)</a>
+    <li><a href="#ref-for-webvtt-cue-box-24">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-cue-box-25">(2)</a> <a href="#ref-for-webvtt-cue-box-26">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-writing-direction">
    <b><a href="#webvtt-cue-writing-direction">#webvtt-cue-writing-direction</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-writing-direction">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-writing-direction①">(2)</a> <a href="#ref-for-webvtt-cue-writing-direction②">(3)</a> <a href="#ref-for-webvtt-cue-writing-direction③">(4)</a> <a href="#ref-for-webvtt-cue-writing-direction④">(5)</a> <a href="#ref-for-webvtt-cue-writing-direction⑤">(6)</a> <a href="#ref-for-webvtt-cue-writing-direction⑥">(7)</a> <a href="#ref-for-webvtt-cue-writing-direction⑦">(8)</a> <a href="#ref-for-webvtt-cue-writing-direction⑧">(9)</a> <a href="#ref-for-webvtt-cue-writing-direction⑨">(10)</a> <a href="#ref-for-webvtt-cue-writing-direction①⓪">(11)</a>
-    <li><a href="#ref-for-webvtt-cue-writing-direction①①">4.4. WebVTT cue settings</a>
-    <li><a href="#ref-for-webvtt-cue-writing-direction①②">5.1. WebVTT file parsing</a>
-    <li><a href="#ref-for-webvtt-cue-writing-direction①③">5.3. WebVTT cue timings and settings parsing</a> <a href="#ref-for-webvtt-cue-writing-direction①④">(2)</a>
-    <li><a href="#ref-for-webvtt-cue-writing-direction①⑤">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-writing-direction①⑥">(2)</a> <a href="#ref-for-webvtt-cue-writing-direction①⑦">(3)</a> <a href="#ref-for-webvtt-cue-writing-direction①⑧">(4)</a> <a href="#ref-for-webvtt-cue-writing-direction①⑨">(5)</a> <a href="#ref-for-webvtt-cue-writing-direction②⓪">(6)</a> <a href="#ref-for-webvtt-cue-writing-direction②①">(7)</a> <a href="#ref-for-webvtt-cue-writing-direction②②">(8)</a> <a href="#ref-for-webvtt-cue-writing-direction②③">(9)</a> <a href="#ref-for-webvtt-cue-writing-direction②④">(10)</a> <a href="#ref-for-webvtt-cue-writing-direction②⑤">(11)</a> <a href="#ref-for-webvtt-cue-writing-direction②⑥">(12)</a> <a href="#ref-for-webvtt-cue-writing-direction②⑦">(13)</a> <a href="#ref-for-webvtt-cue-writing-direction②⑧">(14)</a> <a href="#ref-for-webvtt-cue-writing-direction②⑨">(15)</a> <a href="#ref-for-webvtt-cue-writing-direction③⓪">(16)</a> <a href="#ref-for-webvtt-cue-writing-direction③①">(17)</a> <a href="#ref-for-webvtt-cue-writing-direction③②">(18)</a> <a href="#ref-for-webvtt-cue-writing-direction③③">(19)</a>
-    <li><a href="#ref-for-webvtt-cue-writing-direction③④">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-writing-direction③⑤">(2)</a> <a href="#ref-for-webvtt-cue-writing-direction③⑥">(3)</a> <a href="#ref-for-webvtt-cue-writing-direction③⑦">(4)</a> <a href="#ref-for-webvtt-cue-writing-direction③⑧">(5)</a>
+    <li><a href="#ref-for-webvtt-cue-writing-direction-1">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-writing-direction-2">(2)</a> <a href="#ref-for-webvtt-cue-writing-direction-3">(3)</a> <a href="#ref-for-webvtt-cue-writing-direction-4">(4)</a> <a href="#ref-for-webvtt-cue-writing-direction-5">(5)</a> <a href="#ref-for-webvtt-cue-writing-direction-6">(6)</a> <a href="#ref-for-webvtt-cue-writing-direction-7">(7)</a> <a href="#ref-for-webvtt-cue-writing-direction-8">(8)</a> <a href="#ref-for-webvtt-cue-writing-direction-9">(9)</a> <a href="#ref-for-webvtt-cue-writing-direction-10">(10)</a> <a href="#ref-for-webvtt-cue-writing-direction-11">(11)</a>
+    <li><a href="#ref-for-webvtt-cue-writing-direction-12">4.4. WebVTT cue settings</a>
+    <li><a href="#ref-for-webvtt-cue-writing-direction-13">5.1. WebVTT file parsing</a>
+    <li><a href="#ref-for-webvtt-cue-writing-direction-14">5.3. WebVTT cue timings and settings parsing</a> <a href="#ref-for-webvtt-cue-writing-direction-15">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-writing-direction-16">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-writing-direction-17">(2)</a> <a href="#ref-for-webvtt-cue-writing-direction-18">(3)</a> <a href="#ref-for-webvtt-cue-writing-direction-19">(4)</a> <a href="#ref-for-webvtt-cue-writing-direction-20">(5)</a> <a href="#ref-for-webvtt-cue-writing-direction-21">(6)</a> <a href="#ref-for-webvtt-cue-writing-direction-22">(7)</a> <a href="#ref-for-webvtt-cue-writing-direction-23">(8)</a> <a href="#ref-for-webvtt-cue-writing-direction-24">(9)</a> <a href="#ref-for-webvtt-cue-writing-direction-25">(10)</a> <a href="#ref-for-webvtt-cue-writing-direction-26">(11)</a> <a href="#ref-for-webvtt-cue-writing-direction-27">(12)</a> <a href="#ref-for-webvtt-cue-writing-direction-28">(13)</a> <a href="#ref-for-webvtt-cue-writing-direction-29">(14)</a> <a href="#ref-for-webvtt-cue-writing-direction-30">(15)</a> <a href="#ref-for-webvtt-cue-writing-direction-31">(16)</a> <a href="#ref-for-webvtt-cue-writing-direction-32">(17)</a> <a href="#ref-for-webvtt-cue-writing-direction-33">(18)</a> <a href="#ref-for-webvtt-cue-writing-direction-34">(19)</a>
+    <li><a href="#ref-for-webvtt-cue-writing-direction-35">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-writing-direction-36">(2)</a> <a href="#ref-for-webvtt-cue-writing-direction-37">(3)</a> <a href="#ref-for-webvtt-cue-writing-direction-38">(4)</a> <a href="#ref-for-webvtt-cue-writing-direction-39">(5)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-horizontal-writing-direction">
    <b><a href="#webvtt-cue-horizontal-writing-direction">#webvtt-cue-horizontal-writing-direction</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-horizontal-writing-direction">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction①">(2)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction②">(3)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction③">(4)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction④">(5)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction⑤">(6)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction⑥">(7)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction⑦">(8)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction⑧">(9)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction⑨">(10)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction①⓪">(11)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction①①">(12)</a>
-    <li><a href="#ref-for-webvtt-cue-horizontal-writing-direction①②">5.1. WebVTT file parsing</a>
-    <li><a href="#ref-for-webvtt-cue-horizontal-writing-direction①③">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction①④">(2)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction①⑤">(3)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction①⑥">(4)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction①⑦">(5)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction①⑧">(6)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction①⑨">(7)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction②⓪">(8)</a>
-    <li><a href="#ref-for-webvtt-cue-horizontal-writing-direction②①">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction②②">(2)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction②③">(3)</a>
+    <li><a href="#ref-for-webvtt-cue-horizontal-writing-direction-1">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-2">(2)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-3">(3)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-4">(4)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-5">(5)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-6">(6)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-7">(7)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-8">(8)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-9">(9)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-10">(10)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-11">(11)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-12">(12)</a>
+    <li><a href="#ref-for-webvtt-cue-horizontal-writing-direction-13">5.1. WebVTT file parsing</a>
+    <li><a href="#ref-for-webvtt-cue-horizontal-writing-direction-14">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-15">(2)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-16">(3)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-17">(4)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-18">(5)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-19">(6)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-20">(7)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-21">(8)</a>
+    <li><a href="#ref-for-webvtt-cue-horizontal-writing-direction-22">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-23">(2)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction-24">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-vertical-growing-left-writing-direction">
    <b><a href="#webvtt-cue-vertical-growing-left-writing-direction">#webvtt-cue-vertical-growing-left-writing-direction</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction①">(2)</a> <a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction②">(3)</a>
-    <li><a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction③">5.3. WebVTT cue timings and settings parsing</a>
-    <li><a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction④">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction⑤">(2)</a> <a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction⑥">(3)</a> <a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction⑦">(4)</a> <a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction⑧">(5)</a> <a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction⑨">(6)</a> <a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction①⓪">(7)</a> <a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction①①">(8)</a>
-    <li><a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction①②">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction①③">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction-1">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction-2">(2)</a> <a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction-3">(3)</a>
+    <li><a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction-4">5.3. WebVTT cue timings and settings parsing</a>
+    <li><a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction-5">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction-6">(2)</a> <a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction-7">(3)</a> <a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction-8">(4)</a> <a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction-9">(5)</a> <a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction-10">(6)</a> <a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction-11">(7)</a> <a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction-12">(8)</a>
+    <li><a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction-13">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction-14">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-vertical-growing-right-writing-direction">
    <b><a href="#webvtt-cue-vertical-growing-right-writing-direction">#webvtt-cue-vertical-growing-right-writing-direction</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction①">(2)</a> <a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction②">(3)</a>
-    <li><a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction③">5.3. WebVTT cue timings and settings parsing</a>
-    <li><a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction④">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction⑤">(2)</a> <a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction⑥">(3)</a> <a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction⑦">(4)</a> <a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction⑧">(5)</a> <a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction⑨">(6)</a> <a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction①⓪">(7)</a> <a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction①①">(8)</a>
-    <li><a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction①②">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction①③">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction-1">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction-2">(2)</a> <a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction-3">(3)</a>
+    <li><a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction-4">5.3. WebVTT cue timings and settings parsing</a>
+    <li><a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction-5">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction-6">(2)</a> <a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction-7">(3)</a> <a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction-8">(4)</a> <a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction-9">(5)</a> <a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction-10">(6)</a> <a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction-11">(7)</a> <a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction-12">(8)</a>
+    <li><a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction-13">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction-14">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-snap-to-lines-flag">
    <b><a href="#webvtt-cue-snap-to-lines-flag">#webvtt-cue-snap-to-lines-flag</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-snap-to-lines-flag">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag①">(2)</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag②">(3)</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag③">(4)</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag④">(5)</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag⑤">(6)</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag⑥">(7)</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag⑦">(8)</a>
-    <li><a href="#ref-for-webvtt-cue-snap-to-lines-flag⑧">5.1. WebVTT file parsing</a>
-    <li><a href="#ref-for-webvtt-cue-snap-to-lines-flag⑨">5.3. WebVTT cue timings and settings parsing</a>
-    <li><a href="#ref-for-webvtt-cue-snap-to-lines-flag①⓪">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag①①">(2)</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag①②">(3)</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag①③">(4)</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag①④">(5)</a>
-    <li><a href="#ref-for-webvtt-cue-snap-to-lines-flag①⑤">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag①⑥">(2)</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag①⑦">(3)</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag①⑧">(4)</a>
+    <li><a href="#ref-for-webvtt-cue-snap-to-lines-flag-1">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag-2">(2)</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag-3">(3)</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag-4">(4)</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag-5">(5)</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag-6">(6)</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag-7">(7)</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag-8">(8)</a>
+    <li><a href="#ref-for-webvtt-cue-snap-to-lines-flag-9">5.1. WebVTT file parsing</a>
+    <li><a href="#ref-for-webvtt-cue-snap-to-lines-flag-10">5.3. WebVTT cue timings and settings parsing</a>
+    <li><a href="#ref-for-webvtt-cue-snap-to-lines-flag-11">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag-12">(2)</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag-13">(3)</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag-14">(4)</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag-15">(5)</a>
+    <li><a href="#ref-for-webvtt-cue-snap-to-lines-flag-16">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag-17">(2)</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag-18">(3)</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag-19">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-line">
    <b><a href="#webvtt-cue-line">#webvtt-cue-line</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-line">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-line①">(2)</a> <a href="#ref-for-webvtt-cue-line②">(3)</a> <a href="#ref-for-webvtt-cue-line③">(4)</a> <a href="#ref-for-webvtt-cue-line④">(5)</a> <a href="#ref-for-webvtt-cue-line⑤">(6)</a> <a href="#ref-for-webvtt-cue-line⑥">(7)</a> <a href="#ref-for-webvtt-cue-line⑦">(8)</a> <a href="#ref-for-webvtt-cue-line⑧">(9)</a> <a href="#ref-for-webvtt-cue-line⑨">(10)</a> <a href="#ref-for-webvtt-cue-line①⓪">(11)</a> <a href="#ref-for-webvtt-cue-line①①">(12)</a> <a href="#ref-for-webvtt-cue-line①②">(13)</a> <a href="#ref-for-webvtt-cue-line①③">(14)</a> <a href="#ref-for-webvtt-cue-line①④">(15)</a> <a href="#ref-for-webvtt-cue-line①⑤">(16)</a> <a href="#ref-for-webvtt-cue-line①⑥">(17)</a> <a href="#ref-for-webvtt-cue-line①⑦">(18)</a> <a href="#ref-for-webvtt-cue-line①⑧">(19)</a> <a href="#ref-for-webvtt-cue-line①⑨">(20)</a>
-    <li><a href="#ref-for-webvtt-cue-line②⓪">5.1. WebVTT file parsing</a>
-    <li><a href="#ref-for-webvtt-cue-line②①">5.3. WebVTT cue timings and settings parsing</a>
-    <li><a href="#ref-for-webvtt-cue-line②②">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-line②③">(2)</a> <a href="#ref-for-webvtt-cue-line②④">(3)</a> <a href="#ref-for-webvtt-cue-line②⑤">(4)</a>
+    <li><a href="#ref-for-webvtt-cue-line-1">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-line-2">(2)</a> <a href="#ref-for-webvtt-cue-line-3">(3)</a> <a href="#ref-for-webvtt-cue-line-4">(4)</a> <a href="#ref-for-webvtt-cue-line-5">(5)</a> <a href="#ref-for-webvtt-cue-line-6">(6)</a> <a href="#ref-for-webvtt-cue-line-7">(7)</a> <a href="#ref-for-webvtt-cue-line-8">(8)</a> <a href="#ref-for-webvtt-cue-line-9">(9)</a> <a href="#ref-for-webvtt-cue-line-10">(10)</a> <a href="#ref-for-webvtt-cue-line-11">(11)</a> <a href="#ref-for-webvtt-cue-line-12">(12)</a> <a href="#ref-for-webvtt-cue-line-13">(13)</a> <a href="#ref-for-webvtt-cue-line-14">(14)</a> <a href="#ref-for-webvtt-cue-line-15">(15)</a> <a href="#ref-for-webvtt-cue-line-16">(16)</a> <a href="#ref-for-webvtt-cue-line-17">(17)</a> <a href="#ref-for-webvtt-cue-line-18">(18)</a> <a href="#ref-for-webvtt-cue-line-19">(19)</a> <a href="#ref-for-webvtt-cue-line-20">(20)</a>
+    <li><a href="#ref-for-webvtt-cue-line-21">5.1. WebVTT file parsing</a>
+    <li><a href="#ref-for-webvtt-cue-line-22">5.3. WebVTT cue timings and settings parsing</a>
+    <li><a href="#ref-for-webvtt-cue-line-23">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-line-24">(2)</a> <a href="#ref-for-webvtt-cue-line-25">(3)</a> <a href="#ref-for-webvtt-cue-line-26">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-line-automatic">
    <b><a href="#webvtt-cue-line-automatic">#webvtt-cue-line-automatic</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-line-automatic">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-line-automatic①">(2)</a> <a href="#ref-for-webvtt-cue-line-automatic②">(3)</a>
-    <li><a href="#ref-for-webvtt-cue-line-automatic③">5.1. WebVTT file parsing</a>
-    <li><a href="#ref-for-webvtt-cue-line-automatic④">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-line-automatic⑤">(2)</a> <a href="#ref-for-webvtt-cue-line-automatic⑥">(3)</a> <a href="#ref-for-webvtt-cue-line-automatic⑦">(4)</a>
+    <li><a href="#ref-for-webvtt-cue-line-automatic-1">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-line-automatic-2">(2)</a> <a href="#ref-for-webvtt-cue-line-automatic-3">(3)</a>
+    <li><a href="#ref-for-webvtt-cue-line-automatic-4">5.1. WebVTT file parsing</a>
+    <li><a href="#ref-for-webvtt-cue-line-automatic-5">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-line-automatic-6">(2)</a> <a href="#ref-for-webvtt-cue-line-automatic-7">(3)</a> <a href="#ref-for-webvtt-cue-line-automatic-8">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="cue-computed-line">
    <b><a href="#cue-computed-line">#cue-computed-line</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-cue-computed-line">3.1. WebVTT cues</a>
-    <li><a href="#ref-for-cue-computed-line①">6.1. Processing model</a> <a href="#ref-for-cue-computed-line②">(2)</a> <a href="#ref-for-cue-computed-line③">(3)</a>
+    <li><a href="#ref-for-cue-computed-line-1">3.1. WebVTT cues</a>
+    <li><a href="#ref-for-cue-computed-line-2">6.1. Processing model</a> <a href="#ref-for-cue-computed-line-3">(2)</a> <a href="#ref-for-cue-computed-line-4">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-line-alignment">
    <b><a href="#webvtt-cue-line-alignment">#webvtt-cue-line-alignment</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-line-alignment">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-line-alignment①">(2)</a> <a href="#ref-for-webvtt-cue-line-alignment②">(3)</a> <a href="#ref-for-webvtt-cue-line-alignment③">(4)</a>
-    <li><a href="#ref-for-webvtt-cue-line-alignment④">4.4. WebVTT cue settings</a>
-    <li><a href="#ref-for-webvtt-cue-line-alignment⑤">5.1. WebVTT file parsing</a>
-    <li><a href="#ref-for-webvtt-cue-line-alignment⑥">5.3. WebVTT cue timings and settings parsing</a> <a href="#ref-for-webvtt-cue-line-alignment⑦">(2)</a> <a href="#ref-for-webvtt-cue-line-alignment⑧">(3)</a>
-    <li><a href="#ref-for-webvtt-cue-line-alignment⑨">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-line-alignment①⓪">(2)</a> <a href="#ref-for-webvtt-cue-line-alignment①①">(3)</a> <a href="#ref-for-webvtt-cue-line-alignment①②">(4)</a>
-    <li><a href="#ref-for-webvtt-cue-line-alignment①③">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-line-alignment①④">(2)</a> <a href="#ref-for-webvtt-cue-line-alignment①⑤">(3)</a> <a href="#ref-for-webvtt-cue-line-alignment①⑥">(4)</a> <a href="#ref-for-webvtt-cue-line-alignment①⑦">(5)</a>
+    <li><a href="#ref-for-webvtt-cue-line-alignment-1">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-line-alignment-2">(2)</a> <a href="#ref-for-webvtt-cue-line-alignment-3">(3)</a> <a href="#ref-for-webvtt-cue-line-alignment-4">(4)</a>
+    <li><a href="#ref-for-webvtt-cue-line-alignment-5">4.4. WebVTT cue settings</a>
+    <li><a href="#ref-for-webvtt-cue-line-alignment-6">5.1. WebVTT file parsing</a>
+    <li><a href="#ref-for-webvtt-cue-line-alignment-7">5.3. WebVTT cue timings and settings parsing</a> <a href="#ref-for-webvtt-cue-line-alignment-8">(2)</a> <a href="#ref-for-webvtt-cue-line-alignment-9">(3)</a>
+    <li><a href="#ref-for-webvtt-cue-line-alignment-10">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-line-alignment-11">(2)</a> <a href="#ref-for-webvtt-cue-line-alignment-12">(3)</a> <a href="#ref-for-webvtt-cue-line-alignment-13">(4)</a>
+    <li><a href="#ref-for-webvtt-cue-line-alignment-14">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-line-alignment-15">(2)</a> <a href="#ref-for-webvtt-cue-line-alignment-16">(3)</a> <a href="#ref-for-webvtt-cue-line-alignment-17">(4)</a> <a href="#ref-for-webvtt-cue-line-alignment-18">(5)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-line-start-alignment">
    <b><a href="#webvtt-cue-line-start-alignment">#webvtt-cue-line-start-alignment</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-line-start-alignment">3.1. WebVTT cues</a>
-    <li><a href="#ref-for-webvtt-cue-line-start-alignment①">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-cue-line-start-alignment②">(2)</a>
-    <li><a href="#ref-for-webvtt-cue-line-start-alignment③">5.1. WebVTT file parsing</a>
-    <li><a href="#ref-for-webvtt-cue-line-start-alignment④">5.3. WebVTT cue timings and settings parsing</a>
-    <li><a href="#ref-for-webvtt-cue-line-start-alignment⑤">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-line-start-alignment⑥">(2)</a> <a href="#ref-for-webvtt-cue-line-start-alignment⑦">(3)</a>
+    <li><a href="#ref-for-webvtt-cue-line-start-alignment-1">3.1. WebVTT cues</a>
+    <li><a href="#ref-for-webvtt-cue-line-start-alignment-2">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-cue-line-start-alignment-3">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-line-start-alignment-4">5.1. WebVTT file parsing</a>
+    <li><a href="#ref-for-webvtt-cue-line-start-alignment-5">5.3. WebVTT cue timings and settings parsing</a>
+    <li><a href="#ref-for-webvtt-cue-line-start-alignment-6">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-line-start-alignment-7">(2)</a> <a href="#ref-for-webvtt-cue-line-start-alignment-8">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-line-center-alignment">
    <b><a href="#webvtt-cue-line-center-alignment">#webvtt-cue-line-center-alignment</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-line-center-alignment">4.4. WebVTT cue settings</a>
-    <li><a href="#ref-for-webvtt-cue-line-center-alignment①">5.3. WebVTT cue timings and settings parsing</a>
-    <li><a href="#ref-for-webvtt-cue-line-center-alignment②">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-line-center-alignment③">(2)</a>
-    <li><a href="#ref-for-webvtt-cue-line-center-alignment④">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-line-center-alignment⑤">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-line-center-alignment-1">4.4. WebVTT cue settings</a>
+    <li><a href="#ref-for-webvtt-cue-line-center-alignment-2">5.3. WebVTT cue timings and settings parsing</a>
+    <li><a href="#ref-for-webvtt-cue-line-center-alignment-3">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-line-center-alignment-4">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-line-center-alignment-5">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-line-center-alignment-6">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-line-end-alignment">
    <b><a href="#webvtt-cue-line-end-alignment">#webvtt-cue-line-end-alignment</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-line-end-alignment">4.4. WebVTT cue settings</a>
-    <li><a href="#ref-for-webvtt-cue-line-end-alignment①">5.3. WebVTT cue timings and settings parsing</a>
-    <li><a href="#ref-for-webvtt-cue-line-end-alignment②">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-line-end-alignment③">(2)</a>
-    <li><a href="#ref-for-webvtt-cue-line-end-alignment④">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-line-end-alignment⑤">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-line-end-alignment-1">4.4. WebVTT cue settings</a>
+    <li><a href="#ref-for-webvtt-cue-line-end-alignment-2">5.3. WebVTT cue timings and settings parsing</a>
+    <li><a href="#ref-for-webvtt-cue-line-end-alignment-3">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-line-end-alignment-4">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-line-end-alignment-5">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-line-end-alignment-6">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-position">
    <b><a href="#webvtt-cue-position">#webvtt-cue-position</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-position">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-position①">(2)</a> <a href="#ref-for-webvtt-cue-position②">(3)</a> <a href="#ref-for-webvtt-cue-position③">(4)</a> <a href="#ref-for-webvtt-cue-position④">(5)</a> <a href="#ref-for-webvtt-cue-position⑤">(6)</a> <a href="#ref-for-webvtt-cue-position⑥">(7)</a> <a href="#ref-for-webvtt-cue-position⑦">(8)</a> <a href="#ref-for-webvtt-cue-position⑧">(9)</a> <a href="#ref-for-webvtt-cue-position⑨">(10)</a> <a href="#ref-for-webvtt-cue-position①⓪">(11)</a> <a href="#ref-for-webvtt-cue-position①①">(12)</a> <a href="#ref-for-webvtt-cue-position①②">(13)</a> <a href="#ref-for-webvtt-cue-position①③">(14)</a> <a href="#ref-for-webvtt-cue-position①④">(15)</a> <a href="#ref-for-webvtt-cue-position①⑤">(16)</a> <a href="#ref-for-webvtt-cue-position①⑥">(17)</a> <a href="#ref-for-webvtt-cue-position①⑦">(18)</a> <a href="#ref-for-webvtt-cue-position①⑧">(19)</a>
-    <li><a href="#ref-for-webvtt-cue-position①⑨">5.1. WebVTT file parsing</a>
-    <li><a href="#ref-for-webvtt-cue-position②⓪">5.3. WebVTT cue timings and settings parsing</a> <a href="#ref-for-webvtt-cue-position②①">(2)</a>
-    <li><a href="#ref-for-webvtt-cue-position②②">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-position②③">(2)</a> <a href="#ref-for-webvtt-cue-position②④">(3)</a> <a href="#ref-for-webvtt-cue-position②⑤">(4)</a>
+    <li><a href="#ref-for-webvtt-cue-position-1">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-position-2">(2)</a> <a href="#ref-for-webvtt-cue-position-3">(3)</a> <a href="#ref-for-webvtt-cue-position-4">(4)</a> <a href="#ref-for-webvtt-cue-position-5">(5)</a> <a href="#ref-for-webvtt-cue-position-6">(6)</a> <a href="#ref-for-webvtt-cue-position-7">(7)</a> <a href="#ref-for-webvtt-cue-position-8">(8)</a> <a href="#ref-for-webvtt-cue-position-9">(9)</a> <a href="#ref-for-webvtt-cue-position-10">(10)</a> <a href="#ref-for-webvtt-cue-position-11">(11)</a> <a href="#ref-for-webvtt-cue-position-12">(12)</a> <a href="#ref-for-webvtt-cue-position-13">(13)</a> <a href="#ref-for-webvtt-cue-position-14">(14)</a> <a href="#ref-for-webvtt-cue-position-15">(15)</a> <a href="#ref-for-webvtt-cue-position-16">(16)</a> <a href="#ref-for-webvtt-cue-position-17">(17)</a> <a href="#ref-for-webvtt-cue-position-18">(18)</a> <a href="#ref-for-webvtt-cue-position-19">(19)</a>
+    <li><a href="#ref-for-webvtt-cue-position-20">5.1. WebVTT file parsing</a>
+    <li><a href="#ref-for-webvtt-cue-position-21">5.3. WebVTT cue timings and settings parsing</a> <a href="#ref-for-webvtt-cue-position-22">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-position-23">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-position-24">(2)</a> <a href="#ref-for-webvtt-cue-position-25">(3)</a> <a href="#ref-for-webvtt-cue-position-26">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-automatic-position">
    <b><a href="#webvtt-cue-automatic-position">#webvtt-cue-automatic-position</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-automatic-position">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-automatic-position①">(2)</a> <a href="#ref-for-webvtt-cue-automatic-position②">(3)</a> <a href="#ref-for-webvtt-cue-automatic-position③">(4)</a> <a href="#ref-for-webvtt-cue-automatic-position④">(5)</a>
-    <li><a href="#ref-for-webvtt-cue-automatic-position⑤">5.1. WebVTT file parsing</a>
-    <li><a href="#ref-for-webvtt-cue-automatic-position⑥">5.3. WebVTT cue timings and settings parsing</a>
-    <li><a href="#ref-for-webvtt-cue-automatic-position⑦">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-automatic-position⑧">(2)</a> <a href="#ref-for-webvtt-cue-automatic-position⑨">(3)</a> <a href="#ref-for-webvtt-cue-automatic-position①⓪">(4)</a>
+    <li><a href="#ref-for-webvtt-cue-automatic-position-1">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-automatic-position-2">(2)</a> <a href="#ref-for-webvtt-cue-automatic-position-3">(3)</a> <a href="#ref-for-webvtt-cue-automatic-position-4">(4)</a> <a href="#ref-for-webvtt-cue-automatic-position-5">(5)</a>
+    <li><a href="#ref-for-webvtt-cue-automatic-position-6">5.1. WebVTT file parsing</a>
+    <li><a href="#ref-for-webvtt-cue-automatic-position-7">5.3. WebVTT cue timings and settings parsing</a>
+    <li><a href="#ref-for-webvtt-cue-automatic-position-8">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-automatic-position-9">(2)</a> <a href="#ref-for-webvtt-cue-automatic-position-10">(3)</a> <a href="#ref-for-webvtt-cue-automatic-position-11">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="cue-computed-position">
    <b><a href="#cue-computed-position">#cue-computed-position</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-cue-computed-position">6.1. Processing model</a> <a href="#ref-for-cue-computed-position①">(2)</a> <a href="#ref-for-cue-computed-position②">(3)</a> <a href="#ref-for-cue-computed-position③">(4)</a> <a href="#ref-for-cue-computed-position④">(5)</a> <a href="#ref-for-cue-computed-position⑤">(6)</a> <a href="#ref-for-cue-computed-position⑥">(7)</a> <a href="#ref-for-cue-computed-position⑦">(8)</a> <a href="#ref-for-cue-computed-position⑧">(9)</a> <a href="#ref-for-cue-computed-position⑨">(10)</a> <a href="#ref-for-cue-computed-position①⓪">(11)</a> <a href="#ref-for-cue-computed-position①①">(12)</a> <a href="#ref-for-cue-computed-position①②">(13)</a>
+    <li><a href="#ref-for-cue-computed-position-1">6.1. Processing model</a> <a href="#ref-for-cue-computed-position-2">(2)</a> <a href="#ref-for-cue-computed-position-3">(3)</a> <a href="#ref-for-cue-computed-position-4">(4)</a> <a href="#ref-for-cue-computed-position-5">(5)</a> <a href="#ref-for-cue-computed-position-6">(6)</a> <a href="#ref-for-cue-computed-position-7">(7)</a> <a href="#ref-for-cue-computed-position-8">(8)</a> <a href="#ref-for-cue-computed-position-9">(9)</a> <a href="#ref-for-cue-computed-position-10">(10)</a> <a href="#ref-for-cue-computed-position-11">(11)</a> <a href="#ref-for-cue-computed-position-12">(12)</a> <a href="#ref-for-cue-computed-position-13">(13)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-position-alignment">
    <b><a href="#webvtt-cue-position-alignment">#webvtt-cue-position-alignment</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-position-alignment">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-position-alignment①">(2)</a> <a href="#ref-for-webvtt-cue-position-alignment②">(3)</a> <a href="#ref-for-webvtt-cue-position-alignment③">(4)</a> <a href="#ref-for-webvtt-cue-position-alignment④">(5)</a> <a href="#ref-for-webvtt-cue-position-alignment⑤">(6)</a>
-    <li><a href="#ref-for-webvtt-cue-position-alignment⑥">5.1. WebVTT file parsing</a>
-    <li><a href="#ref-for-webvtt-cue-position-alignment⑦">5.3. WebVTT cue timings and settings parsing</a> <a href="#ref-for-webvtt-cue-position-alignment⑧">(2)</a> <a href="#ref-for-webvtt-cue-position-alignment⑨">(3)</a>
-    <li><a href="#ref-for-webvtt-cue-position-alignment①⓪">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-position-alignment①①">(2)</a> <a href="#ref-for-webvtt-cue-position-alignment①②">(3)</a> <a href="#ref-for-webvtt-cue-position-alignment①③">(4)</a> <a href="#ref-for-webvtt-cue-position-alignment①④">(5)</a>
+    <li><a href="#ref-for-webvtt-cue-position-alignment-1">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-position-alignment-2">(2)</a> <a href="#ref-for-webvtt-cue-position-alignment-3">(3)</a> <a href="#ref-for-webvtt-cue-position-alignment-4">(4)</a> <a href="#ref-for-webvtt-cue-position-alignment-5">(5)</a> <a href="#ref-for-webvtt-cue-position-alignment-6">(6)</a>
+    <li><a href="#ref-for-webvtt-cue-position-alignment-7">5.1. WebVTT file parsing</a>
+    <li><a href="#ref-for-webvtt-cue-position-alignment-8">5.3. WebVTT cue timings and settings parsing</a> <a href="#ref-for-webvtt-cue-position-alignment-9">(2)</a> <a href="#ref-for-webvtt-cue-position-alignment-10">(3)</a>
+    <li><a href="#ref-for-webvtt-cue-position-alignment-11">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-position-alignment-12">(2)</a> <a href="#ref-for-webvtt-cue-position-alignment-13">(3)</a> <a href="#ref-for-webvtt-cue-position-alignment-14">(4)</a> <a href="#ref-for-webvtt-cue-position-alignment-15">(5)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-position-line-left-alignment">
    <b><a href="#webvtt-cue-position-line-left-alignment">#webvtt-cue-position-line-left-alignment</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-position-line-left-alignment">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-position-line-left-alignment①">(2)</a>
-    <li><a href="#ref-for-webvtt-cue-position-line-left-alignment②">4.4. WebVTT cue settings</a>
-    <li><a href="#ref-for-webvtt-cue-position-line-left-alignment③">5.3. WebVTT cue timings and settings parsing</a>
-    <li><a href="#ref-for-webvtt-cue-position-line-left-alignment④">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-position-line-left-alignment⑤">(2)</a> <a href="#ref-for-webvtt-cue-position-line-left-alignment⑥">(3)</a>
-    <li><a href="#ref-for-webvtt-cue-position-line-left-alignment⑦">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-position-line-left-alignment⑧">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-position-line-left-alignment-1">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-position-line-left-alignment-2">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-position-line-left-alignment-3">4.4. WebVTT cue settings</a>
+    <li><a href="#ref-for-webvtt-cue-position-line-left-alignment-4">5.3. WebVTT cue timings and settings parsing</a>
+    <li><a href="#ref-for-webvtt-cue-position-line-left-alignment-5">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-position-line-left-alignment-6">(2)</a> <a href="#ref-for-webvtt-cue-position-line-left-alignment-7">(3)</a>
+    <li><a href="#ref-for-webvtt-cue-position-line-left-alignment-8">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-position-line-left-alignment-9">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-position-center-alignment">
    <b><a href="#webvtt-cue-position-center-alignment">#webvtt-cue-position-center-alignment</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-position-center-alignment">4.4. WebVTT cue settings</a>
-    <li><a href="#ref-for-webvtt-cue-position-center-alignment①">5.3. WebVTT cue timings and settings parsing</a>
-    <li><a href="#ref-for-webvtt-cue-position-center-alignment②">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-position-center-alignment③">(2)</a> <a href="#ref-for-webvtt-cue-position-center-alignment④">(3)</a> <a href="#ref-for-webvtt-cue-position-center-alignment⑤">(4)</a> <a href="#ref-for-webvtt-cue-position-center-alignment⑥">(5)</a>
-    <li><a href="#ref-for-webvtt-cue-position-center-alignment⑦">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-position-center-alignment⑧">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-position-center-alignment-1">4.4. WebVTT cue settings</a>
+    <li><a href="#ref-for-webvtt-cue-position-center-alignment-2">5.3. WebVTT cue timings and settings parsing</a>
+    <li><a href="#ref-for-webvtt-cue-position-center-alignment-3">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-position-center-alignment-4">(2)</a> <a href="#ref-for-webvtt-cue-position-center-alignment-5">(3)</a> <a href="#ref-for-webvtt-cue-position-center-alignment-6">(4)</a> <a href="#ref-for-webvtt-cue-position-center-alignment-7">(5)</a>
+    <li><a href="#ref-for-webvtt-cue-position-center-alignment-8">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-position-center-alignment-9">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-position-line-right-alignment">
    <b><a href="#webvtt-cue-position-line-right-alignment">#webvtt-cue-position-line-right-alignment</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-position-line-right-alignment">3.1. WebVTT cues</a>
-    <li><a href="#ref-for-webvtt-cue-position-line-right-alignment①">4.4. WebVTT cue settings</a>
-    <li><a href="#ref-for-webvtt-cue-position-line-right-alignment②">5.3. WebVTT cue timings and settings parsing</a>
-    <li><a href="#ref-for-webvtt-cue-position-line-right-alignment③">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-position-line-right-alignment④">(2)</a> <a href="#ref-for-webvtt-cue-position-line-right-alignment⑤">(3)</a> <a href="#ref-for-webvtt-cue-position-line-right-alignment⑥">(4)</a>
-    <li><a href="#ref-for-webvtt-cue-position-line-right-alignment⑦">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-position-line-right-alignment⑧">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-position-line-right-alignment-1">3.1. WebVTT cues</a>
+    <li><a href="#ref-for-webvtt-cue-position-line-right-alignment-2">4.4. WebVTT cue settings</a>
+    <li><a href="#ref-for-webvtt-cue-position-line-right-alignment-3">5.3. WebVTT cue timings and settings parsing</a>
+    <li><a href="#ref-for-webvtt-cue-position-line-right-alignment-4">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-position-line-right-alignment-5">(2)</a> <a href="#ref-for-webvtt-cue-position-line-right-alignment-6">(3)</a> <a href="#ref-for-webvtt-cue-position-line-right-alignment-7">(4)</a>
+    <li><a href="#ref-for-webvtt-cue-position-line-right-alignment-8">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-position-line-right-alignment-9">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-position-automatic-alignment">
    <b><a href="#webvtt-cue-position-automatic-alignment">#webvtt-cue-position-automatic-alignment</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-position-automatic-alignment">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-position-automatic-alignment①">(2)</a>
-    <li><a href="#ref-for-webvtt-cue-position-automatic-alignment②">5.1. WebVTT file parsing</a>
-    <li><a href="#ref-for-webvtt-cue-position-automatic-alignment③">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-position-automatic-alignment④">(2)</a> <a href="#ref-for-webvtt-cue-position-automatic-alignment⑤">(3)</a>
+    <li><a href="#ref-for-webvtt-cue-position-automatic-alignment-1">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-position-automatic-alignment-2">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-position-automatic-alignment-3">5.1. WebVTT file parsing</a>
+    <li><a href="#ref-for-webvtt-cue-position-automatic-alignment-4">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-position-automatic-alignment-5">(2)</a> <a href="#ref-for-webvtt-cue-position-automatic-alignment-6">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="cue-computed-position-alignment">
    <b><a href="#cue-computed-position-alignment">#cue-computed-position-alignment</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-cue-computed-position-alignment">4.4. WebVTT cue settings</a>
-    <li><a href="#ref-for-cue-computed-position-alignment①">6.1. Processing model</a> <a href="#ref-for-cue-computed-position-alignment②">(2)</a> <a href="#ref-for-cue-computed-position-alignment③">(3)</a> <a href="#ref-for-cue-computed-position-alignment④">(4)</a> <a href="#ref-for-cue-computed-position-alignment⑤">(5)</a> <a href="#ref-for-cue-computed-position-alignment⑥">(6)</a> <a href="#ref-for-cue-computed-position-alignment⑦">(7)</a> <a href="#ref-for-cue-computed-position-alignment⑧">(8)</a> <a href="#ref-for-cue-computed-position-alignment⑨">(9)</a> <a href="#ref-for-cue-computed-position-alignment①⓪">(10)</a> <a href="#ref-for-cue-computed-position-alignment①①">(11)</a> <a href="#ref-for-cue-computed-position-alignment①②">(12)</a> <a href="#ref-for-cue-computed-position-alignment①③">(13)</a>
+    <li><a href="#ref-for-cue-computed-position-alignment-1">4.4. WebVTT cue settings</a>
+    <li><a href="#ref-for-cue-computed-position-alignment-2">6.1. Processing model</a> <a href="#ref-for-cue-computed-position-alignment-3">(2)</a> <a href="#ref-for-cue-computed-position-alignment-4">(3)</a> <a href="#ref-for-cue-computed-position-alignment-5">(4)</a> <a href="#ref-for-cue-computed-position-alignment-6">(5)</a> <a href="#ref-for-cue-computed-position-alignment-7">(6)</a> <a href="#ref-for-cue-computed-position-alignment-8">(7)</a> <a href="#ref-for-cue-computed-position-alignment-9">(8)</a> <a href="#ref-for-cue-computed-position-alignment-10">(9)</a> <a href="#ref-for-cue-computed-position-alignment-11">(10)</a> <a href="#ref-for-cue-computed-position-alignment-12">(11)</a> <a href="#ref-for-cue-computed-position-alignment-13">(12)</a> <a href="#ref-for-cue-computed-position-alignment-14">(13)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-size">
    <b><a href="#webvtt-cue-size">#webvtt-cue-size</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-size">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-size①">(2)</a> <a href="#ref-for-webvtt-cue-size②">(3)</a> <a href="#ref-for-webvtt-cue-size③">(4)</a> <a href="#ref-for-webvtt-cue-size④">(5)</a> <a href="#ref-for-webvtt-cue-size⑤">(6)</a>
-    <li><a href="#ref-for-webvtt-cue-size⑥">5.1. WebVTT file parsing</a>
-    <li><a href="#ref-for-webvtt-cue-size⑦">5.3. WebVTT cue timings and settings parsing</a>
-    <li><a href="#ref-for-webvtt-cue-size⑧">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-size⑨">(2)</a>
-    <li><a href="#ref-for-webvtt-cue-size①⓪">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-size①①">(2)</a> <a href="#ref-for-webvtt-cue-size①②">(3)</a> <a href="#ref-for-webvtt-cue-size①③">(4)</a>
+    <li><a href="#ref-for-webvtt-cue-size-1">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-size-2">(2)</a> <a href="#ref-for-webvtt-cue-size-3">(3)</a> <a href="#ref-for-webvtt-cue-size-4">(4)</a> <a href="#ref-for-webvtt-cue-size-5">(5)</a> <a href="#ref-for-webvtt-cue-size-6">(6)</a>
+    <li><a href="#ref-for-webvtt-cue-size-7">5.1. WebVTT file parsing</a>
+    <li><a href="#ref-for-webvtt-cue-size-8">5.3. WebVTT cue timings and settings parsing</a>
+    <li><a href="#ref-for-webvtt-cue-size-9">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-size-10">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-size-11">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-size-12">(2)</a> <a href="#ref-for-webvtt-cue-size-13">(3)</a> <a href="#ref-for-webvtt-cue-size-14">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-text-alignment">
    <b><a href="#webvtt-cue-text-alignment">#webvtt-cue-text-alignment</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-text-alignment">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-text-alignment①">(2)</a> <a href="#ref-for-webvtt-cue-text-alignment②">(3)</a> <a href="#ref-for-webvtt-cue-text-alignment③">(4)</a> <a href="#ref-for-webvtt-cue-text-alignment④">(5)</a> <a href="#ref-for-webvtt-cue-text-alignment⑤">(6)</a> <a href="#ref-for-webvtt-cue-text-alignment⑥">(7)</a> <a href="#ref-for-webvtt-cue-text-alignment⑦">(8)</a> <a href="#ref-for-webvtt-cue-text-alignment⑧">(9)</a> <a href="#ref-for-webvtt-cue-text-alignment⑨">(10)</a> <a href="#ref-for-webvtt-cue-text-alignment①⓪">(11)</a> <a href="#ref-for-webvtt-cue-text-alignment①①">(12)</a>
-    <li><a href="#ref-for-webvtt-cue-text-alignment①②">5.1. WebVTT file parsing</a>
-    <li><a href="#ref-for-webvtt-cue-text-alignment①③">5.3. WebVTT cue timings and settings parsing</a> <a href="#ref-for-webvtt-cue-text-alignment①④">(2)</a> <a href="#ref-for-webvtt-cue-text-alignment①⑤">(3)</a> <a href="#ref-for-webvtt-cue-text-alignment①⑥">(4)</a> <a href="#ref-for-webvtt-cue-text-alignment①⑦">(5)</a>
-    <li><a href="#ref-for-webvtt-cue-text-alignment①⑧">6.1.1. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-webvtt-cue-text-alignment①⑨">(2)</a>
-    <li><a href="#ref-for-webvtt-cue-text-alignment②⓪">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-text-alignment②①">(2)</a> <a href="#ref-for-webvtt-cue-text-alignment②②">(3)</a> <a href="#ref-for-webvtt-cue-text-alignment②③">(4)</a> <a href="#ref-for-webvtt-cue-text-alignment②④">(5)</a>
+    <li><a href="#ref-for-webvtt-cue-text-alignment-1">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-text-alignment-2">(2)</a> <a href="#ref-for-webvtt-cue-text-alignment-3">(3)</a> <a href="#ref-for-webvtt-cue-text-alignment-4">(4)</a> <a href="#ref-for-webvtt-cue-text-alignment-5">(5)</a> <a href="#ref-for-webvtt-cue-text-alignment-6">(6)</a> <a href="#ref-for-webvtt-cue-text-alignment-7">(7)</a> <a href="#ref-for-webvtt-cue-text-alignment-8">(8)</a> <a href="#ref-for-webvtt-cue-text-alignment-9">(9)</a> <a href="#ref-for-webvtt-cue-text-alignment-10">(10)</a> <a href="#ref-for-webvtt-cue-text-alignment-11">(11)</a> <a href="#ref-for-webvtt-cue-text-alignment-12">(12)</a>
+    <li><a href="#ref-for-webvtt-cue-text-alignment-13">5.1. WebVTT file parsing</a>
+    <li><a href="#ref-for-webvtt-cue-text-alignment-14">5.3. WebVTT cue timings and settings parsing</a> <a href="#ref-for-webvtt-cue-text-alignment-15">(2)</a> <a href="#ref-for-webvtt-cue-text-alignment-16">(3)</a> <a href="#ref-for-webvtt-cue-text-alignment-17">(4)</a> <a href="#ref-for-webvtt-cue-text-alignment-18">(5)</a>
+    <li><a href="#ref-for-webvtt-cue-text-alignment-19">6.1.1. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-webvtt-cue-text-alignment-20">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-text-alignment-21">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-text-alignment-22">(2)</a> <a href="#ref-for-webvtt-cue-text-alignment-23">(3)</a> <a href="#ref-for-webvtt-cue-text-alignment-24">(4)</a> <a href="#ref-for-webvtt-cue-text-alignment-25">(5)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-start-alignment">
    <b><a href="#webvtt-cue-start-alignment">#webvtt-cue-start-alignment</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-start-alignment">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-start-alignment①">(2)</a> <a href="#ref-for-webvtt-cue-start-alignment②">(3)</a> <a href="#ref-for-webvtt-cue-start-alignment③">(4)</a> <a href="#ref-for-webvtt-cue-start-alignment④">(5)</a>
-    <li><a href="#ref-for-webvtt-cue-start-alignment⑤">5.3. WebVTT cue timings and settings parsing</a>
-    <li><a href="#ref-for-webvtt-cue-start-alignment⑥">6.1.1. Applying CSS properties to WebVTT Node Objects</a>
-    <li><a href="#ref-for-webvtt-cue-start-alignment⑦">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-start-alignment⑧">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-start-alignment-1">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-start-alignment-2">(2)</a> <a href="#ref-for-webvtt-cue-start-alignment-3">(3)</a> <a href="#ref-for-webvtt-cue-start-alignment-4">(4)</a> <a href="#ref-for-webvtt-cue-start-alignment-5">(5)</a>
+    <li><a href="#ref-for-webvtt-cue-start-alignment-6">5.3. WebVTT cue timings and settings parsing</a>
+    <li><a href="#ref-for-webvtt-cue-start-alignment-7">6.1.1. Applying CSS properties to WebVTT Node Objects</a>
+    <li><a href="#ref-for-webvtt-cue-start-alignment-8">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-start-alignment-9">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-center-alignment">
    <b><a href="#webvtt-cue-center-alignment">#webvtt-cue-center-alignment</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-center-alignment">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-center-alignment①">(2)</a> <a href="#ref-for-webvtt-cue-center-alignment②">(3)</a> <a href="#ref-for-webvtt-cue-center-alignment③">(4)</a>
-    <li><a href="#ref-for-webvtt-cue-center-alignment④">5.1. WebVTT file parsing</a>
-    <li><a href="#ref-for-webvtt-cue-center-alignment⑤">5.3. WebVTT cue timings and settings parsing</a>
-    <li><a href="#ref-for-webvtt-cue-center-alignment⑥">6.1.1. Applying CSS properties to WebVTT Node Objects</a>
-    <li><a href="#ref-for-webvtt-cue-center-alignment⑦">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-center-alignment⑧">(2)</a> <a href="#ref-for-webvtt-cue-center-alignment⑨">(3)</a>
+    <li><a href="#ref-for-webvtt-cue-center-alignment-1">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-center-alignment-2">(2)</a> <a href="#ref-for-webvtt-cue-center-alignment-3">(3)</a> <a href="#ref-for-webvtt-cue-center-alignment-4">(4)</a>
+    <li><a href="#ref-for-webvtt-cue-center-alignment-5">5.1. WebVTT file parsing</a>
+    <li><a href="#ref-for-webvtt-cue-center-alignment-6">5.3. WebVTT cue timings and settings parsing</a>
+    <li><a href="#ref-for-webvtt-cue-center-alignment-7">6.1.1. Applying CSS properties to WebVTT Node Objects</a>
+    <li><a href="#ref-for-webvtt-cue-center-alignment-8">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-center-alignment-9">(2)</a> <a href="#ref-for-webvtt-cue-center-alignment-10">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-end-alignment">
    <b><a href="#webvtt-cue-end-alignment">#webvtt-cue-end-alignment</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-end-alignment">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-end-alignment①">(2)</a> <a href="#ref-for-webvtt-cue-end-alignment②">(3)</a> <a href="#ref-for-webvtt-cue-end-alignment③">(4)</a>
-    <li><a href="#ref-for-webvtt-cue-end-alignment④">5.3. WebVTT cue timings and settings parsing</a>
-    <li><a href="#ref-for-webvtt-cue-end-alignment⑤">6.1.1. Applying CSS properties to WebVTT Node Objects</a>
-    <li><a href="#ref-for-webvtt-cue-end-alignment⑥">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-end-alignment⑦">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-end-alignment-1">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-end-alignment-2">(2)</a> <a href="#ref-for-webvtt-cue-end-alignment-3">(3)</a> <a href="#ref-for-webvtt-cue-end-alignment-4">(4)</a>
+    <li><a href="#ref-for-webvtt-cue-end-alignment-5">5.3. WebVTT cue timings and settings parsing</a>
+    <li><a href="#ref-for-webvtt-cue-end-alignment-6">6.1.1. Applying CSS properties to WebVTT Node Objects</a>
+    <li><a href="#ref-for-webvtt-cue-end-alignment-7">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-end-alignment-8">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-left-alignment">
    <b><a href="#webvtt-cue-left-alignment">#webvtt-cue-left-alignment</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-left-alignment">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-left-alignment①">(2)</a> <a href="#ref-for-webvtt-cue-left-alignment②">(3)</a> <a href="#ref-for-webvtt-cue-left-alignment③">(4)</a>
-    <li><a href="#ref-for-webvtt-cue-left-alignment④">5.3. WebVTT cue timings and settings parsing</a>
-    <li><a href="#ref-for-webvtt-cue-left-alignment⑤">6.1.1. Applying CSS properties to WebVTT Node Objects</a>
-    <li><a href="#ref-for-webvtt-cue-left-alignment⑥">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-left-alignment⑦">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-left-alignment-1">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-left-alignment-2">(2)</a> <a href="#ref-for-webvtt-cue-left-alignment-3">(3)</a> <a href="#ref-for-webvtt-cue-left-alignment-4">(4)</a>
+    <li><a href="#ref-for-webvtt-cue-left-alignment-5">5.3. WebVTT cue timings and settings parsing</a>
+    <li><a href="#ref-for-webvtt-cue-left-alignment-6">6.1.1. Applying CSS properties to WebVTT Node Objects</a>
+    <li><a href="#ref-for-webvtt-cue-left-alignment-7">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-left-alignment-8">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-right-alignment">
    <b><a href="#webvtt-cue-right-alignment">#webvtt-cue-right-alignment</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-right-alignment">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-right-alignment①">(2)</a> <a href="#ref-for-webvtt-cue-right-alignment②">(3)</a> <a href="#ref-for-webvtt-cue-right-alignment③">(4)</a>
-    <li><a href="#ref-for-webvtt-cue-right-alignment④">5.3. WebVTT cue timings and settings parsing</a>
-    <li><a href="#ref-for-webvtt-cue-right-alignment⑤">6.1.1. Applying CSS properties to WebVTT Node Objects</a>
-    <li><a href="#ref-for-webvtt-cue-right-alignment⑥">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-right-alignment⑦">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-right-alignment-1">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-cue-right-alignment-2">(2)</a> <a href="#ref-for-webvtt-cue-right-alignment-3">(3)</a> <a href="#ref-for-webvtt-cue-right-alignment-4">(4)</a>
+    <li><a href="#ref-for-webvtt-cue-right-alignment-5">5.3. WebVTT cue timings and settings parsing</a>
+    <li><a href="#ref-for-webvtt-cue-right-alignment-6">6.1.1. Applying CSS properties to WebVTT Node Objects</a>
+    <li><a href="#ref-for-webvtt-cue-right-alignment-7">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-right-alignment-8">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-region">
    <b><a href="#webvtt-cue-region">#webvtt-cue-region</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-region">3.1. WebVTT cues</a>
-    <li><a href="#ref-for-webvtt-cue-region①">5.1. WebVTT file parsing</a>
-    <li><a href="#ref-for-webvtt-cue-region②">5.3. WebVTT cue timings and settings parsing</a>
-    <li><a href="#ref-for-webvtt-cue-region③">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-region④">(2)</a> <a href="#ref-for-webvtt-cue-region⑤">(3)</a>
-    <li><a href="#ref-for-webvtt-cue-region⑥">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-region⑦">(2)</a> <a href="#ref-for-webvtt-cue-region⑧">(3)</a>
+    <li><a href="#ref-for-webvtt-cue-region-1">3.1. WebVTT cues</a>
+    <li><a href="#ref-for-webvtt-cue-region-2">5.1. WebVTT file parsing</a>
+    <li><a href="#ref-for-webvtt-cue-region-3">5.3. WebVTT cue timings and settings parsing</a>
+    <li><a href="#ref-for-webvtt-cue-region-4">6.1. Processing model</a> <a href="#ref-for-webvtt-cue-region-5">(2)</a> <a href="#ref-for-webvtt-cue-region-6">(3)</a>
+    <li><a href="#ref-for-webvtt-cue-region-7">8.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-region-8">(2)</a> <a href="#ref-for-webvtt-cue-region-9">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-region">
    <b><a href="#webvtt-region">#webvtt-region</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-region">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-region①">(2)</a> <a href="#ref-for-webvtt-region②">(3)</a>
-    <li><a href="#ref-for-webvtt-region③">3.2. WebVTT regions</a> <a href="#ref-for-webvtt-region④">(2)</a>
-    <li><a href="#ref-for-webvtt-region⑤">4.3. WebVTT region settings</a> <a href="#ref-for-webvtt-region⑥">(2)</a> <a href="#ref-for-webvtt-region⑦">(3)</a>
-    <li><a href="#ref-for-webvtt-region⑧">5.1. WebVTT file parsing</a>
-    <li><a href="#ref-for-webvtt-region⑨">5.2. WebVTT region settings parsing</a>
-    <li><a href="#ref-for-webvtt-region①⓪">5.3. WebVTT cue timings and settings parsing</a>
-    <li><a href="#ref-for-webvtt-region①①">6.1. Processing model</a> <a href="#ref-for-webvtt-region①②">(2)</a> <a href="#ref-for-webvtt-region①③">(3)</a>
-    <li><a href="#ref-for-webvtt-region①④">6.1.1. Applying CSS properties to WebVTT Node Objects</a>
-    <li><a href="#ref-for-webvtt-region①⑤">8.2. The VTTRegion interface</a> <a href="#ref-for-webvtt-region①⑥">(2)</a> <a href="#ref-for-webvtt-region①⑦">(3)</a> <a href="#ref-for-webvtt-region①⑧">(4)</a> <a href="#ref-for-webvtt-region①⑨">(5)</a> <a href="#ref-for-webvtt-region②⓪">(6)</a> <a href="#ref-for-webvtt-region②①">(7)</a> <a href="#ref-for-webvtt-region②②">(8)</a> <a href="#ref-for-webvtt-region②③">(9)</a> <a href="#ref-for-webvtt-region②④">(10)</a>
+    <li><a href="#ref-for-webvtt-region-1">3.1. WebVTT cues</a> <a href="#ref-for-webvtt-region-2">(2)</a> <a href="#ref-for-webvtt-region-3">(3)</a>
+    <li><a href="#ref-for-webvtt-region-4">3.2. WebVTT regions</a> <a href="#ref-for-webvtt-region-5">(2)</a>
+    <li><a href="#ref-for-webvtt-region-6">4.3. WebVTT region settings</a> <a href="#ref-for-webvtt-region-7">(2)</a> <a href="#ref-for-webvtt-region-8">(3)</a>
+    <li><a href="#ref-for-webvtt-region-9">5.1. WebVTT file parsing</a>
+    <li><a href="#ref-for-webvtt-region-10">5.2. WebVTT region settings parsing</a>
+    <li><a href="#ref-for-webvtt-region-11">5.3. WebVTT cue timings and settings parsing</a>
+    <li><a href="#ref-for-webvtt-region-12">6.1. Processing model</a> <a href="#ref-for-webvtt-region-13">(2)</a> <a href="#ref-for-webvtt-region-14">(3)</a>
+    <li><a href="#ref-for-webvtt-region-15">6.1.1. Applying CSS properties to WebVTT Node Objects</a>
+    <li><a href="#ref-for-webvtt-region-16">8.2. The VTTRegion interface</a> <a href="#ref-for-webvtt-region-17">(2)</a> <a href="#ref-for-webvtt-region-18">(3)</a> <a href="#ref-for-webvtt-region-19">(4)</a> <a href="#ref-for-webvtt-region-20">(5)</a> <a href="#ref-for-webvtt-region-21">(6)</a> <a href="#ref-for-webvtt-region-22">(7)</a> <a href="#ref-for-webvtt-region-23">(8)</a> <a href="#ref-for-webvtt-region-24">(9)</a> <a href="#ref-for-webvtt-region-25">(10)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-region-identifier">
    <b><a href="#webvtt-region-identifier">#webvtt-region-identifier</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-region-identifier">4.4. WebVTT cue settings</a>
-    <li><a href="#ref-for-webvtt-region-identifier①">5.1. WebVTT file parsing</a>
-    <li><a href="#ref-for-webvtt-region-identifier②">5.2. WebVTT region settings parsing</a>
-    <li><a href="#ref-for-webvtt-region-identifier③">5.3. WebVTT cue timings and settings parsing</a>
-    <li><a href="#ref-for-webvtt-region-identifier④">7.1. Introduction</a>
-    <li><a href="#ref-for-webvtt-region-identifier⑤">7.2.3. The ::cue-region pseudo-element</a>
-    <li><a href="#ref-for-webvtt-region-identifier⑥">8.2. The VTTRegion interface</a> <a href="#ref-for-webvtt-region-identifier⑦">(2)</a> <a href="#ref-for-webvtt-region-identifier⑧">(3)</a>
+    <li><a href="#ref-for-webvtt-region-identifier-1">4.4. WebVTT cue settings</a>
+    <li><a href="#ref-for-webvtt-region-identifier-2">5.1. WebVTT file parsing</a>
+    <li><a href="#ref-for-webvtt-region-identifier-3">5.2. WebVTT region settings parsing</a>
+    <li><a href="#ref-for-webvtt-region-identifier-4">5.3. WebVTT cue timings and settings parsing</a>
+    <li><a href="#ref-for-webvtt-region-identifier-5">7.1. Introduction</a>
+    <li><a href="#ref-for-webvtt-region-identifier-6">7.2.3. The ::cue-region pseudo-element</a>
+    <li><a href="#ref-for-webvtt-region-identifier-7">8.2. The VTTRegion interface</a> <a href="#ref-for-webvtt-region-identifier-8">(2)</a> <a href="#ref-for-webvtt-region-identifier-9">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-region-width">
    <b><a href="#webvtt-region-width">#webvtt-region-width</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-region-width">5.1. WebVTT file parsing</a>
-    <li><a href="#ref-for-webvtt-region-width①">5.2. WebVTT region settings parsing</a>
-    <li><a href="#ref-for-webvtt-region-width②">6.1. Processing model</a> <a href="#ref-for-webvtt-region-width③">(2)</a> <a href="#ref-for-webvtt-region-width④">(3)</a> <a href="#ref-for-webvtt-region-width⑤">(4)</a>
-    <li><a href="#ref-for-webvtt-region-width⑥">8.2. The VTTRegion interface</a> <a href="#ref-for-webvtt-region-width⑦">(2)</a> <a href="#ref-for-webvtt-region-width⑧">(3)</a>
+    <li><a href="#ref-for-webvtt-region-width-1">5.1. WebVTT file parsing</a>
+    <li><a href="#ref-for-webvtt-region-width-2">5.2. WebVTT region settings parsing</a>
+    <li><a href="#ref-for-webvtt-region-width-3">6.1. Processing model</a> <a href="#ref-for-webvtt-region-width-4">(2)</a> <a href="#ref-for-webvtt-region-width-5">(3)</a> <a href="#ref-for-webvtt-region-width-6">(4)</a>
+    <li><a href="#ref-for-webvtt-region-width-7">8.2. The VTTRegion interface</a> <a href="#ref-for-webvtt-region-width-8">(2)</a> <a href="#ref-for-webvtt-region-width-9">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-region-lines">
    <b><a href="#webvtt-region-lines">#webvtt-region-lines</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-region-lines">5.1. WebVTT file parsing</a>
-    <li><a href="#ref-for-webvtt-region-lines①">5.2. WebVTT region settings parsing</a>
-    <li><a href="#ref-for-webvtt-region-lines②">6.1. Processing model</a>
-    <li><a href="#ref-for-webvtt-region-lines③">8.2. The VTTRegion interface</a> <a href="#ref-for-webvtt-region-lines④">(2)</a> <a href="#ref-for-webvtt-region-lines⑤">(3)</a>
+    <li><a href="#ref-for-webvtt-region-lines-1">5.1. WebVTT file parsing</a>
+    <li><a href="#ref-for-webvtt-region-lines-2">5.2. WebVTT region settings parsing</a>
+    <li><a href="#ref-for-webvtt-region-lines-3">6.1. Processing model</a>
+    <li><a href="#ref-for-webvtt-region-lines-4">8.2. The VTTRegion interface</a> <a href="#ref-for-webvtt-region-lines-5">(2)</a> <a href="#ref-for-webvtt-region-lines-6">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-region-anchor">
    <b><a href="#webvtt-region-anchor">#webvtt-region-anchor</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-region-anchor">5.1. WebVTT file parsing</a>
-    <li><a href="#ref-for-webvtt-region-anchor①">5.2. WebVTT region settings parsing</a>
-    <li><a href="#ref-for-webvtt-region-anchor②">6.1. Processing model</a> <a href="#ref-for-webvtt-region-anchor③">(2)</a> <a href="#ref-for-webvtt-region-anchor④">(3)</a> <a href="#ref-for-webvtt-region-anchor⑤">(4)</a>
-    <li><a href="#ref-for-webvtt-region-anchor⑥">8.2. The VTTRegion interface</a> <a href="#ref-for-webvtt-region-anchor⑦">(2)</a> <a href="#ref-for-webvtt-region-anchor⑧">(3)</a> <a href="#ref-for-webvtt-region-anchor⑨">(4)</a> <a href="#ref-for-webvtt-region-anchor①⓪">(5)</a> <a href="#ref-for-webvtt-region-anchor①①">(6)</a>
+    <li><a href="#ref-for-webvtt-region-anchor-1">5.1. WebVTT file parsing</a>
+    <li><a href="#ref-for-webvtt-region-anchor-2">5.2. WebVTT region settings parsing</a>
+    <li><a href="#ref-for-webvtt-region-anchor-3">6.1. Processing model</a> <a href="#ref-for-webvtt-region-anchor-4">(2)</a> <a href="#ref-for-webvtt-region-anchor-5">(3)</a> <a href="#ref-for-webvtt-region-anchor-6">(4)</a>
+    <li><a href="#ref-for-webvtt-region-anchor-7">8.2. The VTTRegion interface</a> <a href="#ref-for-webvtt-region-anchor-8">(2)</a> <a href="#ref-for-webvtt-region-anchor-9">(3)</a> <a href="#ref-for-webvtt-region-anchor-10">(4)</a> <a href="#ref-for-webvtt-region-anchor-11">(5)</a> <a href="#ref-for-webvtt-region-anchor-12">(6)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-region-viewport-anchor">
    <b><a href="#webvtt-region-viewport-anchor">#webvtt-region-viewport-anchor</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-region-viewport-anchor">5.1. WebVTT file parsing</a>
-    <li><a href="#ref-for-webvtt-region-viewport-anchor①">5.2. WebVTT region settings parsing</a>
-    <li><a href="#ref-for-webvtt-region-viewport-anchor②">8.2. The VTTRegion interface</a> <a href="#ref-for-webvtt-region-viewport-anchor③">(2)</a> <a href="#ref-for-webvtt-region-viewport-anchor④">(3)</a> <a href="#ref-for-webvtt-region-viewport-anchor⑤">(4)</a> <a href="#ref-for-webvtt-region-viewport-anchor⑥">(5)</a> <a href="#ref-for-webvtt-region-viewport-anchor⑦">(6)</a>
+    <li><a href="#ref-for-webvtt-region-viewport-anchor-1">5.1. WebVTT file parsing</a>
+    <li><a href="#ref-for-webvtt-region-viewport-anchor-2">5.2. WebVTT region settings parsing</a>
+    <li><a href="#ref-for-webvtt-region-viewport-anchor-3">8.2. The VTTRegion interface</a> <a href="#ref-for-webvtt-region-viewport-anchor-4">(2)</a> <a href="#ref-for-webvtt-region-viewport-anchor-5">(3)</a> <a href="#ref-for-webvtt-region-viewport-anchor-6">(4)</a> <a href="#ref-for-webvtt-region-viewport-anchor-7">(5)</a> <a href="#ref-for-webvtt-region-viewport-anchor-8">(6)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-region-scroll">
    <b><a href="#webvtt-region-scroll">#webvtt-region-scroll</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-region-scroll">5.1. WebVTT file parsing</a>
-    <li><a href="#ref-for-webvtt-region-scroll①">5.2. WebVTT region settings parsing</a>
-    <li><a href="#ref-for-webvtt-region-scroll②">6.1. Processing model</a>
-    <li><a href="#ref-for-webvtt-region-scroll③">8.2. The VTTRegion interface</a> <a href="#ref-for-webvtt-region-scroll④">(2)</a> <a href="#ref-for-webvtt-region-scroll⑤">(3)</a> <a href="#ref-for-webvtt-region-scroll⑥">(4)</a> <a href="#ref-for-webvtt-region-scroll⑦">(5)</a>
+    <li><a href="#ref-for-webvtt-region-scroll-1">5.1. WebVTT file parsing</a>
+    <li><a href="#ref-for-webvtt-region-scroll-2">5.2. WebVTT region settings parsing</a>
+    <li><a href="#ref-for-webvtt-region-scroll-3">6.1. Processing model</a>
+    <li><a href="#ref-for-webvtt-region-scroll-4">8.2. The VTTRegion interface</a> <a href="#ref-for-webvtt-region-scroll-5">(2)</a> <a href="#ref-for-webvtt-region-scroll-6">(3)</a> <a href="#ref-for-webvtt-region-scroll-7">(4)</a> <a href="#ref-for-webvtt-region-scroll-8">(5)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-region-scroll-none">
    <b><a href="#webvtt-region-scroll-none">#webvtt-region-scroll-none</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-region-scroll-none">5.1. WebVTT file parsing</a>
-    <li><a href="#ref-for-webvtt-region-scroll-none①">8.2. The VTTRegion interface</a>
+    <li><a href="#ref-for-webvtt-region-scroll-none-1">5.1. WebVTT file parsing</a>
+    <li><a href="#ref-for-webvtt-region-scroll-none-2">8.2. The VTTRegion interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-region-scroll-up">
    <b><a href="#webvtt-region-scroll-up">#webvtt-region-scroll-up</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-region-scroll-up">5.2. WebVTT region settings parsing</a>
-    <li><a href="#ref-for-webvtt-region-scroll-up①">6.1. Processing model</a>
-    <li><a href="#ref-for-webvtt-region-scroll-up②">8.2. The VTTRegion interface</a>
+    <li><a href="#ref-for-webvtt-region-scroll-up-1">5.2. WebVTT region settings parsing</a>
+    <li><a href="#ref-for-webvtt-region-scroll-up-2">6.1. Processing model</a>
+    <li><a href="#ref-for-webvtt-region-scroll-up-3">8.2. The VTTRegion interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="text-track-list-of-regions">
    <b><a href="#text-track-list-of-regions">#text-track-list-of-regions</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-text-track-list-of-regions">5.1. WebVTT file parsing</a>
-    <li><a href="#ref-for-text-track-list-of-regions①">5.3. WebVTT cue timings and settings parsing</a> <a href="#ref-for-text-track-list-of-regions②">(2)</a>
-    <li><a href="#ref-for-text-track-list-of-regions③">6.1. Processing model</a>
+    <li><a href="#ref-for-text-track-list-of-regions-1">5.1. WebVTT file parsing</a>
+    <li><a href="#ref-for-text-track-list-of-regions-2">5.3. WebVTT cue timings and settings parsing</a> <a href="#ref-for-text-track-list-of-regions-3">(2)</a>
+    <li><a href="#ref-for-text-track-list-of-regions-4">6.1. Processing model</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-file">
    <b><a href="#webvtt-file">#webvtt-file</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-file">2.1. Conformance classes</a> <a href="#ref-for-webvtt-file①">(2)</a> <a href="#ref-for-webvtt-file②">(3)</a> <a href="#ref-for-webvtt-file③">(4)</a> <a href="#ref-for-webvtt-file④">(5)</a> <a href="#ref-for-webvtt-file⑤">(6)</a>
-    <li><a href="#ref-for-webvtt-file⑥">4.1. WebVTT file structure</a> <a href="#ref-for-webvtt-file⑦">(2)</a>
-    <li><a href="#ref-for-webvtt-file⑧">4.3. WebVTT region settings</a>
-    <li><a href="#ref-for-webvtt-file⑨">4.5.1. WebVTT file using only nested cues</a>
-    <li><a href="#ref-for-webvtt-file①⓪">4.6. Types of WebVTT files</a>
-    <li><a href="#ref-for-webvtt-file①①">4.6.1. WebVTT file using metadata content</a>
-    <li><a href="#ref-for-webvtt-file①②">4.6.3. WebVTT file using cue text</a>
-    <li><a href="#ref-for-webvtt-file①③">5.1. WebVTT file parsing</a> <a href="#ref-for-webvtt-file①④">(2)</a> <a href="#ref-for-webvtt-file①⑤">(3)</a>
+    <li><a href="#ref-for-webvtt-file-1">2.1. Conformance classes</a> <a href="#ref-for-webvtt-file-2">(2)</a> <a href="#ref-for-webvtt-file-3">(3)</a> <a href="#ref-for-webvtt-file-4">(4)</a> <a href="#ref-for-webvtt-file-5">(5)</a> <a href="#ref-for-webvtt-file-6">(6)</a>
+    <li><a href="#ref-for-webvtt-file-7">4.1. WebVTT file structure</a> <a href="#ref-for-webvtt-file-8">(2)</a>
+    <li><a href="#ref-for-webvtt-file-9">4.3. WebVTT region settings</a>
+    <li><a href="#ref-for-webvtt-file-10">4.5.1. WebVTT file using only nested cues</a>
+    <li><a href="#ref-for-webvtt-file-11">4.6. Types of WebVTT files</a>
+    <li><a href="#ref-for-webvtt-file-12">4.6.1. WebVTT file using metadata content</a>
+    <li><a href="#ref-for-webvtt-file-13">4.6.3. WebVTT file using cue text</a>
+    <li><a href="#ref-for-webvtt-file-14">5.1. WebVTT file parsing</a> <a href="#ref-for-webvtt-file-15">(2)</a> <a href="#ref-for-webvtt-file-16">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-file-body">
    <b><a href="#webvtt-file-body">#webvtt-file-body</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-file-body">4.1. WebVTT file structure</a>
+    <li><a href="#ref-for-webvtt-file-body-1">4.1. WebVTT file structure</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-line-terminator">
    <b><a href="#webvtt-line-terminator">#webvtt-line-terminator</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-line-terminator">4.1. WebVTT file structure</a> <a href="#ref-for-webvtt-line-terminator①">(2)</a> <a href="#ref-for-webvtt-line-terminator②">(3)</a> <a href="#ref-for-webvtt-line-terminator③">(4)</a> <a href="#ref-for-webvtt-line-terminator④">(5)</a> <a href="#ref-for-webvtt-line-terminator⑤">(6)</a> <a href="#ref-for-webvtt-line-terminator⑥">(7)</a> <a href="#ref-for-webvtt-line-terminator⑦">(8)</a> <a href="#ref-for-webvtt-line-terminator⑧">(9)</a> <a href="#ref-for-webvtt-line-terminator⑨">(10)</a> <a href="#ref-for-webvtt-line-terminator①⓪">(11)</a> <a href="#ref-for-webvtt-line-terminator①①">(12)</a> <a href="#ref-for-webvtt-line-terminator①②">(13)</a> <a href="#ref-for-webvtt-line-terminator①③">(14)</a> <a href="#ref-for-webvtt-line-terminator①④">(15)</a> <a href="#ref-for-webvtt-line-terminator①⑤">(16)</a>
-    <li><a href="#ref-for-webvtt-line-terminator①⑥">4.2.1. WebVTT metadata text</a> <a href="#ref-for-webvtt-line-terminator①⑦">(2)</a> <a href="#ref-for-webvtt-line-terminator①⑧">(3)</a>
-    <li><a href="#ref-for-webvtt-line-terminator①⑨">4.2.2. WebVTT cue text</a> <a href="#ref-for-webvtt-line-terminator②⓪">(2)</a> <a href="#ref-for-webvtt-line-terminator②①">(3)</a> <a href="#ref-for-webvtt-line-terminator②②">(4)</a> <a href="#ref-for-webvtt-line-terminator②③">(5)</a>
-    <li><a href="#ref-for-webvtt-line-terminator②④">4.2.3. WebVTT chapter title text</a>
-    <li><a href="#ref-for-webvtt-line-terminator②⑤">4.3. WebVTT region settings</a> <a href="#ref-for-webvtt-line-terminator②⑥">(2)</a>
+    <li><a href="#ref-for-webvtt-line-terminator-1">4.1. WebVTT file structure</a> <a href="#ref-for-webvtt-line-terminator-2">(2)</a> <a href="#ref-for-webvtt-line-terminator-3">(3)</a> <a href="#ref-for-webvtt-line-terminator-4">(4)</a> <a href="#ref-for-webvtt-line-terminator-5">(5)</a> <a href="#ref-for-webvtt-line-terminator-6">(6)</a> <a href="#ref-for-webvtt-line-terminator-7">(7)</a> <a href="#ref-for-webvtt-line-terminator-8">(8)</a> <a href="#ref-for-webvtt-line-terminator-9">(9)</a> <a href="#ref-for-webvtt-line-terminator-10">(10)</a> <a href="#ref-for-webvtt-line-terminator-11">(11)</a> <a href="#ref-for-webvtt-line-terminator-12">(12)</a> <a href="#ref-for-webvtt-line-terminator-13">(13)</a> <a href="#ref-for-webvtt-line-terminator-14">(14)</a> <a href="#ref-for-webvtt-line-terminator-15">(15)</a> <a href="#ref-for-webvtt-line-terminator-16">(16)</a>
+    <li><a href="#ref-for-webvtt-line-terminator-17">4.2.1. WebVTT metadata text</a> <a href="#ref-for-webvtt-line-terminator-18">(2)</a> <a href="#ref-for-webvtt-line-terminator-19">(3)</a>
+    <li><a href="#ref-for-webvtt-line-terminator-20">4.2.2. WebVTT cue text</a> <a href="#ref-for-webvtt-line-terminator-21">(2)</a> <a href="#ref-for-webvtt-line-terminator-22">(3)</a> <a href="#ref-for-webvtt-line-terminator-23">(4)</a> <a href="#ref-for-webvtt-line-terminator-24">(5)</a>
+    <li><a href="#ref-for-webvtt-line-terminator-25">4.2.3. WebVTT chapter title text</a>
+    <li><a href="#ref-for-webvtt-line-terminator-26">4.3. WebVTT region settings</a> <a href="#ref-for-webvtt-line-terminator-27">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-region-definition-block">
    <b><a href="#webvtt-region-definition-block">#webvtt-region-definition-block</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-region-definition-block">4.1. WebVTT file structure</a>
-    <li><a href="#ref-for-webvtt-region-definition-block①">4.3. WebVTT region settings</a>
+    <li><a href="#ref-for-webvtt-region-definition-block-1">4.1. WebVTT file structure</a>
+    <li><a href="#ref-for-webvtt-region-definition-block-2">4.3. WebVTT region settings</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-style-block">
    <b><a href="#webvtt-style-block">#webvtt-style-block</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-style-block">4.1. WebVTT file structure</a>
+    <li><a href="#ref-for-webvtt-style-block-1">4.1. WebVTT file structure</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-block">
    <b><a href="#webvtt-cue-block">#webvtt-cue-block</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-block">4.1. WebVTT file structure</a> <a href="#ref-for-webvtt-cue-block①">(2)</a> <a href="#ref-for-webvtt-cue-block②">(3)</a> <a href="#ref-for-webvtt-cue-block③">(4)</a>
+    <li><a href="#ref-for-webvtt-cue-block-1">4.1. WebVTT file structure</a> <a href="#ref-for-webvtt-cue-block-2">(2)</a> <a href="#ref-for-webvtt-cue-block-3">(3)</a> <a href="#ref-for-webvtt-cue-block-4">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="cue-payload">
    <b><a href="#cue-payload">#cue-payload</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-cue-payload">4.1. WebVTT file structure</a>
-    <li><a href="#ref-for-cue-payload①">4.2.2. WebVTT cue text</a>
-    <li><a href="#ref-for-cue-payload②">4.6.1. WebVTT file using metadata content</a>
-    <li><a href="#ref-for-cue-payload③">4.6.2. WebVTT file using chapter title text</a>
-    <li><a href="#ref-for-cue-payload④">4.6.3. WebVTT file using cue text</a>
+    <li><a href="#ref-for-cue-payload-1">4.1. WebVTT file structure</a>
+    <li><a href="#ref-for-cue-payload-2">4.2.2. WebVTT cue text</a>
+    <li><a href="#ref-for-cue-payload-3">4.6.1. WebVTT file using metadata content</a>
+    <li><a href="#ref-for-cue-payload-4">4.6.2. WebVTT file using chapter title text</a>
+    <li><a href="#ref-for-cue-payload-5">4.6.3. WebVTT file using cue text</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-identifier">
    <b><a href="#webvtt-cue-identifier">#webvtt-cue-identifier</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-identifier">4.1. WebVTT file structure</a> <a href="#ref-for-webvtt-cue-identifier①">(2)</a> <a href="#ref-for-webvtt-cue-identifier②">(3)</a> <a href="#ref-for-webvtt-cue-identifier③">(4)</a>
+    <li><a href="#ref-for-webvtt-cue-identifier-1">4.1. WebVTT file structure</a> <a href="#ref-for-webvtt-cue-identifier-2">(2)</a> <a href="#ref-for-webvtt-cue-identifier-3">(3)</a> <a href="#ref-for-webvtt-cue-identifier-4">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-timings">
    <b><a href="#webvtt-cue-timings">#webvtt-cue-timings</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-timings">4.1. WebVTT file structure</a> <a href="#ref-for-webvtt-cue-timings①">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-timings-1">4.1. WebVTT file structure</a> <a href="#ref-for-webvtt-cue-timings-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-timestamp">
    <b><a href="#webvtt-timestamp">#webvtt-timestamp</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-timestamp">4.1. WebVTT file structure</a> <a href="#ref-for-webvtt-timestamp①">(2)</a> <a href="#ref-for-webvtt-timestamp②">(3)</a> <a href="#ref-for-webvtt-timestamp③">(4)</a> <a href="#ref-for-webvtt-timestamp④">(5)</a>
-    <li><a href="#ref-for-webvtt-timestamp⑤">4.2.2. WebVTT cue text</a> <a href="#ref-for-webvtt-timestamp⑥">(2)</a>
-    <li><a href="#ref-for-webvtt-timestamp⑦">5.5. WebVTT cue text DOM construction rules</a>
+    <li><a href="#ref-for-webvtt-timestamp-1">4.1. WebVTT file structure</a> <a href="#ref-for-webvtt-timestamp-2">(2)</a> <a href="#ref-for-webvtt-timestamp-3">(3)</a> <a href="#ref-for-webvtt-timestamp-4">(4)</a> <a href="#ref-for-webvtt-timestamp-5">(5)</a>
+    <li><a href="#ref-for-webvtt-timestamp-6">4.2.2. WebVTT cue text</a> <a href="#ref-for-webvtt-timestamp-7">(2)</a>
+    <li><a href="#ref-for-webvtt-timestamp-8">5.5. WebVTT cue text DOM construction rules</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-settings-list">
    <b><a href="#webvtt-cue-settings-list">#webvtt-cue-settings-list</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-settings-list">4.1. WebVTT file structure</a>
-    <li><a href="#ref-for-webvtt-cue-settings-list①">4.3. WebVTT region settings</a> <a href="#ref-for-webvtt-cue-settings-list②">(2)</a>
-    <li><a href="#ref-for-webvtt-cue-settings-list③">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-cue-settings-list④">(2)</a> <a href="#ref-for-webvtt-cue-settings-list⑤">(3)</a>
+    <li><a href="#ref-for-webvtt-cue-settings-list-1">4.1. WebVTT file structure</a>
+    <li><a href="#ref-for-webvtt-cue-settings-list-2">4.3. WebVTT region settings</a> <a href="#ref-for-webvtt-cue-settings-list-3">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-settings-list-4">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-cue-settings-list-5">(2)</a> <a href="#ref-for-webvtt-cue-settings-list-6">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-setting">
    <b><a href="#webvtt-cue-setting">#webvtt-cue-setting</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-setting">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-cue-setting①">(2)</a> <a href="#ref-for-webvtt-cue-setting②">(3)</a>
+    <li><a href="#ref-for-webvtt-cue-setting-1">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-cue-setting-2">(2)</a> <a href="#ref-for-webvtt-cue-setting-3">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-setting-name">
    <b><a href="#webvtt-cue-setting-name">#webvtt-cue-setting-name</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-setting-name">4.1. WebVTT file structure</a>
-    <li><a href="#ref-for-webvtt-cue-setting-name①">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-cue-setting-name②">(2)</a> <a href="#ref-for-webvtt-cue-setting-name③">(3)</a> <a href="#ref-for-webvtt-cue-setting-name④">(4)</a> <a href="#ref-for-webvtt-cue-setting-name⑤">(5)</a> <a href="#ref-for-webvtt-cue-setting-name⑥">(6)</a>
+    <li><a href="#ref-for-webvtt-cue-setting-name-1">4.1. WebVTT file structure</a>
+    <li><a href="#ref-for-webvtt-cue-setting-name-2">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-cue-setting-name-3">(2)</a> <a href="#ref-for-webvtt-cue-setting-name-4">(3)</a> <a href="#ref-for-webvtt-cue-setting-name-5">(4)</a> <a href="#ref-for-webvtt-cue-setting-name-6">(5)</a> <a href="#ref-for-webvtt-cue-setting-name-7">(6)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-setting-value">
    <b><a href="#webvtt-cue-setting-value">#webvtt-cue-setting-value</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-setting-value">4.1. WebVTT file structure</a>
-    <li><a href="#ref-for-webvtt-cue-setting-value①">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-cue-setting-value②">(2)</a> <a href="#ref-for-webvtt-cue-setting-value③">(3)</a> <a href="#ref-for-webvtt-cue-setting-value④">(4)</a> <a href="#ref-for-webvtt-cue-setting-value⑤">(5)</a> <a href="#ref-for-webvtt-cue-setting-value⑥">(6)</a>
+    <li><a href="#ref-for-webvtt-cue-setting-value-1">4.1. WebVTT file structure</a>
+    <li><a href="#ref-for-webvtt-cue-setting-value-2">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-cue-setting-value-3">(2)</a> <a href="#ref-for-webvtt-cue-setting-value-4">(3)</a> <a href="#ref-for-webvtt-cue-setting-value-5">(4)</a> <a href="#ref-for-webvtt-cue-setting-value-6">(5)</a> <a href="#ref-for-webvtt-cue-setting-value-7">(6)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-percentage">
    <b><a href="#webvtt-percentage">#webvtt-percentage</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-percentage">4.1. WebVTT file structure</a>
-    <li><a href="#ref-for-webvtt-percentage①">4.3. WebVTT region settings</a> <a href="#ref-for-webvtt-percentage②">(2)</a> <a href="#ref-for-webvtt-percentage③">(3)</a> <a href="#ref-for-webvtt-percentage④">(4)</a> <a href="#ref-for-webvtt-percentage⑤">(5)</a>
-    <li><a href="#ref-for-webvtt-percentage⑥">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-percentage⑦">(2)</a> <a href="#ref-for-webvtt-percentage⑧">(3)</a>
-    <li><a href="#ref-for-webvtt-percentage⑨">5.2. WebVTT region settings parsing</a>
+    <li><a href="#ref-for-webvtt-percentage-1">4.1. WebVTT file structure</a>
+    <li><a href="#ref-for-webvtt-percentage-2">4.3. WebVTT region settings</a> <a href="#ref-for-webvtt-percentage-3">(2)</a> <a href="#ref-for-webvtt-percentage-4">(3)</a> <a href="#ref-for-webvtt-percentage-5">(4)</a> <a href="#ref-for-webvtt-percentage-6">(5)</a>
+    <li><a href="#ref-for-webvtt-percentage-7">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-percentage-8">(2)</a> <a href="#ref-for-webvtt-percentage-9">(3)</a>
+    <li><a href="#ref-for-webvtt-percentage-10">5.2. WebVTT region settings parsing</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-comment-block">
    <b><a href="#webvtt-comment-block">#webvtt-comment-block</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-comment-block">4.1. WebVTT file structure</a> <a href="#ref-for-webvtt-comment-block①">(2)</a> <a href="#ref-for-webvtt-comment-block②">(3)</a>
+    <li><a href="#ref-for-webvtt-comment-block-1">4.1. WebVTT file structure</a> <a href="#ref-for-webvtt-comment-block-2">(2)</a> <a href="#ref-for-webvtt-comment-block-3">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-metadata-text">
    <b><a href="#webvtt-metadata-text">#webvtt-metadata-text</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-metadata-text">4.1. WebVTT file structure</a>
-    <li><a href="#ref-for-webvtt-metadata-text①">4.2.1. WebVTT metadata text</a>
-    <li><a href="#ref-for-webvtt-metadata-text②">4.6.1. WebVTT file using metadata content</a>
+    <li><a href="#ref-for-webvtt-metadata-text-1">4.1. WebVTT file structure</a>
+    <li><a href="#ref-for-webvtt-metadata-text-2">4.2.1. WebVTT metadata text</a>
+    <li><a href="#ref-for-webvtt-metadata-text-3">4.6.1. WebVTT file using metadata content</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-text">
    <b><a href="#webvtt-cue-text">#webvtt-cue-text</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-text">3.1. WebVTT cues</a>
-    <li><a href="#ref-for-webvtt-cue-text①">4.1. WebVTT file structure</a>
-    <li><a href="#ref-for-webvtt-cue-text②">4.2.2. WebVTT cue text</a>
-    <li><a href="#ref-for-webvtt-cue-text③">4.2.3. WebVTT chapter title text</a>
-    <li><a href="#ref-for-webvtt-cue-text④">4.6.3. WebVTT file using cue text</a>
-    <li><a href="#ref-for-webvtt-cue-text⑤">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-cue-text⑥">(2)</a> <a href="#ref-for-webvtt-cue-text⑦">(3)</a> <a href="#ref-for-webvtt-cue-text⑧">(4)</a> <a href="#ref-for-webvtt-cue-text⑨">(5)</a> <a href="#ref-for-webvtt-cue-text①⓪">(6)</a> <a href="#ref-for-webvtt-cue-text①①">(7)</a> <a href="#ref-for-webvtt-cue-text①②">(8)</a> <a href="#ref-for-webvtt-cue-text①③">(9)</a> <a href="#ref-for-webvtt-cue-text①④">(10)</a>
+    <li><a href="#ref-for-webvtt-cue-text-1">3.1. WebVTT cues</a>
+    <li><a href="#ref-for-webvtt-cue-text-2">4.1. WebVTT file structure</a>
+    <li><a href="#ref-for-webvtt-cue-text-3">4.2.2. WebVTT cue text</a>
+    <li><a href="#ref-for-webvtt-cue-text-4">4.2.3. WebVTT chapter title text</a>
+    <li><a href="#ref-for-webvtt-cue-text-5">4.6.3. WebVTT file using cue text</a>
+    <li><a href="#ref-for-webvtt-cue-text-6">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-cue-text-7">(2)</a> <a href="#ref-for-webvtt-cue-text-8">(3)</a> <a href="#ref-for-webvtt-cue-text-9">(4)</a> <a href="#ref-for-webvtt-cue-text-10">(5)</a> <a href="#ref-for-webvtt-cue-text-11">(6)</a> <a href="#ref-for-webvtt-cue-text-12">(7)</a> <a href="#ref-for-webvtt-cue-text-13">(8)</a> <a href="#ref-for-webvtt-cue-text-14">(9)</a> <a href="#ref-for-webvtt-cue-text-15">(10)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-components">
    <b><a href="#webvtt-cue-components">#webvtt-cue-components</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-components">4.2.2. WebVTT cue text</a> <a href="#ref-for-webvtt-cue-components①">(2)</a> <a href="#ref-for-webvtt-cue-components②">(3)</a>
+    <li><a href="#ref-for-webvtt-cue-components-1">4.2.2. WebVTT cue text</a> <a href="#ref-for-webvtt-cue-components-2">(2)</a> <a href="#ref-for-webvtt-cue-components-3">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-internal-text">
    <b><a href="#webvtt-cue-internal-text">#webvtt-cue-internal-text</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-internal-text">4.2.2. WebVTT cue text</a> <a href="#ref-for-webvtt-cue-internal-text①">(2)</a> <a href="#ref-for-webvtt-cue-internal-text②">(3)</a> <a href="#ref-for-webvtt-cue-internal-text③">(4)</a> <a href="#ref-for-webvtt-cue-internal-text④">(5)</a> <a href="#ref-for-webvtt-cue-internal-text⑤">(6)</a> <a href="#ref-for-webvtt-cue-internal-text⑥">(7)</a> <a href="#ref-for-webvtt-cue-internal-text⑦">(8)</a>
+    <li><a href="#ref-for-webvtt-cue-internal-text-1">4.2.2. WebVTT cue text</a> <a href="#ref-for-webvtt-cue-internal-text-2">(2)</a> <a href="#ref-for-webvtt-cue-internal-text-3">(3)</a> <a href="#ref-for-webvtt-cue-internal-text-4">(4)</a> <a href="#ref-for-webvtt-cue-internal-text-5">(5)</a> <a href="#ref-for-webvtt-cue-internal-text-6">(6)</a> <a href="#ref-for-webvtt-cue-internal-text-7">(7)</a> <a href="#ref-for-webvtt-cue-internal-text-8">(8)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-class-span">
    <b><a href="#webvtt-cue-class-span">#webvtt-cue-class-span</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-class-span">4.2.2. WebVTT cue text</a>
-    <li><a href="#ref-for-webvtt-cue-class-span①">5.4. WebVTT cue text parsing rules</a>
+    <li><a href="#ref-for-webvtt-cue-class-span-1">4.2.2. WebVTT cue text</a>
+    <li><a href="#ref-for-webvtt-cue-class-span-2">5.4. WebVTT cue text parsing rules</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-italics-span">
    <b><a href="#webvtt-cue-italics-span">#webvtt-cue-italics-span</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-italics-span">4.2.2. WebVTT cue text</a>
-    <li><a href="#ref-for-webvtt-cue-italics-span①">5.4. WebVTT cue text parsing rules</a>
+    <li><a href="#ref-for-webvtt-cue-italics-span-1">4.2.2. WebVTT cue text</a>
+    <li><a href="#ref-for-webvtt-cue-italics-span-2">5.4. WebVTT cue text parsing rules</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-bold-span">
    <b><a href="#webvtt-cue-bold-span">#webvtt-cue-bold-span</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-bold-span">4.2.2. WebVTT cue text</a>
-    <li><a href="#ref-for-webvtt-cue-bold-span①">5.4. WebVTT cue text parsing rules</a>
+    <li><a href="#ref-for-webvtt-cue-bold-span-1">4.2.2. WebVTT cue text</a>
+    <li><a href="#ref-for-webvtt-cue-bold-span-2">5.4. WebVTT cue text parsing rules</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-underline-span">
    <b><a href="#webvtt-cue-underline-span">#webvtt-cue-underline-span</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-underline-span">4.2.2. WebVTT cue text</a>
-    <li><a href="#ref-for-webvtt-cue-underline-span①">5.4. WebVTT cue text parsing rules</a>
+    <li><a href="#ref-for-webvtt-cue-underline-span-1">4.2.2. WebVTT cue text</a>
+    <li><a href="#ref-for-webvtt-cue-underline-span-2">5.4. WebVTT cue text parsing rules</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-ruby-span">
    <b><a href="#webvtt-cue-ruby-span">#webvtt-cue-ruby-span</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-ruby-span">4.2.2. WebVTT cue text</a> <a href="#ref-for-webvtt-cue-ruby-span①">(2)</a>
-    <li><a href="#ref-for-webvtt-cue-ruby-span②">5.4. WebVTT cue text parsing rules</a>
+    <li><a href="#ref-for-webvtt-cue-ruby-span-1">4.2.2. WebVTT cue text</a> <a href="#ref-for-webvtt-cue-ruby-span-2">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-ruby-span-3">5.4. WebVTT cue text parsing rules</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-ruby-text-span">
    <b><a href="#webvtt-cue-ruby-text-span">#webvtt-cue-ruby-text-span</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-ruby-text-span">5.4. WebVTT cue text parsing rules</a>
+    <li><a href="#ref-for-webvtt-cue-ruby-text-span-1">5.4. WebVTT cue text parsing rules</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-voice-span">
    <b><a href="#webvtt-cue-voice-span">#webvtt-cue-voice-span</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-voice-span">4.2.2. WebVTT cue text</a> <a href="#ref-for-webvtt-cue-voice-span①">(2)</a>
-    <li><a href="#ref-for-webvtt-cue-voice-span②">5.4. WebVTT cue text parsing rules</a>
+    <li><a href="#ref-for-webvtt-cue-voice-span-1">4.2.2. WebVTT cue text</a> <a href="#ref-for-webvtt-cue-voice-span-2">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-voice-span-3">5.4. WebVTT cue text parsing rules</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-language-span">
    <b><a href="#webvtt-cue-language-span">#webvtt-cue-language-span</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-language-span">4.2.2. WebVTT cue text</a>
-    <li><a href="#ref-for-webvtt-cue-language-span①">5.4. WebVTT cue text parsing rules</a>
+    <li><a href="#ref-for-webvtt-cue-language-span-1">4.2.2. WebVTT cue text</a>
+    <li><a href="#ref-for-webvtt-cue-language-span-2">5.4. WebVTT cue text parsing rules</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-span-start-tag">
    <b><a href="#webvtt-cue-span-start-tag">#webvtt-cue-span-start-tag</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-span-start-tag">4.2.2. WebVTT cue text</a> <a href="#ref-for-webvtt-cue-span-start-tag①">(2)</a> <a href="#ref-for-webvtt-cue-span-start-tag②">(3)</a> <a href="#ref-for-webvtt-cue-span-start-tag③">(4)</a> <a href="#ref-for-webvtt-cue-span-start-tag④">(5)</a> <a href="#ref-for-webvtt-cue-span-start-tag⑤">(6)</a> <a href="#ref-for-webvtt-cue-span-start-tag⑥">(7)</a> <a href="#ref-for-webvtt-cue-span-start-tag⑦">(8)</a>
+    <li><a href="#ref-for-webvtt-cue-span-start-tag-1">4.2.2. WebVTT cue text</a> <a href="#ref-for-webvtt-cue-span-start-tag-2">(2)</a> <a href="#ref-for-webvtt-cue-span-start-tag-3">(3)</a> <a href="#ref-for-webvtt-cue-span-start-tag-4">(4)</a> <a href="#ref-for-webvtt-cue-span-start-tag-5">(5)</a> <a href="#ref-for-webvtt-cue-span-start-tag-6">(6)</a> <a href="#ref-for-webvtt-cue-span-start-tag-7">(7)</a> <a href="#ref-for-webvtt-cue-span-start-tag-8">(8)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-span-end-tag">
    <b><a href="#webvtt-cue-span-end-tag">#webvtt-cue-span-end-tag</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-span-end-tag">4.2.2. WebVTT cue text</a> <a href="#ref-for-webvtt-cue-span-end-tag①">(2)</a> <a href="#ref-for-webvtt-cue-span-end-tag②">(3)</a> <a href="#ref-for-webvtt-cue-span-end-tag③">(4)</a> <a href="#ref-for-webvtt-cue-span-end-tag④">(5)</a> <a href="#ref-for-webvtt-cue-span-end-tag⑤">(6)</a> <a href="#ref-for-webvtt-cue-span-end-tag⑥">(7)</a> <a href="#ref-for-webvtt-cue-span-end-tag⑦">(8)</a>
+    <li><a href="#ref-for-webvtt-cue-span-end-tag-1">4.2.2. WebVTT cue text</a> <a href="#ref-for-webvtt-cue-span-end-tag-2">(2)</a> <a href="#ref-for-webvtt-cue-span-end-tag-3">(3)</a> <a href="#ref-for-webvtt-cue-span-end-tag-4">(4)</a> <a href="#ref-for-webvtt-cue-span-end-tag-5">(5)</a> <a href="#ref-for-webvtt-cue-span-end-tag-6">(6)</a> <a href="#ref-for-webvtt-cue-span-end-tag-7">(7)</a> <a href="#ref-for-webvtt-cue-span-end-tag-8">(8)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-timestamp">
    <b><a href="#webvtt-cue-timestamp">#webvtt-cue-timestamp</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-timestamp">4.2.2. WebVTT cue text</a> <a href="#ref-for-webvtt-cue-timestamp①">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-timestamp-1">4.2.2. WebVTT cue text</a> <a href="#ref-for-webvtt-cue-timestamp-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-text-span">
    <b><a href="#webvtt-cue-text-span">#webvtt-cue-text-span</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-text-span">4.2.2. WebVTT cue text</a>
-    <li><a href="#ref-for-webvtt-cue-text-span①">4.2.3. WebVTT chapter title text</a>
+    <li><a href="#ref-for-webvtt-cue-text-span-1">4.2.2. WebVTT cue text</a>
+    <li><a href="#ref-for-webvtt-cue-text-span-2">4.2.3. WebVTT chapter title text</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-span-start-tag-annotation-text">
    <b><a href="#webvtt-cue-span-start-tag-annotation-text">#webvtt-cue-span-start-tag-annotation-text</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-span-start-tag-annotation-text">4.2.2. WebVTT cue text</a>
+    <li><a href="#ref-for-webvtt-cue-span-start-tag-annotation-text-1">4.2.2. WebVTT cue text</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-chapter-title-text">
    <b><a href="#webvtt-chapter-title-text">#webvtt-chapter-title-text</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-chapter-title-text">4.1. WebVTT file structure</a>
-    <li><a href="#ref-for-webvtt-chapter-title-text①">4.6.2. WebVTT file using chapter title text</a>
+    <li><a href="#ref-for-webvtt-chapter-title-text-1">4.1. WebVTT file structure</a>
+    <li><a href="#ref-for-webvtt-chapter-title-text-2">4.6.2. WebVTT file using chapter title text</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-region-settings-list">
    <b><a href="#webvtt-region-settings-list">#webvtt-region-settings-list</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-region-settings-list">4.1. WebVTT file structure</a>
-    <li><a href="#ref-for-webvtt-region-settings-list①">4.3. WebVTT region settings</a> <a href="#ref-for-webvtt-region-settings-list②">(2)</a>
+    <li><a href="#ref-for-webvtt-region-settings-list-1">4.1. WebVTT file structure</a>
+    <li><a href="#ref-for-webvtt-region-settings-list-2">4.3. WebVTT region settings</a> <a href="#ref-for-webvtt-region-settings-list-3">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-region-identifier-setting">
    <b><a href="#webvtt-region-identifier-setting">#webvtt-region-identifier-setting</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-region-identifier-setting">4.3. WebVTT region settings</a> <a href="#ref-for-webvtt-region-identifier-setting①">(2)</a> <a href="#ref-for-webvtt-region-identifier-setting②">(3)</a> <a href="#ref-for-webvtt-region-identifier-setting③">(4)</a> <a href="#ref-for-webvtt-region-identifier-setting④">(5)</a>
+    <li><a href="#ref-for-webvtt-region-identifier-setting-1">4.3. WebVTT region settings</a> <a href="#ref-for-webvtt-region-identifier-setting-2">(2)</a> <a href="#ref-for-webvtt-region-identifier-setting-3">(3)</a> <a href="#ref-for-webvtt-region-identifier-setting-4">(4)</a> <a href="#ref-for-webvtt-region-identifier-setting-5">(5)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-region-width-setting">
    <b><a href="#webvtt-region-width-setting">#webvtt-region-width-setting</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-region-width-setting">4.3. WebVTT region settings</a> <a href="#ref-for-webvtt-region-width-setting①">(2)</a>
+    <li><a href="#ref-for-webvtt-region-width-setting-1">4.3. WebVTT region settings</a> <a href="#ref-for-webvtt-region-width-setting-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-region-lines-setting">
    <b><a href="#webvtt-region-lines-setting">#webvtt-region-lines-setting</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-region-lines-setting">4.3. WebVTT region settings</a> <a href="#ref-for-webvtt-region-lines-setting①">(2)</a>
+    <li><a href="#ref-for-webvtt-region-lines-setting-1">4.3. WebVTT region settings</a> <a href="#ref-for-webvtt-region-lines-setting-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-region-anchor-setting">
    <b><a href="#webvtt-region-anchor-setting">#webvtt-region-anchor-setting</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-region-anchor-setting">4.3. WebVTT region settings</a> <a href="#ref-for-webvtt-region-anchor-setting①">(2)</a> <a href="#ref-for-webvtt-region-anchor-setting②">(3)</a>
+    <li><a href="#ref-for-webvtt-region-anchor-setting-1">4.3. WebVTT region settings</a> <a href="#ref-for-webvtt-region-anchor-setting-2">(2)</a> <a href="#ref-for-webvtt-region-anchor-setting-3">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-region-viewport-anchor-setting">
    <b><a href="#webvtt-region-viewport-anchor-setting">#webvtt-region-viewport-anchor-setting</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-region-viewport-anchor-setting">4.3. WebVTT region settings</a> <a href="#ref-for-webvtt-region-viewport-anchor-setting①">(2)</a>
+    <li><a href="#ref-for-webvtt-region-viewport-anchor-setting-1">4.3. WebVTT region settings</a> <a href="#ref-for-webvtt-region-viewport-anchor-setting-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-region-scroll-setting">
    <b><a href="#webvtt-region-scroll-setting">#webvtt-region-scroll-setting</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-region-scroll-setting">4.3. WebVTT region settings</a> <a href="#ref-for-webvtt-region-scroll-setting①">(2)</a>
+    <li><a href="#ref-for-webvtt-region-scroll-setting-1">4.3. WebVTT region settings</a> <a href="#ref-for-webvtt-region-scroll-setting-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-vertical-text-cue-setting">
    <b><a href="#webvtt-vertical-text-cue-setting">#webvtt-vertical-text-cue-setting</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-vertical-text-cue-setting">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-vertical-text-cue-setting①">(2)</a> <a href="#ref-for-webvtt-vertical-text-cue-setting②">(3)</a>
+    <li><a href="#ref-for-webvtt-vertical-text-cue-setting-1">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-vertical-text-cue-setting-2">(2)</a> <a href="#ref-for-webvtt-vertical-text-cue-setting-3">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-line-cue-setting">
    <b><a href="#webvtt-line-cue-setting">#webvtt-line-cue-setting</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-line-cue-setting">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-line-cue-setting①">(2)</a> <a href="#ref-for-webvtt-line-cue-setting②">(3)</a> <a href="#ref-for-webvtt-line-cue-setting③">(4)</a>
+    <li><a href="#ref-for-webvtt-line-cue-setting-1">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-line-cue-setting-2">(2)</a> <a href="#ref-for-webvtt-line-cue-setting-3">(3)</a> <a href="#ref-for-webvtt-line-cue-setting-4">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-position-cue-setting">
    <b><a href="#webvtt-position-cue-setting">#webvtt-position-cue-setting</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-position-cue-setting">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-position-cue-setting①">(2)</a> <a href="#ref-for-webvtt-position-cue-setting②">(3)</a> <a href="#ref-for-webvtt-position-cue-setting③">(4)</a> <a href="#ref-for-webvtt-position-cue-setting④">(5)</a>
+    <li><a href="#ref-for-webvtt-position-cue-setting-1">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-position-cue-setting-2">(2)</a> <a href="#ref-for-webvtt-position-cue-setting-3">(3)</a> <a href="#ref-for-webvtt-position-cue-setting-4">(4)</a> <a href="#ref-for-webvtt-position-cue-setting-5">(5)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-size-cue-setting">
    <b><a href="#webvtt-size-cue-setting">#webvtt-size-cue-setting</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-size-cue-setting">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-size-cue-setting①">(2)</a> <a href="#ref-for-webvtt-size-cue-setting②">(3)</a>
+    <li><a href="#ref-for-webvtt-size-cue-setting-1">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-size-cue-setting-2">(2)</a> <a href="#ref-for-webvtt-size-cue-setting-3">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-alignment-cue-setting">
    <b><a href="#webvtt-alignment-cue-setting">#webvtt-alignment-cue-setting</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-alignment-cue-setting">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-alignment-cue-setting①">(2)</a> <a href="#ref-for-webvtt-alignment-cue-setting②">(3)</a>
+    <li><a href="#ref-for-webvtt-alignment-cue-setting-1">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-alignment-cue-setting-2">(2)</a> <a href="#ref-for-webvtt-alignment-cue-setting-3">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-region-cue-setting">
    <b><a href="#webvtt-region-cue-setting">#webvtt-region-cue-setting</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-region-cue-setting">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-region-cue-setting①">(2)</a>
+    <li><a href="#ref-for-webvtt-region-cue-setting-1">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-region-cue-setting-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-file-using-only-nested-cues">
    <b><a href="#webvtt-file-using-only-nested-cues">#webvtt-file-using-only-nested-cues</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-file-using-only-nested-cues">4.5.1. WebVTT file using only nested cues</a> <a href="#ref-for-webvtt-file-using-only-nested-cues①">(2)</a>
-    <li><a href="#ref-for-webvtt-file-using-only-nested-cues②">4.6.2. WebVTT file using chapter title text</a>
+    <li><a href="#ref-for-webvtt-file-using-only-nested-cues-1">4.5.1. WebVTT file using only nested cues</a> <a href="#ref-for-webvtt-file-using-only-nested-cues-2">(2)</a>
+    <li><a href="#ref-for-webvtt-file-using-only-nested-cues-3">4.6.2. WebVTT file using chapter title text</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-parser">
    <b><a href="#webvtt-parser">#webvtt-parser</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-parser">3.1. WebVTT cues</a>
-    <li><a href="#ref-for-webvtt-parser①">5.1. WebVTT file parsing</a> <a href="#ref-for-webvtt-parser②">(2)</a> <a href="#ref-for-webvtt-parser③">(3)</a>
-    <li><a href="#ref-for-webvtt-parser④">5.2. WebVTT region settings parsing</a>
+    <li><a href="#ref-for-webvtt-parser-1">3.1. WebVTT cues</a>
+    <li><a href="#ref-for-webvtt-parser-2">5.1. WebVTT file parsing</a> <a href="#ref-for-webvtt-parser-3">(2)</a> <a href="#ref-for-webvtt-parser-4">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="incremental-webvtt-parser">
    <b><a href="#incremental-webvtt-parser">#incremental-webvtt-parser</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-incremental-webvtt-parser">5.1. WebVTT file parsing</a>
+    <li><a href="#ref-for-incremental-webvtt-parser-1">5.1. WebVTT file parsing</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-parser-algorithm">
    <b><a href="#webvtt-parser-algorithm">#webvtt-parser-algorithm</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-parser-algorithm">5.1. WebVTT file parsing</a>
+    <li><a href="#ref-for-webvtt-parser-algorithm-1">5.1. WebVTT file parsing</a>
+    <li><a href="#ref-for-webvtt-parser-algorithm-2">5.2. WebVTT region settings parsing</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="collect-a-webvtt-block">
    <b><a href="#collect-a-webvtt-block">#collect-a-webvtt-block</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-collect-a-webvtt-block">5.1. WebVTT file parsing</a> <a href="#ref-for-collect-a-webvtt-block①">(2)</a>
+    <li><a href="#ref-for-collect-a-webvtt-block-1">5.1. WebVTT file parsing</a> <a href="#ref-for-collect-a-webvtt-block-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="collect-webvtt-region-settings">
    <b><a href="#collect-webvtt-region-settings">#collect-webvtt-region-settings</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-collect-webvtt-region-settings">5.1. WebVTT file parsing</a>
+    <li><a href="#ref-for-collect-webvtt-region-settings-1">5.1. WebVTT file parsing</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-region-object">
    <b><a href="#webvtt-region-object">#webvtt-region-object</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-region-object">5.1. WebVTT file parsing</a> <a href="#ref-for-webvtt-region-object①">(2)</a>
-    <li><a href="#ref-for-webvtt-region-object②">5.2. WebVTT region settings parsing</a>
-    <li><a href="#ref-for-webvtt-region-object③">5.5. WebVTT cue text DOM construction rules</a>
-    <li><a href="#ref-for-webvtt-region-object④">6.1. Processing model</a>
-    <li><a href="#ref-for-webvtt-region-object⑤">6.1.1. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-webvtt-region-object⑥">(2)</a> <a href="#ref-for-webvtt-region-object⑦">(3)</a> <a href="#ref-for-webvtt-region-object⑧">(4)</a>
-    <li><a href="#ref-for-webvtt-region-object⑨">7.1. Introduction</a> <a href="#ref-for-webvtt-region-object①⓪">(2)</a>
-    <li><a href="#ref-for-webvtt-region-object①①">7.2.3. The ::cue-region pseudo-element</a> <a href="#ref-for-webvtt-region-object①②">(2)</a> <a href="#ref-for-webvtt-region-object①③">(3)</a> <a href="#ref-for-webvtt-region-object①④">(4)</a>
+    <li><a href="#ref-for-webvtt-region-object-1">5.1. WebVTT file parsing</a> <a href="#ref-for-webvtt-region-object-2">(2)</a>
+    <li><a href="#ref-for-webvtt-region-object-3">5.2. WebVTT region settings parsing</a>
+    <li><a href="#ref-for-webvtt-region-object-4">5.5. WebVTT cue text DOM construction rules</a>
+    <li><a href="#ref-for-webvtt-region-object-5">6.1. Processing model</a>
+    <li><a href="#ref-for-webvtt-region-object-6">6.1.1. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-webvtt-region-object-7">(2)</a> <a href="#ref-for-webvtt-region-object-8">(3)</a> <a href="#ref-for-webvtt-region-object-9">(4)</a>
+    <li><a href="#ref-for-webvtt-region-object-10">7.1. Introduction</a> <a href="#ref-for-webvtt-region-object-11">(2)</a>
+    <li><a href="#ref-for-webvtt-region-object-12">7.2.3. The ::cue-region pseudo-element</a> <a href="#ref-for-webvtt-region-object-13">(2)</a> <a href="#ref-for-webvtt-region-object-14">(3)</a> <a href="#ref-for-webvtt-region-object-15">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="parse-a-percentage-string">
    <b><a href="#parse-a-percentage-string">#parse-a-percentage-string</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-parse-a-percentage-string">5.2. WebVTT region settings parsing</a> <a href="#ref-for-parse-a-percentage-string①">(2)</a> <a href="#ref-for-parse-a-percentage-string②">(3)</a> <a href="#ref-for-parse-a-percentage-string③">(4)</a> <a href="#ref-for-parse-a-percentage-string④">(5)</a>
-    <li><a href="#ref-for-parse-a-percentage-string⑤">5.3. WebVTT cue timings and settings parsing</a> <a href="#ref-for-parse-a-percentage-string⑥">(2)</a> <a href="#ref-for-parse-a-percentage-string⑦">(3)</a>
+    <li><a href="#ref-for-parse-a-percentage-string-1">5.2. WebVTT region settings parsing</a> <a href="#ref-for-parse-a-percentage-string-2">(2)</a> <a href="#ref-for-parse-a-percentage-string-3">(3)</a> <a href="#ref-for-parse-a-percentage-string-4">(4)</a> <a href="#ref-for-parse-a-percentage-string-5">(5)</a>
+    <li><a href="#ref-for-parse-a-percentage-string-6">5.3. WebVTT cue timings and settings parsing</a> <a href="#ref-for-parse-a-percentage-string-7">(2)</a> <a href="#ref-for-parse-a-percentage-string-8">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="collect-webvtt-cue-timings-and-settings">
    <b><a href="#collect-webvtt-cue-timings-and-settings">#collect-webvtt-cue-timings-and-settings</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-collect-webvtt-cue-timings-and-settings">5.1. WebVTT file parsing</a>
+    <li><a href="#ref-for-collect-webvtt-cue-timings-and-settings-1">5.1. WebVTT file parsing</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="parse-the-webvtt-cue-settings">
    <b><a href="#parse-the-webvtt-cue-settings">#parse-the-webvtt-cue-settings</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-parse-the-webvtt-cue-settings">5.3. WebVTT cue timings and settings parsing</a>
+    <li><a href="#ref-for-parse-the-webvtt-cue-settings-1">5.3. WebVTT cue timings and settings parsing</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="collect-a-webvtt-timestamp">
    <b><a href="#collect-a-webvtt-timestamp">#collect-a-webvtt-timestamp</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-collect-a-webvtt-timestamp">5.3. WebVTT cue timings and settings parsing</a> <a href="#ref-for-collect-a-webvtt-timestamp①">(2)</a>
-    <li><a href="#ref-for-collect-a-webvtt-timestamp②">5.4. WebVTT cue text parsing rules</a>
+    <li><a href="#ref-for-collect-a-webvtt-timestamp-1">5.3. WebVTT cue timings and settings parsing</a> <a href="#ref-for-collect-a-webvtt-timestamp-2">(2)</a>
+    <li><a href="#ref-for-collect-a-webvtt-timestamp-3">5.4. WebVTT cue text parsing rules</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-node-object">
    <b><a href="#webvtt-node-object">#webvtt-node-object</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-node-object">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-node-object①">(2)</a> <a href="#ref-for-webvtt-node-object②">(3)</a> <a href="#ref-for-webvtt-node-object③">(4)</a> <a href="#ref-for-webvtt-node-object④">(5)</a>
-    <li><a href="#ref-for-webvtt-node-object⑤">5.5. WebVTT cue text DOM construction rules</a> <a href="#ref-for-webvtt-node-object⑥">(2)</a> <a href="#ref-for-webvtt-node-object⑦">(3)</a>
-    <li><a href="#ref-for-webvtt-node-object⑧">6.1. Processing model</a> <a href="#ref-for-webvtt-node-object⑨">(2)</a>
-    <li><a href="#ref-for-webvtt-node-object①⓪">6.1.1. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-webvtt-node-object①①">(2)</a>
-    <li><a href="#ref-for-webvtt-node-object①②">7.2. Processing model</a> <a href="#ref-for-webvtt-node-object①③">(2)</a>
-    <li><a href="#ref-for-webvtt-node-object①④">7.2.1. The ::cue pseudo-element</a>
-    <li><a href="#ref-for-webvtt-node-object①⑤">7.2.2. The :past and :future pseudo-classes</a> <a href="#ref-for-webvtt-node-object①⑥">(2)</a> <a href="#ref-for-webvtt-node-object①⑦">(3)</a> <a href="#ref-for-webvtt-node-object①⑧">(4)</a> <a href="#ref-for-webvtt-node-object①⑨">(5)</a> <a href="#ref-for-webvtt-node-object②⓪">(6)</a> <a href="#ref-for-webvtt-node-object②①">(7)</a>
+    <li><a href="#ref-for-webvtt-node-object-1">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-node-object-2">(2)</a> <a href="#ref-for-webvtt-node-object-3">(3)</a> <a href="#ref-for-webvtt-node-object-4">(4)</a> <a href="#ref-for-webvtt-node-object-5">(5)</a>
+    <li><a href="#ref-for-webvtt-node-object-6">5.5. WebVTT cue text DOM construction rules</a> <a href="#ref-for-webvtt-node-object-7">(2)</a> <a href="#ref-for-webvtt-node-object-8">(3)</a>
+    <li><a href="#ref-for-webvtt-node-object-9">6.1. Processing model</a> <a href="#ref-for-webvtt-node-object-10">(2)</a>
+    <li><a href="#ref-for-webvtt-node-object-11">6.1.1. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-webvtt-node-object-12">(2)</a>
+    <li><a href="#ref-for-webvtt-node-object-13">7.2. Processing model</a> <a href="#ref-for-webvtt-node-object-14">(2)</a>
+    <li><a href="#ref-for-webvtt-node-object-15">7.2.1. The ::cue pseudo-element</a>
+    <li><a href="#ref-for-webvtt-node-object-16">7.2.2. The :past and :future pseudo-classes</a> <a href="#ref-for-webvtt-node-object-17">(2)</a> <a href="#ref-for-webvtt-node-object-18">(3)</a> <a href="#ref-for-webvtt-node-object-19">(4)</a> <a href="#ref-for-webvtt-node-object-20">(5)</a> <a href="#ref-for-webvtt-node-object-21">(6)</a> <a href="#ref-for-webvtt-node-object-22">(7)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-internal-node-object">
    <b><a href="#webvtt-internal-node-object">#webvtt-internal-node-object</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-internal-node-object">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-internal-node-object①">(2)</a> <a href="#ref-for-webvtt-internal-node-object②">(3)</a> <a href="#ref-for-webvtt-internal-node-object③">(4)</a> <a href="#ref-for-webvtt-internal-node-object④">(5)</a> <a href="#ref-for-webvtt-internal-node-object⑤">(6)</a> <a href="#ref-for-webvtt-internal-node-object⑥">(7)</a>
-    <li><a href="#ref-for-webvtt-internal-node-object⑦">5.5. WebVTT cue text DOM construction rules</a>
-    <li><a href="#ref-for-webvtt-internal-node-object⑧">6.1. Processing model</a>
-    <li><a href="#ref-for-webvtt-internal-node-object⑨">7.1. Introduction</a> <a href="#ref-for-webvtt-internal-node-object①⓪">(2)</a> <a href="#ref-for-webvtt-internal-node-object①①">(3)</a> <a href="#ref-for-webvtt-internal-node-object①②">(4)</a> <a href="#ref-for-webvtt-internal-node-object①③">(5)</a>
-    <li><a href="#ref-for-webvtt-internal-node-object①④">7.2.1. The ::cue pseudo-element</a> <a href="#ref-for-webvtt-internal-node-object①⑤">(2)</a> <a href="#ref-for-webvtt-internal-node-object①⑥">(3)</a> <a href="#ref-for-webvtt-internal-node-object①⑦">(4)</a> <a href="#ref-for-webvtt-internal-node-object①⑧">(5)</a> <a href="#ref-for-webvtt-internal-node-object①⑨">(6)</a> <a href="#ref-for-webvtt-internal-node-object②⓪">(7)</a>
+    <li><a href="#ref-for-webvtt-internal-node-object-1">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-internal-node-object-2">(2)</a> <a href="#ref-for-webvtt-internal-node-object-3">(3)</a> <a href="#ref-for-webvtt-internal-node-object-4">(4)</a> <a href="#ref-for-webvtt-internal-node-object-5">(5)</a> <a href="#ref-for-webvtt-internal-node-object-6">(6)</a> <a href="#ref-for-webvtt-internal-node-object-7">(7)</a>
+    <li><a href="#ref-for-webvtt-internal-node-object-8">5.5. WebVTT cue text DOM construction rules</a>
+    <li><a href="#ref-for-webvtt-internal-node-object-9">6.1. Processing model</a>
+    <li><a href="#ref-for-webvtt-internal-node-object-10">7.1. Introduction</a> <a href="#ref-for-webvtt-internal-node-object-11">(2)</a> <a href="#ref-for-webvtt-internal-node-object-12">(3)</a> <a href="#ref-for-webvtt-internal-node-object-13">(4)</a> <a href="#ref-for-webvtt-internal-node-object-14">(5)</a>
+    <li><a href="#ref-for-webvtt-internal-node-object-15">7.2.1. The ::cue pseudo-element</a> <a href="#ref-for-webvtt-internal-node-object-16">(2)</a> <a href="#ref-for-webvtt-internal-node-object-17">(3)</a> <a href="#ref-for-webvtt-internal-node-object-18">(4)</a> <a href="#ref-for-webvtt-internal-node-object-19">(5)</a> <a href="#ref-for-webvtt-internal-node-object-20">(6)</a> <a href="#ref-for-webvtt-internal-node-object-21">(7)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-node-objects-applicable-classes">
    <b><a href="#webvtt-node-objects-applicable-classes">#webvtt-node-objects-applicable-classes</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-node-objects-applicable-classes">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-node-objects-applicable-classes①">(2)</a>
-    <li><a href="#ref-for-webvtt-node-objects-applicable-classes②">5.5. WebVTT cue text DOM construction rules</a>
-    <li><a href="#ref-for-webvtt-node-objects-applicable-classes③">7.1. Introduction</a>
-    <li><a href="#ref-for-webvtt-node-objects-applicable-classes④">7.2.1. The ::cue pseudo-element</a>
+    <li><a href="#ref-for-webvtt-node-objects-applicable-classes-1">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-node-objects-applicable-classes-2">(2)</a>
+    <li><a href="#ref-for-webvtt-node-objects-applicable-classes-3">5.5. WebVTT cue text DOM construction rules</a>
+    <li><a href="#ref-for-webvtt-node-objects-applicable-classes-4">7.1. Introduction</a>
+    <li><a href="#ref-for-webvtt-node-objects-applicable-classes-5">7.2.1. The ::cue pseudo-element</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-node-objects-applicable-language">
    <b><a href="#webvtt-node-objects-applicable-language">#webvtt-node-objects-applicable-language</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-node-objects-applicable-language">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-node-objects-applicable-language①">(2)</a> <a href="#ref-for-webvtt-node-objects-applicable-language②">(3)</a> <a href="#ref-for-webvtt-node-objects-applicable-language③">(4)</a>
-    <li><a href="#ref-for-webvtt-node-objects-applicable-language④">5.5. WebVTT cue text DOM construction rules</a>
-    <li><a href="#ref-for-webvtt-node-objects-applicable-language⑤">7.1. Introduction</a> <a href="#ref-for-webvtt-node-objects-applicable-language⑥">(2)</a> <a href="#ref-for-webvtt-node-objects-applicable-language⑦">(3)</a> <a href="#ref-for-webvtt-node-objects-applicable-language⑧">(4)</a>
-    <li><a href="#ref-for-webvtt-node-objects-applicable-language⑨">7.2.1. The ::cue pseudo-element</a> <a href="#ref-for-webvtt-node-objects-applicable-language①⓪">(2)</a> <a href="#ref-for-webvtt-node-objects-applicable-language①①">(3)</a> <a href="#ref-for-webvtt-node-objects-applicable-language①②">(4)</a>
+    <li><a href="#ref-for-webvtt-node-objects-applicable-language-1">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-node-objects-applicable-language-2">(2)</a> <a href="#ref-for-webvtt-node-objects-applicable-language-3">(3)</a> <a href="#ref-for-webvtt-node-objects-applicable-language-4">(4)</a>
+    <li><a href="#ref-for-webvtt-node-objects-applicable-language-5">5.5. WebVTT cue text DOM construction rules</a>
+    <li><a href="#ref-for-webvtt-node-objects-applicable-language-6">7.1. Introduction</a> <a href="#ref-for-webvtt-node-objects-applicable-language-7">(2)</a> <a href="#ref-for-webvtt-node-objects-applicable-language-8">(3)</a> <a href="#ref-for-webvtt-node-objects-applicable-language-9">(4)</a>
+    <li><a href="#ref-for-webvtt-node-objects-applicable-language-10">7.2.1. The ::cue pseudo-element</a> <a href="#ref-for-webvtt-node-objects-applicable-language-11">(2)</a> <a href="#ref-for-webvtt-node-objects-applicable-language-12">(3)</a> <a href="#ref-for-webvtt-node-objects-applicable-language-13">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="list-of-webvtt-node-objects">
    <b><a href="#list-of-webvtt-node-objects">#list-of-webvtt-node-objects</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-list-of-webvtt-node-objects">5.2. WebVTT region settings parsing</a>
-    <li><a href="#ref-for-list-of-webvtt-node-objects①">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-list-of-webvtt-node-objects②">(2)</a>
-    <li><a href="#ref-for-list-of-webvtt-node-objects③">5.5. WebVTT cue text DOM construction rules</a> <a href="#ref-for-list-of-webvtt-node-objects④">(2)</a>
-    <li><a href="#ref-for-list-of-webvtt-node-objects⑤">5.6. WebVTT rules for extracting the chapter
+    <li><a href="#ref-for-list-of-webvtt-node-objects-1">5.2. WebVTT region settings parsing</a>
+    <li><a href="#ref-for-list-of-webvtt-node-objects-2">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-list-of-webvtt-node-objects-3">(2)</a>
+    <li><a href="#ref-for-list-of-webvtt-node-objects-4">5.5. WebVTT cue text DOM construction rules</a> <a href="#ref-for-list-of-webvtt-node-objects-5">(2)</a>
+    <li><a href="#ref-for-list-of-webvtt-node-objects-6">5.6. WebVTT rules for extracting the chapter
 title</a>
-    <li><a href="#ref-for-list-of-webvtt-node-objects⑥">6.1. Processing model</a> <a href="#ref-for-list-of-webvtt-node-objects⑦">(2)</a>
-    <li><a href="#ref-for-list-of-webvtt-node-objects⑧">6.1.1. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-list-of-webvtt-node-objects⑨">(2)</a> <a href="#ref-for-list-of-webvtt-node-objects①⓪">(3)</a> <a href="#ref-for-list-of-webvtt-node-objects①①">(4)</a> <a href="#ref-for-list-of-webvtt-node-objects①②">(5)</a> <a href="#ref-for-list-of-webvtt-node-objects①③">(6)</a> <a href="#ref-for-list-of-webvtt-node-objects①④">(7)</a> <a href="#ref-for-list-of-webvtt-node-objects①⑤">(8)</a> <a href="#ref-for-list-of-webvtt-node-objects①⑥">(9)</a>
-    <li><a href="#ref-for-list-of-webvtt-node-objects①⑦">7.1. Introduction</a> <a href="#ref-for-list-of-webvtt-node-objects①⑧">(2)</a> <a href="#ref-for-list-of-webvtt-node-objects①⑨">(3)</a> <a href="#ref-for-list-of-webvtt-node-objects②⓪">(4)</a> <a href="#ref-for-list-of-webvtt-node-objects②①">(5)</a> <a href="#ref-for-list-of-webvtt-node-objects②②">(6)</a> <a href="#ref-for-list-of-webvtt-node-objects②③">(7)</a>
-    <li><a href="#ref-for-list-of-webvtt-node-objects②④">7.2. Processing model</a>
-    <li><a href="#ref-for-list-of-webvtt-node-objects②⑤">7.2.1. The ::cue pseudo-element</a> <a href="#ref-for-list-of-webvtt-node-objects②⑥">(2)</a> <a href="#ref-for-list-of-webvtt-node-objects②⑦">(3)</a> <a href="#ref-for-list-of-webvtt-node-objects②⑧">(4)</a> <a href="#ref-for-list-of-webvtt-node-objects②⑨">(5)</a> <a href="#ref-for-list-of-webvtt-node-objects③⓪">(6)</a> <a href="#ref-for-list-of-webvtt-node-objects③①">(7)</a>
-    <li><a href="#ref-for-list-of-webvtt-node-objects③②">7.2.2. The :past and :future pseudo-classes</a> <a href="#ref-for-list-of-webvtt-node-objects③③">(2)</a>
+    <li><a href="#ref-for-list-of-webvtt-node-objects-7">6.1. Processing model</a> <a href="#ref-for-list-of-webvtt-node-objects-8">(2)</a>
+    <li><a href="#ref-for-list-of-webvtt-node-objects-9">6.1.1. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-list-of-webvtt-node-objects-10">(2)</a> <a href="#ref-for-list-of-webvtt-node-objects-11">(3)</a> <a href="#ref-for-list-of-webvtt-node-objects-12">(4)</a> <a href="#ref-for-list-of-webvtt-node-objects-13">(5)</a> <a href="#ref-for-list-of-webvtt-node-objects-14">(6)</a> <a href="#ref-for-list-of-webvtt-node-objects-15">(7)</a> <a href="#ref-for-list-of-webvtt-node-objects-16">(8)</a> <a href="#ref-for-list-of-webvtt-node-objects-17">(9)</a>
+    <li><a href="#ref-for-list-of-webvtt-node-objects-18">7.1. Introduction</a> <a href="#ref-for-list-of-webvtt-node-objects-19">(2)</a> <a href="#ref-for-list-of-webvtt-node-objects-20">(3)</a> <a href="#ref-for-list-of-webvtt-node-objects-21">(4)</a> <a href="#ref-for-list-of-webvtt-node-objects-22">(5)</a> <a href="#ref-for-list-of-webvtt-node-objects-23">(6)</a> <a href="#ref-for-list-of-webvtt-node-objects-24">(7)</a>
+    <li><a href="#ref-for-list-of-webvtt-node-objects-25">7.2. Processing model</a>
+    <li><a href="#ref-for-list-of-webvtt-node-objects-26">7.2.1. The ::cue pseudo-element</a> <a href="#ref-for-list-of-webvtt-node-objects-27">(2)</a> <a href="#ref-for-list-of-webvtt-node-objects-28">(3)</a> <a href="#ref-for-list-of-webvtt-node-objects-29">(4)</a> <a href="#ref-for-list-of-webvtt-node-objects-30">(5)</a> <a href="#ref-for-list-of-webvtt-node-objects-31">(6)</a> <a href="#ref-for-list-of-webvtt-node-objects-32">(7)</a>
+    <li><a href="#ref-for-list-of-webvtt-node-objects-33">7.2.2. The :past and :future pseudo-classes</a> <a href="#ref-for-list-of-webvtt-node-objects-34">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-class-object">
    <b><a href="#webvtt-class-object">#webvtt-class-object</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-class-object">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-class-object①">(2)</a>
-    <li><a href="#ref-for-webvtt-class-object②">5.5. WebVTT cue text DOM construction rules</a>
-    <li><a href="#ref-for-webvtt-class-object③">7.2.1. The ::cue pseudo-element</a>
+    <li><a href="#ref-for-webvtt-class-object-1">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-class-object-2">(2)</a>
+    <li><a href="#ref-for-webvtt-class-object-3">5.5. WebVTT cue text DOM construction rules</a>
+    <li><a href="#ref-for-webvtt-class-object-4">7.2.1. The ::cue pseudo-element</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-italic-object">
    <b><a href="#webvtt-italic-object">#webvtt-italic-object</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-italic-object">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-italic-object①">(2)</a>
-    <li><a href="#ref-for-webvtt-italic-object②">5.5. WebVTT cue text DOM construction rules</a>
-    <li><a href="#ref-for-webvtt-italic-object③">6.1.1. Applying CSS properties to WebVTT Node Objects</a>
-    <li><a href="#ref-for-webvtt-italic-object④">7.2.1. The ::cue pseudo-element</a>
+    <li><a href="#ref-for-webvtt-italic-object-1">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-italic-object-2">(2)</a>
+    <li><a href="#ref-for-webvtt-italic-object-3">5.5. WebVTT cue text DOM construction rules</a>
+    <li><a href="#ref-for-webvtt-italic-object-4">6.1.1. Applying CSS properties to WebVTT Node Objects</a>
+    <li><a href="#ref-for-webvtt-italic-object-5">7.2.1. The ::cue pseudo-element</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-bold-object">
    <b><a href="#webvtt-bold-object">#webvtt-bold-object</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-bold-object">1.3. Styling</a>
-    <li><a href="#ref-for-webvtt-bold-object①">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-bold-object②">(2)</a>
-    <li><a href="#ref-for-webvtt-bold-object③">5.5. WebVTT cue text DOM construction rules</a>
-    <li><a href="#ref-for-webvtt-bold-object④">6.1.1. Applying CSS properties to WebVTT Node Objects</a>
-    <li><a href="#ref-for-webvtt-bold-object⑤">7.2.1. The ::cue pseudo-element</a>
+    <li><a href="#ref-for-webvtt-bold-object-1">1.3. Styling</a>
+    <li><a href="#ref-for-webvtt-bold-object-2">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-bold-object-3">(2)</a>
+    <li><a href="#ref-for-webvtt-bold-object-4">5.5. WebVTT cue text DOM construction rules</a>
+    <li><a href="#ref-for-webvtt-bold-object-5">6.1.1. Applying CSS properties to WebVTT Node Objects</a>
+    <li><a href="#ref-for-webvtt-bold-object-6">7.2.1. The ::cue pseudo-element</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-underline-object">
    <b><a href="#webvtt-underline-object">#webvtt-underline-object</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-underline-object">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-underline-object①">(2)</a>
-    <li><a href="#ref-for-webvtt-underline-object②">5.5. WebVTT cue text DOM construction rules</a>
-    <li><a href="#ref-for-webvtt-underline-object③">6.1.1. Applying CSS properties to WebVTT Node Objects</a>
-    <li><a href="#ref-for-webvtt-underline-object④">7.2.1. The ::cue pseudo-element</a>
+    <li><a href="#ref-for-webvtt-underline-object-1">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-underline-object-2">(2)</a>
+    <li><a href="#ref-for-webvtt-underline-object-3">5.5. WebVTT cue text DOM construction rules</a>
+    <li><a href="#ref-for-webvtt-underline-object-4">6.1.1. Applying CSS properties to WebVTT Node Objects</a>
+    <li><a href="#ref-for-webvtt-underline-object-5">7.2.1. The ::cue pseudo-element</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-ruby-object">
    <b><a href="#webvtt-ruby-object">#webvtt-ruby-object</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-ruby-object">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-ruby-object①">(2)</a> <a href="#ref-for-webvtt-ruby-object②">(3)</a>
-    <li><a href="#ref-for-webvtt-ruby-object③">5.5. WebVTT cue text DOM construction rules</a>
-    <li><a href="#ref-for-webvtt-ruby-object④">6.1. Processing model</a>
-    <li><a href="#ref-for-webvtt-ruby-object⑤">6.1.1. Applying CSS properties to WebVTT Node Objects</a>
-    <li><a href="#ref-for-webvtt-ruby-object⑥">7.2.1. The ::cue pseudo-element</a>
+    <li><a href="#ref-for-webvtt-ruby-object-1">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-ruby-object-2">(2)</a> <a href="#ref-for-webvtt-ruby-object-3">(3)</a>
+    <li><a href="#ref-for-webvtt-ruby-object-4">5.5. WebVTT cue text DOM construction rules</a>
+    <li><a href="#ref-for-webvtt-ruby-object-5">6.1. Processing model</a>
+    <li><a href="#ref-for-webvtt-ruby-object-6">6.1.1. Applying CSS properties to WebVTT Node Objects</a>
+    <li><a href="#ref-for-webvtt-ruby-object-7">7.2.1. The ::cue pseudo-element</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-ruby-text-object">
    <b><a href="#webvtt-ruby-text-object">#webvtt-ruby-text-object</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-ruby-text-object">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-ruby-text-object①">(2)</a> <a href="#ref-for-webvtt-ruby-text-object②">(3)</a>
-    <li><a href="#ref-for-webvtt-ruby-text-object③">5.5. WebVTT cue text DOM construction rules</a>
-    <li><a href="#ref-for-webvtt-ruby-text-object④">5.6. WebVTT rules for extracting the chapter
+    <li><a href="#ref-for-webvtt-ruby-text-object-1">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-ruby-text-object-2">(2)</a> <a href="#ref-for-webvtt-ruby-text-object-3">(3)</a>
+    <li><a href="#ref-for-webvtt-ruby-text-object-4">5.5. WebVTT cue text DOM construction rules</a>
+    <li><a href="#ref-for-webvtt-ruby-text-object-5">5.6. WebVTT rules for extracting the chapter
 title</a>
-    <li><a href="#ref-for-webvtt-ruby-text-object⑤">6.1. Processing model</a>
-    <li><a href="#ref-for-webvtt-ruby-text-object⑥">6.1.1. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-webvtt-ruby-text-object⑦">(2)</a>
-    <li><a href="#ref-for-webvtt-ruby-text-object⑧">7.2.1. The ::cue pseudo-element</a>
+    <li><a href="#ref-for-webvtt-ruby-text-object-6">6.1. Processing model</a>
+    <li><a href="#ref-for-webvtt-ruby-text-object-7">6.1.1. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-webvtt-ruby-text-object-8">(2)</a>
+    <li><a href="#ref-for-webvtt-ruby-text-object-9">7.2.1. The ::cue pseudo-element</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-voice-object">
    <b><a href="#webvtt-voice-object">#webvtt-voice-object</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-voice-object">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-voice-object①">(2)</a> <a href="#ref-for-webvtt-voice-object②">(3)</a>
-    <li><a href="#ref-for-webvtt-voice-object③">5.5. WebVTT cue text DOM construction rules</a> <a href="#ref-for-webvtt-voice-object④">(2)</a>
-    <li><a href="#ref-for-webvtt-voice-object⑤">7.1. Introduction</a>
-    <li><a href="#ref-for-webvtt-voice-object⑥">7.2.1. The ::cue pseudo-element</a> <a href="#ref-for-webvtt-voice-object⑦">(2)</a> <a href="#ref-for-webvtt-voice-object⑧">(3)</a>
+    <li><a href="#ref-for-webvtt-voice-object-1">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-voice-object-2">(2)</a> <a href="#ref-for-webvtt-voice-object-3">(3)</a>
+    <li><a href="#ref-for-webvtt-voice-object-4">5.5. WebVTT cue text DOM construction rules</a> <a href="#ref-for-webvtt-voice-object-5">(2)</a>
+    <li><a href="#ref-for-webvtt-voice-object-6">7.1. Introduction</a>
+    <li><a href="#ref-for-webvtt-voice-object-7">7.2.1. The ::cue pseudo-element</a> <a href="#ref-for-webvtt-voice-object-8">(2)</a> <a href="#ref-for-webvtt-voice-object-9">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-language-object">
    <b><a href="#webvtt-language-object">#webvtt-language-object</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-language-object">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-language-object①">(2)</a>
-    <li><a href="#ref-for-webvtt-language-object②">5.5. WebVTT cue text DOM construction rules</a> <a href="#ref-for-webvtt-language-object③">(2)</a>
-    <li><a href="#ref-for-webvtt-language-object④">7.1. Introduction</a>
-    <li><a href="#ref-for-webvtt-language-object⑤">7.2.1. The ::cue pseudo-element</a> <a href="#ref-for-webvtt-language-object⑥">(2)</a>
+    <li><a href="#ref-for-webvtt-language-object-1">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-language-object-2">(2)</a>
+    <li><a href="#ref-for-webvtt-language-object-3">5.5. WebVTT cue text DOM construction rules</a> <a href="#ref-for-webvtt-language-object-4">(2)</a>
+    <li><a href="#ref-for-webvtt-language-object-5">7.1. Introduction</a>
+    <li><a href="#ref-for-webvtt-language-object-6">7.2.1. The ::cue pseudo-element</a> <a href="#ref-for-webvtt-language-object-7">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-leaf-node-object">
    <b><a href="#webvtt-leaf-node-object">#webvtt-leaf-node-object</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-leaf-node-object">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-leaf-node-object①">(2)</a>
-    <li><a href="#ref-for-webvtt-leaf-node-object②">7.2.1. The ::cue pseudo-element</a>
+    <li><a href="#ref-for-webvtt-leaf-node-object-1">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-leaf-node-object-2">(2)</a>
+    <li><a href="#ref-for-webvtt-leaf-node-object-3">7.2.1. The ::cue pseudo-element</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-text-object">
    <b><a href="#webvtt-text-object">#webvtt-text-object</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-text-object">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-text-object①">(2)</a> <a href="#ref-for-webvtt-text-object②">(3)</a>
-    <li><a href="#ref-for-webvtt-text-object③">5.5. WebVTT cue text DOM construction rules</a> <a href="#ref-for-webvtt-text-object④">(2)</a>
-    <li><a href="#ref-for-webvtt-text-object⑤">5.6. WebVTT rules for extracting the chapter
+    <li><a href="#ref-for-webvtt-text-object-1">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-text-object-2">(2)</a> <a href="#ref-for-webvtt-text-object-3">(3)</a>
+    <li><a href="#ref-for-webvtt-text-object-4">5.5. WebVTT cue text DOM construction rules</a> <a href="#ref-for-webvtt-text-object-5">(2)</a>
+    <li><a href="#ref-for-webvtt-text-object-6">5.6. WebVTT rules for extracting the chapter
 title</a>
-    <li><a href="#ref-for-webvtt-text-object⑥">6.1. Processing model</a>
+    <li><a href="#ref-for-webvtt-text-object-7">6.1. Processing model</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-timestamp-object">
    <b><a href="#webvtt-timestamp-object">#webvtt-timestamp-object</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-timestamp-object">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-timestamp-object①">(2)</a>
-    <li><a href="#ref-for-webvtt-timestamp-object②">5.5. WebVTT cue text DOM construction rules</a> <a href="#ref-for-webvtt-timestamp-object③">(2)</a>
-    <li><a href="#ref-for-webvtt-timestamp-object④">7.1. Introduction</a>
-    <li><a href="#ref-for-webvtt-timestamp-object⑤">7.2.2. The :past and :future pseudo-classes</a> <a href="#ref-for-webvtt-timestamp-object⑥">(2)</a>
+    <li><a href="#ref-for-webvtt-timestamp-object-1">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-timestamp-object-2">(2)</a>
+    <li><a href="#ref-for-webvtt-timestamp-object-3">5.5. WebVTT cue text DOM construction rules</a> <a href="#ref-for-webvtt-timestamp-object-4">(2)</a>
+    <li><a href="#ref-for-webvtt-timestamp-object-5">7.1. Introduction</a>
+    <li><a href="#ref-for-webvtt-timestamp-object-6">7.2.2. The :past and :future pseudo-classes</a> <a href="#ref-for-webvtt-timestamp-object-7">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-text-parsing-rules">
    <b><a href="#webvtt-cue-text-parsing-rules">#webvtt-cue-text-parsing-rules</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-text-parsing-rules">5.6. WebVTT rules for extracting the chapter
+    <li><a href="#ref-for-webvtt-cue-text-parsing-rules-1">5.6. WebVTT rules for extracting the chapter
 title</a>
-    <li><a href="#ref-for-webvtt-cue-text-parsing-rules①">6.1. Processing model</a>
-    <li><a href="#ref-for-webvtt-cue-text-parsing-rules②">8.1. The VTTCue interface</a>
+    <li><a href="#ref-for-webvtt-cue-text-parsing-rules-2">6.1. Processing model</a>
+    <li><a href="#ref-for-webvtt-cue-text-parsing-rules-3">8.1. The VTTCue interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="attach-a-webvtt-internal-node-object">
    <b><a href="#attach-a-webvtt-internal-node-object">#attach-a-webvtt-internal-node-object</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-attach-a-webvtt-internal-node-object">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-attach-a-webvtt-internal-node-object①">(2)</a> <a href="#ref-for-attach-a-webvtt-internal-node-object②">(3)</a> <a href="#ref-for-attach-a-webvtt-internal-node-object③">(4)</a> <a href="#ref-for-attach-a-webvtt-internal-node-object④">(5)</a> <a href="#ref-for-attach-a-webvtt-internal-node-object⑤">(6)</a> <a href="#ref-for-attach-a-webvtt-internal-node-object⑥">(7)</a> <a href="#ref-for-attach-a-webvtt-internal-node-object⑦">(8)</a>
+    <li><a href="#ref-for-attach-a-webvtt-internal-node-object-1">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-attach-a-webvtt-internal-node-object-2">(2)</a> <a href="#ref-for-attach-a-webvtt-internal-node-object-3">(3)</a> <a href="#ref-for-attach-a-webvtt-internal-node-object-4">(4)</a> <a href="#ref-for-attach-a-webvtt-internal-node-object-5">(5)</a> <a href="#ref-for-attach-a-webvtt-internal-node-object-6">(6)</a> <a href="#ref-for-attach-a-webvtt-internal-node-object-7">(7)</a> <a href="#ref-for-attach-a-webvtt-internal-node-object-8">(8)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-text-tokenizer">
    <b><a href="#webvtt-cue-text-tokenizer">#webvtt-cue-text-tokenizer</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-text-tokenizer">5.4. WebVTT cue text parsing rules</a>
+    <li><a href="#ref-for-webvtt-cue-text-tokenizer-1">5.4. WebVTT cue text parsing rules</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-data-state">
    <b><a href="#webvtt-data-state">#webvtt-data-state</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-data-state">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-data-state①">(2)</a>
+    <li><a href="#ref-for-webvtt-data-state-1">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-data-state-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="html-character-reference-in-data-state">
    <b><a href="#html-character-reference-in-data-state">#html-character-reference-in-data-state</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-html-character-reference-in-data-state">5.4. WebVTT cue text parsing rules</a>
+    <li><a href="#ref-for-html-character-reference-in-data-state-1">5.4. WebVTT cue text parsing rules</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-tag-state">
    <b><a href="#webvtt-tag-state">#webvtt-tag-state</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-tag-state">5.4. WebVTT cue text parsing rules</a>
+    <li><a href="#ref-for-webvtt-tag-state-1">5.4. WebVTT cue text parsing rules</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-start-tag-state">
    <b><a href="#webvtt-start-tag-state">#webvtt-start-tag-state</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-start-tag-state">5.4. WebVTT cue text parsing rules</a>
+    <li><a href="#ref-for-webvtt-start-tag-state-1">5.4. WebVTT cue text parsing rules</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-start-tag-class-state">
    <b><a href="#webvtt-start-tag-class-state">#webvtt-start-tag-class-state</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-start-tag-class-state">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-start-tag-class-state①">(2)</a>
+    <li><a href="#ref-for-webvtt-start-tag-class-state-1">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-start-tag-class-state-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-start-tag-annotation-state">
    <b><a href="#webvtt-start-tag-annotation-state">#webvtt-start-tag-annotation-state</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-start-tag-annotation-state">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-start-tag-annotation-state①">(2)</a> <a href="#ref-for-webvtt-start-tag-annotation-state②">(3)</a> <a href="#ref-for-webvtt-start-tag-annotation-state③">(4)</a> <a href="#ref-for-webvtt-start-tag-annotation-state④">(5)</a> <a href="#ref-for-webvtt-start-tag-annotation-state⑤">(6)</a>
+    <li><a href="#ref-for-webvtt-start-tag-annotation-state-1">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-start-tag-annotation-state-2">(2)</a> <a href="#ref-for-webvtt-start-tag-annotation-state-3">(3)</a> <a href="#ref-for-webvtt-start-tag-annotation-state-4">(4)</a> <a href="#ref-for-webvtt-start-tag-annotation-state-5">(5)</a> <a href="#ref-for-webvtt-start-tag-annotation-state-6">(6)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="html-character-reference-in-annotation-state">
    <b><a href="#html-character-reference-in-annotation-state">#html-character-reference-in-annotation-state</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-html-character-reference-in-annotation-state">5.4. WebVTT cue text parsing rules</a>
+    <li><a href="#ref-for-html-character-reference-in-annotation-state-1">5.4. WebVTT cue text parsing rules</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-end-tag-state">
    <b><a href="#webvtt-end-tag-state">#webvtt-end-tag-state</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-end-tag-state">5.4. WebVTT cue text parsing rules</a>
+    <li><a href="#ref-for-webvtt-end-tag-state-1">5.4. WebVTT cue text parsing rules</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-timestamp-tag-state">
    <b><a href="#webvtt-timestamp-tag-state">#webvtt-timestamp-tag-state</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-timestamp-tag-state">5.4. WebVTT cue text parsing rules</a>
+    <li><a href="#ref-for-webvtt-timestamp-tag-state-1">5.4. WebVTT cue text parsing rules</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="consume-an-html-character-reference">
    <b><a href="#consume-an-html-character-reference">#consume-an-html-character-reference</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-consume-an-html-character-reference">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-consume-an-html-character-reference①">(2)</a>
+    <li><a href="#ref-for-consume-an-html-character-reference-1">5.4. WebVTT cue text parsing rules</a> <a href="#ref-for-consume-an-html-character-reference-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-text-dom-construction-rules">
    <b><a href="#webvtt-cue-text-dom-construction-rules">#webvtt-cue-text-dom-construction-rules</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-text-dom-construction-rules">8.1. The VTTCue interface</a>
+    <li><a href="#ref-for-webvtt-cue-text-dom-construction-rules-1">8.1. The VTTCue interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-rules-for-extracting-the-chapter-title">
    <b><a href="#webvtt-rules-for-extracting-the-chapter-title">#webvtt-rules-for-extracting-the-chapter-title</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-rules-for-extracting-the-chapter-title">8.1. The VTTCue interface</a>
+    <li><a href="#ref-for-webvtt-rules-for-extracting-the-chapter-title-1">8.1. The VTTCue interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="rules-for-updating-the-display-of-webvtt-text-tracks">
    <b><a href="#rules-for-updating-the-display-of-webvtt-text-tracks">#rules-for-updating-the-display-of-webvtt-text-tracks</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-rules-for-updating-the-display-of-webvtt-text-tracks">3.1. WebVTT cues</a> <a href="#ref-for-rules-for-updating-the-display-of-webvtt-text-tracks①">(2)</a>
-    <li><a href="#ref-for-rules-for-updating-the-display-of-webvtt-text-tracks②">6.1. Processing model</a>
-    <li><a href="#ref-for-rules-for-updating-the-display-of-webvtt-text-tracks③">6.1.1. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-rules-for-updating-the-display-of-webvtt-text-tracks④">(2)</a> <a href="#ref-for-rules-for-updating-the-display-of-webvtt-text-tracks⑤">(3)</a>
-    <li><a href="#ref-for-rules-for-updating-the-display-of-webvtt-text-tracks⑥">7.2. Processing model</a> <a href="#ref-for-rules-for-updating-the-display-of-webvtt-text-tracks⑦">(2)</a>
-    <li><a href="#ref-for-rules-for-updating-the-display-of-webvtt-text-tracks⑧">7.2.3. The ::cue-region pseudo-element</a>
+    <li><a href="#ref-for-rules-for-updating-the-display-of-webvtt-text-tracks-1">3.1. WebVTT cues</a> <a href="#ref-for-rules-for-updating-the-display-of-webvtt-text-tracks-2">(2)</a>
+    <li><a href="#ref-for-rules-for-updating-the-display-of-webvtt-text-tracks-3">6.1. Processing model</a>
+    <li><a href="#ref-for-rules-for-updating-the-display-of-webvtt-text-tracks-4">6.1.1. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-rules-for-updating-the-display-of-webvtt-text-tracks-5">(2)</a> <a href="#ref-for-rules-for-updating-the-display-of-webvtt-text-tracks-6">(3)</a>
+    <li><a href="#ref-for-rules-for-updating-the-display-of-webvtt-text-tracks-7">7.2. Processing model</a> <a href="#ref-for-rules-for-updating-the-display-of-webvtt-text-tracks-8">(2)</a>
+    <li><a href="#ref-for-rules-for-updating-the-display-of-webvtt-text-tracks-9">7.2.3. The ::cue-region pseudo-element</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="apply-webvtt-cue-settings">
    <b><a href="#apply-webvtt-cue-settings">#apply-webvtt-cue-settings</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-apply-webvtt-cue-settings">6.1. Processing model</a>
+    <li><a href="#ref-for-apply-webvtt-cue-settings-1">6.1. Processing model</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-background-box">
    <b><a href="#webvtt-cue-background-box">#webvtt-cue-background-box</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-background-box">6.1.1. Applying CSS properties to WebVTT Node Objects</a>
-    <li><a href="#ref-for-webvtt-cue-background-box①">7.2.1. The ::cue pseudo-element</a> <a href="#ref-for-webvtt-cue-background-box②">(2)</a>
+    <li><a href="#ref-for-webvtt-cue-background-box-1">6.1.1. Applying CSS properties to WebVTT Node Objects</a>
+    <li><a href="#ref-for-webvtt-cue-background-box-2">7.2.1. The ::cue pseudo-element</a> <a href="#ref-for-webvtt-cue-background-box-3">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="enumdef-autokeyword">
    <b><a href="#enumdef-autokeyword">#enumdef-autokeyword</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-enumdef-autokeyword">8.1. The VTTCue interface</a>
+    <li><a href="#ref-for-enumdef-autokeyword-1">8.1. The VTTCue interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="typedefdef-lineandpositionsetting">
    <b><a href="#typedefdef-lineandpositionsetting">#typedefdef-lineandpositionsetting</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-typedefdef-lineandpositionsetting">8.1. The VTTCue interface</a> <a href="#ref-for-typedefdef-lineandpositionsetting①">(2)</a>
+    <li><a href="#ref-for-typedefdef-lineandpositionsetting-1">8.1. The VTTCue interface</a> <a href="#ref-for-typedefdef-lineandpositionsetting-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="enumdef-directionsetting">
    <b><a href="#enumdef-directionsetting">#enumdef-directionsetting</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-enumdef-directionsetting">8.1. The VTTCue interface</a>
+    <li><a href="#ref-for-enumdef-directionsetting-1">8.1. The VTTCue interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="enumdef-linealignsetting">
    <b><a href="#enumdef-linealignsetting">#enumdef-linealignsetting</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-enumdef-linealignsetting">8.1. The VTTCue interface</a>
+    <li><a href="#ref-for-enumdef-linealignsetting-1">8.1. The VTTCue interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="enumdef-positionalignsetting">
    <b><a href="#enumdef-positionalignsetting">#enumdef-positionalignsetting</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-enumdef-positionalignsetting">8.1. The VTTCue interface</a>
+    <li><a href="#ref-for-enumdef-positionalignsetting-1">8.1. The VTTCue interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="enumdef-alignsetting">
    <b><a href="#enumdef-alignsetting">#enumdef-alignsetting</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-enumdef-alignsetting">8.1. The VTTCue interface</a>
+    <li><a href="#ref-for-enumdef-alignsetting-1">8.1. The VTTCue interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="vttcue">
    <b><a href="#vttcue">#vttcue</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-vttcue">5.5. WebVTT cue text DOM construction rules</a>
-    <li><a href="#ref-for-vttcue①">8.1. The VTTCue interface</a> <a href="#ref-for-vttcue②">(2)</a> <a href="#ref-for-vttcue③">(3)</a> <a href="#ref-for-vttcue④">(4)</a> <a href="#ref-for-vttcue⑤">(5)</a> <a href="#ref-for-vttcue⑥">(6)</a> <a href="#ref-for-vttcue⑦">(7)</a> <a href="#ref-for-vttcue⑧">(8)</a> <a href="#ref-for-vttcue⑨">(9)</a> <a href="#ref-for-vttcue①⓪">(10)</a> <a href="#ref-for-vttcue①①">(11)</a> <a href="#ref-for-vttcue①②">(12)</a> <a href="#ref-for-vttcue①③">(13)</a>
+    <li><a href="#ref-for-vttcue-1">5.5. WebVTT cue text DOM construction rules</a>
+    <li><a href="#ref-for-vttcue-2">8.1. The VTTCue interface</a> <a href="#ref-for-vttcue-3">(2)</a> <a href="#ref-for-vttcue-4">(3)</a> <a href="#ref-for-vttcue-5">(4)</a> <a href="#ref-for-vttcue-6">(5)</a> <a href="#ref-for-vttcue-7">(6)</a> <a href="#ref-for-vttcue-8">(7)</a> <a href="#ref-for-vttcue-9">(8)</a> <a href="#ref-for-vttcue-10">(9)</a> <a href="#ref-for-vttcue-11">(10)</a> <a href="#ref-for-vttcue-12">(11)</a> <a href="#ref-for-vttcue-13">(12)</a> <a href="#ref-for-vttcue-14">(13)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttcue-vttcue">
    <b><a href="#dom-vttcue-vttcue">#dom-vttcue-vttcue</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttcue-vttcue">8.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-vttcue①">(2)</a>
+    <li><a href="#ref-for-dom-vttcue-vttcue-1">8.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-vttcue-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttcue-region">
    <b><a href="#dom-vttcue-region">#dom-vttcue-region</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttcue-region">8.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-region①">(2)</a>
+    <li><a href="#ref-for-dom-vttcue-region-1">8.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-region-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttcue-vertical">
    <b><a href="#dom-vttcue-vertical">#dom-vttcue-vertical</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttcue-vertical">8.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-vertical①">(2)</a> <a href="#ref-for-dom-vttcue-vertical②">(3)</a>
+    <li><a href="#ref-for-dom-vttcue-vertical-1">8.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-vertical-2">(2)</a> <a href="#ref-for-dom-vttcue-vertical-3">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttcue-snaptolines">
    <b><a href="#dom-vttcue-snaptolines">#dom-vttcue-snaptolines</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttcue-snaptolines">3.1. WebVTT cues</a>
-    <li><a href="#ref-for-dom-vttcue-snaptolines①">8.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-snaptolines②">(2)</a> <a href="#ref-for-dom-vttcue-snaptolines③">(3)</a> <a href="#ref-for-dom-vttcue-snaptolines④">(4)</a>
+    <li><a href="#ref-for-dom-vttcue-snaptolines-1">3.1. WebVTT cues</a>
+    <li><a href="#ref-for-dom-vttcue-snaptolines-2">8.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-snaptolines-3">(2)</a> <a href="#ref-for-dom-vttcue-snaptolines-4">(3)</a> <a href="#ref-for-dom-vttcue-snaptolines-5">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttcue-line">
    <b><a href="#dom-vttcue-line">#dom-vttcue-line</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttcue-line">3.1. WebVTT cues</a>
-    <li><a href="#ref-for-dom-vttcue-line①">8.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-line②">(2)</a> <a href="#ref-for-dom-vttcue-line③">(3)</a> <a href="#ref-for-dom-vttcue-line④">(4)</a>
+    <li><a href="#ref-for-dom-vttcue-line-1">3.1. WebVTT cues</a>
+    <li><a href="#ref-for-dom-vttcue-line-2">8.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-line-3">(2)</a> <a href="#ref-for-dom-vttcue-line-4">(3)</a> <a href="#ref-for-dom-vttcue-line-5">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttcue-linealign">
    <b><a href="#dom-vttcue-linealign">#dom-vttcue-linealign</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttcue-linealign">8.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-linealign①">(2)</a> <a href="#ref-for-dom-vttcue-linealign②">(3)</a>
+    <li><a href="#ref-for-dom-vttcue-linealign-1">8.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-linealign-2">(2)</a> <a href="#ref-for-dom-vttcue-linealign-3">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttcue-position">
    <b><a href="#dom-vttcue-position">#dom-vttcue-position</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttcue-position">8.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-position①">(2)</a>
+    <li><a href="#ref-for-dom-vttcue-position-1">8.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-position-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttcue-positionalign">
    <b><a href="#dom-vttcue-positionalign">#dom-vttcue-positionalign</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttcue-positionalign">8.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-positionalign①">(2)</a> <a href="#ref-for-dom-vttcue-positionalign②">(3)</a>
+    <li><a href="#ref-for-dom-vttcue-positionalign-1">8.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-positionalign-2">(2)</a> <a href="#ref-for-dom-vttcue-positionalign-3">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttcue-size">
    <b><a href="#dom-vttcue-size">#dom-vttcue-size</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttcue-size">8.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-size①">(2)</a>
+    <li><a href="#ref-for-dom-vttcue-size-1">8.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-size-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttcue-align">
    <b><a href="#dom-vttcue-align">#dom-vttcue-align</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttcue-align">8.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-align①">(2)</a> <a href="#ref-for-dom-vttcue-align②">(3)</a>
+    <li><a href="#ref-for-dom-vttcue-align-1">8.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-align-2">(2)</a> <a href="#ref-for-dom-vttcue-align-3">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttcue-text">
    <b><a href="#dom-vttcue-text">#dom-vttcue-text</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttcue-text">8.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-text①">(2)</a>
+    <li><a href="#ref-for-dom-vttcue-text-1">8.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-text-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttcue-getcueashtml">
    <b><a href="#dom-vttcue-getcueashtml">#dom-vttcue-getcueashtml</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttcue-getcueashtml">5.5. WebVTT cue text DOM construction rules</a>
-    <li><a href="#ref-for-dom-vttcue-getcueashtml①">8.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-getcueashtml②">(2)</a> <a href="#ref-for-dom-vttcue-getcueashtml③">(3)</a>
+    <li><a href="#ref-for-dom-vttcue-getcueashtml-1">5.5. WebVTT cue text DOM construction rules</a>
+    <li><a href="#ref-for-dom-vttcue-getcueashtml-2">8.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-getcueashtml-3">(2)</a> <a href="#ref-for-dom-vttcue-getcueashtml-4">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="enumdef-scrollsetting">
    <b><a href="#enumdef-scrollsetting">#enumdef-scrollsetting</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-enumdef-scrollsetting">8.2. The VTTRegion interface</a>
+    <li><a href="#ref-for-enumdef-scrollsetting-1">8.2. The VTTRegion interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="vttregion">
    <b><a href="#vttregion">#vttregion</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-vttregion">8.1. The VTTCue interface</a> <a href="#ref-for-vttregion①">(2)</a> <a href="#ref-for-vttregion②">(3)</a>
-    <li><a href="#ref-for-vttregion③">8.2. The VTTRegion interface</a> <a href="#ref-for-vttregion④">(2)</a> <a href="#ref-for-vttregion⑤">(3)</a> <a href="#ref-for-vttregion⑥">(4)</a> <a href="#ref-for-vttregion⑦">(5)</a> <a href="#ref-for-vttregion⑧">(6)</a> <a href="#ref-for-vttregion⑨">(7)</a> <a href="#ref-for-vttregion①⓪">(8)</a> <a href="#ref-for-vttregion①①">(9)</a> <a href="#ref-for-vttregion①②">(10)</a> <a href="#ref-for-vttregion①③">(11)</a>
+    <li><a href="#ref-for-vttregion-1">8.1. The VTTCue interface</a> <a href="#ref-for-vttregion-2">(2)</a> <a href="#ref-for-vttregion-3">(3)</a>
+    <li><a href="#ref-for-vttregion-4">8.2. The VTTRegion interface</a> <a href="#ref-for-vttregion-5">(2)</a> <a href="#ref-for-vttregion-6">(3)</a> <a href="#ref-for-vttregion-7">(4)</a> <a href="#ref-for-vttregion-8">(5)</a> <a href="#ref-for-vttregion-9">(6)</a> <a href="#ref-for-vttregion-10">(7)</a> <a href="#ref-for-vttregion-11">(8)</a> <a href="#ref-for-vttregion-12">(9)</a> <a href="#ref-for-vttregion-13">(10)</a> <a href="#ref-for-vttregion-14">(11)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttregion-vttregion">
    <b><a href="#dom-vttregion-vttregion">#dom-vttregion-vttregion</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttregion-vttregion">8.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-vttregion①">(2)</a>
+    <li><a href="#ref-for-dom-vttregion-vttregion-1">8.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-vttregion-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttregion-id">
    <b><a href="#dom-vttregion-id">#dom-vttregion-id</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttregion-id">8.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-id①">(2)</a>
+    <li><a href="#ref-for-dom-vttregion-id-1">8.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-id-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttregion-width">
    <b><a href="#dom-vttregion-width">#dom-vttregion-width</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttregion-width">8.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-width①">(2)</a>
+    <li><a href="#ref-for-dom-vttregion-width-1">8.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-width-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttregion-lines">
    <b><a href="#dom-vttregion-lines">#dom-vttregion-lines</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttregion-lines">8.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-lines①">(2)</a>
+    <li><a href="#ref-for-dom-vttregion-lines-1">8.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-lines-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttregion-regionanchorx">
    <b><a href="#dom-vttregion-regionanchorx">#dom-vttregion-regionanchorx</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttregion-regionanchorx">8.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-regionanchorx①">(2)</a>
+    <li><a href="#ref-for-dom-vttregion-regionanchorx-1">8.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-regionanchorx-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttregion-regionanchory">
    <b><a href="#dom-vttregion-regionanchory">#dom-vttregion-regionanchory</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttregion-regionanchory">8.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-regionanchory①">(2)</a>
+    <li><a href="#ref-for-dom-vttregion-regionanchory-1">8.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-regionanchory-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttregion-viewportanchorx">
    <b><a href="#dom-vttregion-viewportanchorx">#dom-vttregion-viewportanchorx</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttregion-viewportanchorx">8.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-viewportanchorx①">(2)</a>
+    <li><a href="#ref-for-dom-vttregion-viewportanchorx-1">8.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-viewportanchorx-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttregion-viewportanchory">
    <b><a href="#dom-vttregion-viewportanchory">#dom-vttregion-viewportanchory</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttregion-viewportanchory">8.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-viewportanchory①">(2)</a>
+    <li><a href="#ref-for-dom-vttregion-viewportanchory-1">8.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-viewportanchory-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-vttregion-scroll">
    <b><a href="#dom-vttregion-scroll">#dom-vttregion-scroll</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-vttregion-scroll">8.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-scroll①">(2)</a> <a href="#ref-for-dom-vttregion-scroll②">(3)</a>
+    <li><a href="#ref-for-dom-vttregion-scroll-1">8.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-scroll-2">(2)</a> <a href="#ref-for-dom-vttregion-scroll-3">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="text-vtt">
    <b><a href="#text-vtt">#text-vtt</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-text-vtt">2.1. Conformance classes</a>
+    <li><a href="#ref-for-text-vtt-1">2.1. Conformance classes</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */

--- a/index.html
+++ b/index.html
@@ -2046,13 +2046,19 @@ requirements.</p>
  specification. <a data-link-type="biblio" href="#biblio-webidl">[WEBIDL]</a></p>
     <dt>User agents with no scripting support
     <dd>
-     <p>All processing requirements in this specification apply, except those in <a href="#api">§9 API</a>.</p>
-    <dt>User agents that do not support CSS
+     <p>All processing requirements in this specification apply, except those in <a href="#dom-construction-rules">§6.5 WebVTT cue text DOM construction rules</a> and <a href="#api">§9 API</a>.</p>
+    <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="user-agents-that-do-not-support-css">User agents that do not support CSS</dfn>
     <dd>
-     <p>All processing requirements in this specification apply, except those in <a href="#css-extensions">§8 CSS extensions</a>. The user agent must instead implement equivalent visual rendering to what a
- CSS based renderer produces according to <a href="#rendering">§7 Rendering</a>. <a href="#applying-css-properties">§7.4 Applying CSS properties to WebVTT Node Objects</a> lists the
- default styling properties in CSS speak that will also define the default styling in such user
- agents.</p>
+     <p>All processing requirements in this specification apply, except parts of <a href="#parsing">§6 Parsing</a> that
+ relate to stylesheets and CSS, and all of <a href="#rendering">§7 Rendering</a> and <a href="#css-extensions">§8 CSS extensions</a>. The user agent
+ must instead only render the text inside <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-1">WebVTT cue text</a> in an appropriate manner. Any other
+ styling and positioning instructions are optional.</p>
+    <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="user-agents-that-do-not-support-a-full-html-css-engine">User agents that do not support a full HTML CSS engine</dfn>
+    <dd>
+     <p>All processing requirements in this specification apply. However, the user agent will need
+ to interpret the CSS related features in <a href="#parsing">§6 Parsing</a>, <a href="#rendering">§7 Rendering</a> and <a href="#css-extensions">§8 CSS extensions</a> in
+ such a way that the rendered results are equivalent to what a full CSS supporting renderer
+ produces.</p>
     <dt>Conformance checkers
     <dd>
      <p>Conformance checkers must verify that a <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file-4">WebVTT file</a> conforms to the applicable
@@ -2217,7 +2223,7 @@ precomposed character).</p>
      <p>For <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-9">WebVTT cues</a> that have a <a data-link-type="dfn" href="#webvtt-cue-size" id="ref-for-webvtt-cue-size-3">size</a> other than 100%, and a <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment-6">text alignment</a> of <a data-link-type="dfn" href="#webvtt-cue-start-alignment" id="ref-for-webvtt-cue-start-alignment-1">start</a> or <a data-link-type="dfn" href="#webvtt-cue-end-alignment" id="ref-for-webvtt-cue-end-alignment-1">end</a>, authors must not use the default <a data-link-type="dfn" href="#webvtt-cue-automatic-position" id="ref-for-webvtt-cue-automatic-position-3">auto</a> <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position-11">position</a>.</p>
      <p class="note" role="note">When the <a data-link-type="dfn" href="#webvtt-cue-text-alignment" id="ref-for-webvtt-cue-text-alignment-7">text alignment</a> is <a data-link-type="dfn" href="#webvtt-cue-start-alignment" id="ref-for-webvtt-cue-start-alignment-2">start</a> or <a data-link-type="dfn" href="#webvtt-cue-end-alignment" id="ref-for-webvtt-cue-end-alignment-2">end</a>, the <a data-link-type="dfn" href="#webvtt-cue-automatic-position" id="ref-for-webvtt-cue-automatic-position-4">auto</a> <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position-12">position</a> is 50%. This is different
   from <a data-link-type="dfn" href="#webvtt-cue-left-alignment" id="ref-for-webvtt-cue-left-alignment-2">left</a> and <a data-link-type="dfn" href="#webvtt-cue-right-alignment" id="ref-for-webvtt-cue-right-alignment-2">right</a> aligned text, where the <a data-link-type="dfn" href="#webvtt-cue-automatic-position" id="ref-for-webvtt-cue-automatic-position-5">auto</a> <a data-link-type="dfn" href="#webvtt-cue-position" id="ref-for-webvtt-cue-position-13">position</a> is 0% and 100%, respectively. The above requirement is present because it
-  can be surprising that automatic positioning doesn’t work for <a data-link-type="dfn" href="#webvtt-cue-start-alignment" id="ref-for-webvtt-cue-start-alignment-3">start</a> or <a data-link-type="dfn" href="#webvtt-cue-end-alignment" id="ref-for-webvtt-cue-end-alignment-3">end</a> aligned text. Since <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-1">cue text</a> can consist of text with left-to-right base direction, or right-to-left
+  can be surprising that automatic positioning doesn’t work for <a data-link-type="dfn" href="#webvtt-cue-start-alignment" id="ref-for-webvtt-cue-start-alignment-3">start</a> or <a data-link-type="dfn" href="#webvtt-cue-end-alignment" id="ref-for-webvtt-cue-end-alignment-3">end</a> aligned text. Since <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-2">cue text</a> can consist of text with left-to-right base direction, or right-to-left
   base direction, or both (on different lines), such automatic positioning would have unexpected
   results.</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT cue position alignment" data-noexport="" id="webvtt-cue-position-alignment">A position alignment</dfn>
@@ -2474,7 +2480,7 @@ order:</p>
     <li>Optionally, one or more U+0020 SPACE characters or U+0009 CHARACTER TABULATION (tab) characters
  followed by a <a data-link-type="dfn" href="#webvtt-cue-settings-list" id="ref-for-webvtt-cue-settings-list-1">WebVTT cue settings list</a>.
     <li>A <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator-12">WebVTT line terminator</a>.
-    <li>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="cue-payload">cue payload</dfn>: either <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-2">WebVTT cue text</a>, <a data-link-type="dfn" href="#webvtt-chapter-title-text" id="ref-for-webvtt-chapter-title-text-1">WebVTT chapter title text</a>, or <a data-link-type="dfn" href="#webvtt-metadata-text" id="ref-for-webvtt-metadata-text-1">WebVTT metadata text</a>, but it must not contain the substring "<code>--></code>" (U+002D
+    <li>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="cue-payload">cue payload</dfn>: either <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-3">WebVTT cue text</a>, <a data-link-type="dfn" href="#webvtt-chapter-title-text" id="ref-for-webvtt-chapter-title-text-1">WebVTT chapter title text</a>, or <a data-link-type="dfn" href="#webvtt-metadata-text" id="ref-for-webvtt-metadata-text-1">WebVTT metadata text</a>, but it must not contain the substring "<code>--></code>" (U+002D
  HYPHEN-MINUS, U+002D HYPHEN-MINUS, U+003E GREATER-THAN SIGN).
     <li>A <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator-13">WebVTT line terminator</a>.
    </ol>
@@ -2639,7 +2645,7 @@ are more mature in HTML and CSS. <a data-link-type="biblio" href="#biblio-html">
  represents the name of the voice.
     <li><a data-link-type="dfn" href="#webvtt-cue-internal-text" id="ref-for-webvtt-cue-internal-text-7">WebVTT cue internal text</a>.
     <li>A <a data-link-type="dfn" href="#webvtt-cue-span-end-tag" id="ref-for-webvtt-cue-span-end-tag-7">WebVTT cue span end tag</a> "<code>v</code>". If this <a data-link-type="dfn" href="#webvtt-cue-voice-span" id="ref-for-webvtt-cue-voice-span-2">WebVTT cue voice span</a> is the
- only <a data-link-type="dfn" href="#webvtt-cue-components" id="ref-for-webvtt-cue-components-4">component</a> of its <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-3">WebVTT cue text</a> sequence, then the
+ only <a data-link-type="dfn" href="#webvtt-cue-components" id="ref-for-webvtt-cue-components-4">component</a> of its <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-4">WebVTT cue text</a> sequence, then the
  end tag may be omitted for brevity.
    </ol>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue-language-span">WebVTT cue language span</dfn> consists of the following components, in the order
@@ -2703,7 +2709,7 @@ U+003C LESS-THAN SIGN characters (&lt;).</p>
 than U+000A LINE FEED (LF) characters, U+000D CARRIAGE RETURN (CR) characters, U+0026 AMPERSAND
 characters (&amp;), and U+003E GREATER-THAN SIGN characters (>).</p>
    <h4 class="heading settled" data-level="4.2.3" id="chapter-title-text"><span class="secno">4.2.3. </span><span class="content">WebVTT chapter title text</span><a class="self-link" href="#chapter-title-text"></a></h4>
-   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-chapter-title-text">WebVTT chapter title text</dfn> is <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-4">WebVTT cue text</a> that makes use of zero or more of
+   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-chapter-title-text">WebVTT chapter title text</dfn> is <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-5">WebVTT cue text</a> that makes use of zero or more of
 the following components, each optionally separated from the next by a <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator-25">WebVTT line
 terminator</a>:</p>
    <ul>
@@ -3045,7 +3051,7 @@ for validating these types.</p>
    <h4 class="heading settled" data-level="4.6.2" id="file-using-chapter-title-text"><span class="secno">4.6.2. </span><span class="content">WebVTT file using chapter title text</span><a class="self-link" href="#file-using-chapter-title-text"></a></h4>
    <p>A <dfn data-dfn-type="dfn" data-noexport="" id="webvtt-file-using-chapter-title-text">WebVTT file using chapter title text<a class="self-link" href="#webvtt-file-using-chapter-title-text"></a></dfn> is a <a data-link-type="dfn" href="#webvtt-file-using-only-nested-cues" id="ref-for-webvtt-file-using-only-nested-cues-3">WebVTT file using only nested cues</a> whose cues all have a <a data-link-type="dfn" href="#cue-payload" id="ref-for-cue-payload-4">cue payload</a> that is <a data-link-type="dfn" href="#webvtt-chapter-title-text" id="ref-for-webvtt-chapter-title-text-2">WebVTT chapter title text</a>.</p>
    <h4 class="heading settled" data-level="4.6.3" id="file-using-cue-text"><span class="secno">4.6.3. </span><span class="content">WebVTT file using cue text</span><a class="self-link" href="#file-using-cue-text"></a></h4>
-   <p>A <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file-13">WebVTT file</a> whose cues all have a <a data-link-type="dfn" href="#cue-payload" id="ref-for-cue-payload-5">cue payload</a> that is <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-5">WebVTT cue text</a> is
+   <p>A <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file-13">WebVTT file</a> whose cues all have a <a data-link-type="dfn" href="#cue-payload" id="ref-for-cue-payload-5">cue payload</a> that is <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-6">WebVTT cue text</a> is
 said to be a <dfn data-dfn-type="dfn" data-noexport="" id="webvtt-file-using-cue-text">WebVTT file using cue text<a class="self-link" href="#webvtt-file-using-cue-text"></a></dfn>.</p>
    <h2 class="heading settled" data-level="5" id="default-classes"><span class="secno">5. </span><span class="content">Default classes for WebVTT Cue Components</span><a class="self-link" href="#default-classes"></a></h2>
    <p>Many captioning formats have simple ways of specifying a limited subset of text colors and
@@ -3522,9 +3528,8 @@ means that it is aborted at that point and returns nothing.</p>
      <p>Return <var>percentage</var>.</p>
    </ol>
    <h3 class="heading settled algorithm" data-algorithm="WebVTT cue timings and settings parsing" data-level="6.3" id="cue-timings-and-settings-parsing"><span class="secno">6.3. </span><span class="content">WebVTT cue timings and settings parsing</span><a class="self-link" href="#cue-timings-and-settings-parsing"></a></h3>
-   <p>When the algorithm above requires to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="collect-webvtt-cue-timings-and-settings">collect WebVTT cue timings and settings</dfn> from a
-string <var>input</var> using a <a data-link-type="dfn" href="#text-track-list-of-regions" id="ref-for-text-track-list-of-regions-2">text track list of regions</a> <var>regions</var> for a <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-21">WebVTT cue</a> <var>cue</var>,
-the user agent must run the following algorithm.</p>
+   <p>When the algorithm above says to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="collect-webvtt-cue-timings-and-settings">collect WebVTT cue timings and settings</dfn> from a string <var>input</var> using a <a data-link-type="dfn" href="#text-track-list-of-regions" id="ref-for-text-track-list-of-regions-2">text track list of regions</a> <var>regions</var> for a <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue-21">WebVTT cue</a> <var>cue</var>, the user
+agent must run the following algorithm.</p>
    <ol class="algorithm" data-algorithm="collect WebVTT cue timings and settings">
     <li>
      <p>Let <var>input</var> be the string being parsed.</p>
@@ -3797,7 +3802,7 @@ user agent must run the following steps:</p>
      <p>Return <var>result</var>.</p>
    </ol>
    <h3 class="heading settled algorithm" data-algorithm="WebVTT cue text parsing rules" data-level="6.4" id="cue-text-parsing-rules"><span class="secno">6.4. </span><span class="content">WebVTT cue text parsing rules</span><a class="self-link" href="#cue-text-parsing-rules"></a></h3>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-node-object">WebVTT Node Object</dfn> is a conceptual construct used to represent components of <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-6">WebVTT cue text</a> so that its processing can be described without reference to the underlying
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-node-object">WebVTT Node Object</dfn> is a conceptual construct used to represent components of <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-7">WebVTT cue text</a> so that its processing can be described without reference to the underlying
 syntax.</p>
    <p>There are two broad classes of <a data-link-type="dfn" href="#webvtt-node-object" id="ref-for-webvtt-node-object-1">WebVTT Node Objects</a>: <a data-link-type="dfn" href="#webvtt-internal-node-object" id="ref-for-webvtt-internal-node-object-1">WebVTT Internal Node Objects</a> and <a data-link-type="dfn" href="#webvtt-leaf-node-object" id="ref-for-webvtt-leaf-node-object-1">WebVTT
 Leaf Node Objects</a>.</p>
@@ -3818,35 +3823,35 @@ Objects</a>:</p>
   Objects</a>.</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT Class Object" data-noexport="" id="webvtt-class-object">WebVTT Class Objects</dfn>
     <dd>
-     <p>These represent spans of text (a <a data-link-type="dfn" href="#webvtt-cue-class-span" id="ref-for-webvtt-cue-class-span-2">WebVTT cue class span</a>) in <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-7">WebVTT cue text</a>, and
+     <p>These represent spans of text (a <a data-link-type="dfn" href="#webvtt-cue-class-span" id="ref-for-webvtt-cue-class-span-2">WebVTT cue class span</a>) in <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-8">WebVTT cue text</a>, and
   are used to annotate parts of the cue with <a data-link-type="dfn" href="#webvtt-node-objects-applicable-classes" id="ref-for-webvtt-node-objects-applicable-classes-1">applicable classes</a> without implying further meaning (such as italics or bold).</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT Italic Object" data-noexport="" id="webvtt-italic-object">WebVTT Italic Objects</dfn>
     <dd>
-     <p>These represent spans of italic text (a <a data-link-type="dfn" href="#webvtt-cue-italics-span" id="ref-for-webvtt-cue-italics-span-2">WebVTT cue italics span</a>) in <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-8">WebVTT cue
+     <p>These represent spans of italic text (a <a data-link-type="dfn" href="#webvtt-cue-italics-span" id="ref-for-webvtt-cue-italics-span-2">WebVTT cue italics span</a>) in <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-9">WebVTT cue
   text</a>.</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT Bold Object" data-noexport="" id="webvtt-bold-object">WebVTT Bold Objects</dfn>
     <dd>
-     <p>These represent spans of bold text (a <a data-link-type="dfn" href="#webvtt-cue-bold-span" id="ref-for-webvtt-cue-bold-span-2">WebVTT cue bold span</a>) in <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-9">WebVTT cue
+     <p>These represent spans of bold text (a <a data-link-type="dfn" href="#webvtt-cue-bold-span" id="ref-for-webvtt-cue-bold-span-2">WebVTT cue bold span</a>) in <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-10">WebVTT cue
   text</a>.</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT Underline Object" data-noexport="" id="webvtt-underline-object">WebVTT Underline Objects</dfn>
     <dd>
-     <p>These represent spans of underline text (a <a data-link-type="dfn" href="#webvtt-cue-underline-span" id="ref-for-webvtt-cue-underline-span-2">WebVTT cue underline span</a>) in <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-10">WebVTT cue
+     <p>These represent spans of underline text (a <a data-link-type="dfn" href="#webvtt-cue-underline-span" id="ref-for-webvtt-cue-underline-span-2">WebVTT cue underline span</a>) in <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-11">WebVTT cue
   text</a>.</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT Ruby Object" data-noexport="" id="webvtt-ruby-object">WebVTT Ruby Objects</dfn>
     <dd>
-     <p>These represent spans of ruby (a <a data-link-type="dfn" href="#webvtt-cue-ruby-span" id="ref-for-webvtt-cue-ruby-span-3">WebVTT cue ruby span</a>) in <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-11">WebVTT cue text</a>.</p>
+     <p>These represent spans of ruby (a <a data-link-type="dfn" href="#webvtt-cue-ruby-span" id="ref-for-webvtt-cue-ruby-span-3">WebVTT cue ruby span</a>) in <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-12">WebVTT cue text</a>.</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT Ruby Text Object" data-noexport="" id="webvtt-ruby-text-object">WebVTT Ruby Text Objects</dfn>
     <dd>
-     <p>These represent spans of ruby text (a <a data-link-type="dfn" href="#webvtt-cue-ruby-text-span" id="ref-for-webvtt-cue-ruby-text-span-1">WebVTT cue ruby text span</a>) in <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-12">WebVTT cue
+     <p>These represent spans of ruby text (a <a data-link-type="dfn" href="#webvtt-cue-ruby-text-span" id="ref-for-webvtt-cue-ruby-text-span-1">WebVTT cue ruby text span</a>) in <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-13">WebVTT cue
   text</a>.</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT Voice Object" data-noexport="" id="webvtt-voice-object">WebVTT Voice Objects</dfn>
     <dd>
      <p>These represent spans of text associated with a specific voice (a <a data-link-type="dfn" href="#webvtt-cue-voice-span" id="ref-for-webvtt-cue-voice-span-3">WebVTT cue voice span</a>)
-  in <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-13">WebVTT cue text</a>. A <a data-link-type="dfn" href="#webvtt-voice-object" id="ref-for-webvtt-voice-object-1">WebVTT Voice Object</a> has a value, which is the name of the
+  in <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-14">WebVTT cue text</a>. A <a data-link-type="dfn" href="#webvtt-voice-object" id="ref-for-webvtt-voice-object-1">WebVTT Voice Object</a> has a value, which is the name of the
   voice.</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT Language Object" data-noexport="" id="webvtt-language-object">WebVTT Language Objects</dfn>
     <dd>
-     <p>These represent spans of text (a <a data-link-type="dfn" href="#webvtt-cue-language-span" id="ref-for-webvtt-cue-language-span-2">WebVTT cue language span</a>) in <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-14">WebVTT cue text</a>,
+     <p>These represent spans of text (a <a data-link-type="dfn" href="#webvtt-cue-language-span" id="ref-for-webvtt-cue-language-span-2">WebVTT cue language span</a>) in <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-15">WebVTT cue text</a>,
   and are used to annotate parts of the cue where the <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language-2">applicable language</a> might be different than the surrounding text’s, without implying
   further meaning (such as italics or bold).</p>
    </dl>
@@ -3865,7 +3870,7 @@ Objects</a>:</p>
   second, which is the time represented by the timestamp.</p>
    </dl>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue-text-parsing-rules">WebVTT cue text parsing rules</dfn> consist of the following algorithm. The input is a
-string <var>input</var> supposedly containing <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-15">WebVTT cue text</a>, and optionally a fallback language <var>language</var>. This algorithm returns a <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-2">list of WebVTT Node Objects</a>.</p>
+string <var>input</var> supposedly containing <a data-link-type="dfn" href="#webvtt-cue-text" id="ref-for-webvtt-cue-text-16">WebVTT cue text</a>, and optionally a fallback language <var>language</var>. This algorithm returns a <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-2">list of WebVTT Node Objects</a>.</p>
    <ol class="algorithm" data-algorithm="WebVTT cue text parsing">
     <li>
      <p>Let <var>input</var> be the string being parsed.</p>
@@ -4288,8 +4293,10 @@ follows:</p>
    <h2 class="heading settled" data-level="7" id="rendering"><span class="secno">7. </span><span class="content">Rendering</span><a class="self-link" href="#rendering"></a></h2>
    <p class="note" role="note">This section describes in some detail how to visually render WebVTT cues in a user
 agent. The processing model is quite tightly linked to media elements in HTML, where CSS is
-available. When supporting WebVTT in media players that do not support CSS, equivalent visual
-rendering will need to be implemented.</p>
+available. <a data-link-type="dfn" href="#user-agents-that-do-not-support-css" id="ref-for-user-agents-that-do-not-support-css-1">User agents that do not support CSS</a> are expected to render plain text only,
+without styling and positioning features. <a data-link-type="dfn" href="#user-agents-that-do-not-support-a-full-html-css-engine" id="ref-for-user-agents-that-do-not-support-a-full-html-css-engine-1">User agents that do not support a full HTML CSS
+engine</a> are expected to render an equivalent visual representation to what a user agent with a
+full CSS engine would render.</p>
    <h3 class="heading settled algorithm" data-algorithm="Processing model" data-level="7.1" id="processing-model"><span class="secno">7.1. </span><span class="content">Processing model</span><a class="self-link" href="#processing-model"></a></h3>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="rules-for-updating-the-display-of-webvtt-text-tracks">rules for updating the display of WebVTT text tracks</dfn> render the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track">text tracks</a> of a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media element</a> (specifically, a <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/media.html#video">video</a> element), or of another playback
 mechanism, by applying the steps below. All the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track">text tracks</a> that use these
@@ -4889,7 +4896,7 @@ properties on the root <a data-link-type="dfn" href="#list-of-webvtt-node-object
 then they must be interpreted as defined in the next section.</p>
    <h2 class="heading settled" data-level="8" id="css-extensions"><span class="secno">8. </span><span class="content">CSS extensions</span><a class="self-link" href="#css-extensions"></a></h2>
    <p class="note" role="note">This section specifies some CSS pseudo-elements and pseudo-classes and how they
-apply to WebVTT. This section does not apply to user agents that do not support CSS.</p>
+apply to WebVTT. This section does not apply to <a data-link-type="dfn" href="#user-agents-that-do-not-support-css" id="ref-for-user-agents-that-do-not-support-css-2">user agents that do not support CSS</a>.</p>
    <h3 class="heading settled" data-level="8.1" id="css-extensions-introduction"><span class="secno">8.1. </span><span class="content">Introduction</span><a class="self-link" href="#css-extensions-introduction"></a></h3>
    <p><i>This section is non-normative.</i></p>
    <p>The <span class="css">::cue</span> pseudo-element represents a cue.</p>
@@ -5943,8 +5950,8 @@ originally specified. <a data-link-type="biblio" href="#biblio-html">[HTML]</a><
    <li><a href="#dom-positionalignsetting-line-right">line-right</a><span>, in §9.1</span>
    <li><a href="#dom-vttregion-lines">lines</a><span>, in §9.2</span>
    <li><a href="#list-of-webvtt-node-objects">List of WebVTT Node Objects</a><span>, in §6.4</span>
-   <li><a href="#dom-directionsetting-lr">"lr"</a><span>, in §9.1</span>
    <li><a href="#dom-directionsetting-lr">lr</a><span>, in §9.1</span>
+   <li><a href="#dom-directionsetting-lr">"lr"</a><span>, in §9.1</span>
    <li><a href="#obtain-a-set-of-css-boxes">obtain a set of CSS boxes</a><span>, in §7.3</span>
    <li><a href="#parse-a-percentage-string">parse a percentage string</a><span>, in §6.2</span>
    <li><a href="#parse-the-webvtt-cue-settings">parse the WebVTT cue settings</a><span>, in §6.3</span>
@@ -5982,6 +5989,8 @@ originally specified. <a data-link-type="biblio" href="#biblio-html">[HTML]</a><
    <li><a href="#text-vtt">text/vtt</a><span>, in §10.1</span>
    <li><a href="#dom-scrollsetting-up">up</a><span>, in §9.2</span>
    <li><a href="#dom-scrollsetting-up">"up"</a><span>, in §9.2</span>
+   <li><a href="#user-agents-that-do-not-support-a-full-html-css-engine">User agents that do not support a full HTML CSS engine</a><span>, in §2.1</span>
+   <li><a href="#user-agents-that-do-not-support-css">User agents that do not support CSS</a><span>, in §2.1</span>
    <li><a href="#dom-vttcue-vertical">vertical</a><span>, in §9.1</span>
    <li><a href="#dom-vttregion-viewportanchorx">viewportAnchorX</a><span>, in §9.2</span>
    <li><a href="#dom-vttregion-viewportanchory">viewportAnchorY</a><span>, in §9.2</span>
@@ -6462,6 +6471,19 @@ originally specified. <a data-link-type="biblio" href="#biblio-html">[HTML]</a><
    <b><a href="#webvtt">#webvtt</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-1">2.1. Conformance classes</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="user-agents-that-do-not-support-css">
+   <b><a href="#user-agents-that-do-not-support-css">#user-agents-that-do-not-support-css</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-user-agents-that-do-not-support-css-1">7. Rendering</a>
+    <li><a href="#ref-for-user-agents-that-do-not-support-css-2">8. CSS extensions</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="user-agents-that-do-not-support-a-full-html-css-engine">
+   <b><a href="#user-agents-that-do-not-support-a-full-html-css-engine">#user-agents-that-do-not-support-a-full-html-css-engine</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-user-agents-that-do-not-support-a-full-html-css-engine-1">7. Rendering</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue">
@@ -6998,12 +7020,13 @@ title</a>
   <aside class="dfn-panel" data-for="webvtt-cue-text">
    <b><a href="#webvtt-cue-text">#webvtt-cue-text</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-cue-text-1">3.1. WebVTT cues</a>
-    <li><a href="#ref-for-webvtt-cue-text-2">4.1. WebVTT file structure</a>
-    <li><a href="#ref-for-webvtt-cue-text-3">4.2.2. WebVTT cue text</a>
-    <li><a href="#ref-for-webvtt-cue-text-4">4.2.3. WebVTT chapter title text</a>
-    <li><a href="#ref-for-webvtt-cue-text-5">4.6.3. WebVTT file using cue text</a>
-    <li><a href="#ref-for-webvtt-cue-text-6">6.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-cue-text-7">(2)</a> <a href="#ref-for-webvtt-cue-text-8">(3)</a> <a href="#ref-for-webvtt-cue-text-9">(4)</a> <a href="#ref-for-webvtt-cue-text-10">(5)</a> <a href="#ref-for-webvtt-cue-text-11">(6)</a> <a href="#ref-for-webvtt-cue-text-12">(7)</a> <a href="#ref-for-webvtt-cue-text-13">(8)</a> <a href="#ref-for-webvtt-cue-text-14">(9)</a> <a href="#ref-for-webvtt-cue-text-15">(10)</a>
+    <li><a href="#ref-for-webvtt-cue-text-1">2.1. Conformance classes</a>
+    <li><a href="#ref-for-webvtt-cue-text-2">3.1. WebVTT cues</a>
+    <li><a href="#ref-for-webvtt-cue-text-3">4.1. WebVTT file structure</a>
+    <li><a href="#ref-for-webvtt-cue-text-4">4.2.2. WebVTT cue text</a>
+    <li><a href="#ref-for-webvtt-cue-text-5">4.2.3. WebVTT chapter title text</a>
+    <li><a href="#ref-for-webvtt-cue-text-6">4.6.3. WebVTT file using cue text</a>
+    <li><a href="#ref-for-webvtt-cue-text-7">6.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-cue-text-8">(2)</a> <a href="#ref-for-webvtt-cue-text-9">(3)</a> <a href="#ref-for-webvtt-cue-text-10">(4)</a> <a href="#ref-for-webvtt-cue-text-11">(5)</a> <a href="#ref-for-webvtt-cue-text-12">(6)</a> <a href="#ref-for-webvtt-cue-text-13">(7)</a> <a href="#ref-for-webvtt-cue-text-14">(8)</a> <a href="#ref-for-webvtt-cue-text-15">(9)</a> <a href="#ref-for-webvtt-cue-text-16">(10)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-cue-components">

--- a/index.html
+++ b/index.html
@@ -1188,7 +1188,7 @@ Possible extra rowspan handling
   </style>
   <meta content="Bikeshed version afd377055fd60b78052b08cc89f300fd74918048" name="generator">
   <link href="https://www.w3.org/TR/webvtt1/" rel="canonical">
-  <meta content="76feac6af2228716ad00a0eaed041a053b9c95d4" name="document-revision">
+  <meta content="5b07860bcee459ea12d00a9bcd7f8733630a6278" name="document-revision">
 <style>
  samp {
    font-family: inherit;
@@ -1444,7 +1444,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">WebVTT: The Web Video Text Tracks Format</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-09-29">29 September 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2017-10-01">1 October 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2024,6 +2024,12 @@ requirements.</p>
     <dt>User agents with no scripting support
     <dd>
      <p>All processing requirements in this specification apply, except those in <a href="#api">§8 API</a>.</p>
+    <dt>User agents that do not support CSS
+    <dd>
+     <p>All processing requirements in this specification apply, except those in <a href="#rendering">§6 Rendering</a> and
+ in <a href="#css-extensions">§7 CSS extensions</a>. The user agent must instead implement equivalent visual rendering to what a
+ CSS based rendering produces. <a href="#applying-css-properties">§6.1.1 Applying CSS properties to WebVTT Node Objects</a> lists the default styling properties in
+ CSS speak that will also define the default styling in such user agents.</p>
     <dt>Conformance checkers
     <dd>
      <p>Conformance checkers must verify that a <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file③">WebVTT file</a> conforms to the applicable
@@ -3274,9 +3280,7 @@ header</i> set, the user agent must run the following steps:</p>
      <p>Otherwise, return null.</p>
    </ol>
    <h3 class="heading settled algorithm" data-algorithm="WebVTT region settings parsing" data-level="5.2" id="region-settings-parsing"><span class="secno">5.2. </span><span class="content">WebVTT region settings parsing</span><a class="self-link" href="#region-settings-parsing"></a></h3>
-   <p>When the <a data-link-type="dfn" href="#webvtt-parser" id="ref-for-webvtt-parser④">WebVTT parser</a> requires that the user agent <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="collect WebVTT region settings" data-noexport="" id="collect-webvtt-region-settings">collect WebVTT region
-settings</dfn> from a string <var>input</var> for a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track" id="ref-for-text-track⑧">text track</a>, the user agent must run the following
-algorithm.</p>
+   <p>When the <a data-link-type="dfn" href="#webvtt-parser" id="ref-for-webvtt-parser④">WebVTT parser</a> says to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="collect-webvtt-region-settings">collect WebVTT region settings</dfn> from a string <var>input</var> for a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track" id="ref-for-text-track⑧">text track</a>, the user agent must run the following algorithm.</p>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-region-object">WebVTT region object</dfn> is a conceptual construct to represent a <a data-link-type="dfn" href="#webvtt-region" id="ref-for-webvtt-region⑨">WebVTT region</a> that is used as a root node for <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects">lists of WebVTT node
 objects</a>. This algorithm returns a list of <a data-link-type="dfn" href="#webvtt-region-object" id="ref-for-webvtt-region-object②">WebVTT Region
 Objects</a>.</p>
@@ -3386,8 +3390,9 @@ means that it is aborted at that point and returns nothing.</p>
      <p>Return <var>percentage</var>.</p>
    </ol>
    <h3 class="heading settled algorithm" data-algorithm="WebVTT cue timings and settings parsing" data-level="5.3" id="cue-timings-and-settings-parsing"><span class="secno">5.3. </span><span class="content">WebVTT cue timings and settings parsing</span><a class="self-link" href="#cue-timings-and-settings-parsing"></a></h3>
-   <p>When the algorithm above requires that the user agent <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="collect WebVTT cue timings and settings" data-noexport="" id="collect-webvtt-cue-timings-and-settings">collect WebVTT cue timings and
-settings</dfn> from a string <var>input</var> using a <a data-link-type="dfn" href="#text-track-list-of-regions" id="ref-for-text-track-list-of-regions①">text track list of regions</a> <var>regions</var> for a <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue①⑨">WebVTT cue</a> <var>cue</var>, the user agent must run the following algorithm.</p>
+   <p>When the algorithm above requires to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="collect-webvtt-cue-timings-and-settings">collect WebVTT cue timings and settings</dfn> from a
+string <var>input</var> using a <a data-link-type="dfn" href="#text-track-list-of-regions" id="ref-for-text-track-list-of-regions①">text track list of regions</a> <var>regions</var> for a <a data-link-type="dfn" href="#webvtt-cue" id="ref-for-webvtt-cue①⑨">WebVTT cue</a> <var>cue</var>,
+the user agent must run the following algorithm.</p>
    <ol class="algorithm">
     <li>
      <p>Let <var>input</var> be the string being parsed.</p>
@@ -4150,9 +4155,9 @@ follows:</p>
    </ol>
    <h2 class="heading settled" data-level="6" id="rendering"><span class="secno">6. </span><span class="content">Rendering</span><a class="self-link" href="#rendering"></a></h2>
    <p class="note" role="note">This section describes in some detail how to visually render WebVTT cues in a user
-agent. The processing model is quite tightly linked to media elements in HTML. When supporting
-WebVTT in media players that don’t support CSS, equivalent visual rendering will need to be
-implemented.</p>
+agent. The processing model is quite tightly linked to media elements in HTML, where CSS is
+available. When supporting WebVTT in media players that do not support CSS, equivalent visual
+rendering will need to be implemented.</p>
    <h3 class="heading settled algorithm" data-algorithm="Processing model" data-level="6.1" id="processing-model"><span class="secno">6.1. </span><span class="content">Processing model</span><a class="self-link" href="#processing-model"></a></h3>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="rules-for-updating-the-display-of-webvtt-text-tracks">rules for updating the display of WebVTT text tracks</dfn> render the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track" id="ref-for-text-track⑨">text tracks</a> of a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element" id="ref-for-media-element③">media element</a> (specifically, a <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/media.html#video" id="ref-for-video①">video</a> element), or of another playback
 mechanism, by applying the steps below. All the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track" id="ref-for-text-track①⓪">text tracks</a> that use these
@@ -4299,9 +4304,9 @@ manner suiting the user.</p>
    </ol>
    <p>User agents may allow the user to override the above algorithm’s positioning of cues, e.g. by
 dragging them to another location on the <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/media.html#video" id="ref-for-video②">video</a>, or even off the <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/media.html#video" id="ref-for-video③">video</a> entirely.</p>
-   <p>When the algorithm above requires that the user agent <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="apply-webvtt-cue-settings">apply WebVTT cue settings</dfn> to
-obtain CSS boxes from a <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects⑦">list of WebVTT Node Objects</a> <var>nodes</var>, the user agent must run the
-following algorithm.</p>
+   <p>When the algorithm above requires to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="apply-webvtt-cue-settings">apply WebVTT cue settings</dfn> to obtain CSS boxes
+from a <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects⑦">list of WebVTT Node Objects</a> <var>nodes</var>, the user agent must run the following
+algorithm.</p>
    <ol class="algorithm">
     <li>
      <p>If the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction①⑤">WebVTT cue writing direction</a> is <a data-link-type="dfn" href="#webvtt-cue-horizontal-writing-direction" id="ref-for-webvtt-cue-horizontal-writing-direction①③">horizontal</a>, then let <var>writing-mode</var> be "horizontal-tb". Otherwise, if the <a data-link-type="dfn" href="#webvtt-cue-writing-direction" id="ref-for-webvtt-cue-writing-direction①⑥">WebVTT
@@ -4752,7 +4757,7 @@ properties on the root <a data-link-type="dfn" href="#list-of-webvtt-node-object
 then they must be interpreted as defined in the next section.</p>
    <h2 class="heading settled" data-level="7" id="css-extensions"><span class="secno">7. </span><span class="content">CSS extensions</span><a class="self-link" href="#css-extensions"></a></h2>
    <p class="note" role="note">This section specifies some CSS pseudo-elements and pseudo-classes and how they
-apply to WebVTT. This section does not apply to user agents that don’t support CSS.</p>
+apply to WebVTT. This section does not apply to user agents that do not support CSS.</p>
    <h3 class="heading settled" data-level="7.1" id="css-extensions-introduction"><span class="secno">7.1. </span><span class="content">Introduction</span><a class="self-link" href="#css-extensions-introduction"></a></h3>
    <p><i>This section is non-normative.</i></p>
    <p>The <span class="css">::cue</span> pseudo-element represents a cue.</p>

--- a/index.html
+++ b/index.html
@@ -2132,8 +2132,8 @@ requirements.</p>
     <dd>
      <p>All processing requirements in this specification apply, except parts of <a href="#parsing">§6 Parsing</a> that
  relate to stylesheets and CSS, and all of <a href="#rendering">§7 Rendering</a> and <a href="#css-extensions">§8 CSS extensions</a>. The user agent
- must instead only render the text inside <a data-link-type="dfn">WebVTT cue text</a> in an appropriate manner. Any other
- styling and positioning instructions are optional.</p>
+ must instead only render the text inside <a data-link-type="dfn" href="#webvtt-caption-or-subtitle-cue-text" id="ref-for-webvtt-caption-or-subtitle-cue-text-1">WebVTT caption or subtitle cue text</a> in an
+ appropriate manner. Any other styling and positioning instructions are optional.</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="user-agents-that-do-not-support-a-full-html-css-engine">User agents that do not support a full HTML CSS engine</dfn>
     <dd>
      <p>All processing requirements in this specification apply. However, the user agent will need
@@ -2613,7 +2613,7 @@ order:</p>
     <li>Optionally, one or more U+0020 SPACE characters or U+0009 CHARACTER TABULATION (tab) characters
  followed by a <a data-link-type="dfn" href="#webvtt-cue-settings-list" id="ref-for-webvtt-cue-settings-list-1">WebVTT cue settings list</a>.
     <li>A <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator-12">WebVTT line terminator</a>.
-    <li>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="cue-payload">cue payload</dfn>: either <a data-link-type="dfn" href="#webvtt-caption-or-subtitle-cue-text" id="ref-for-webvtt-caption-or-subtitle-cue-text-1">WebVTT caption or subtitle cue text</a>, <a data-link-type="dfn" href="#webvtt-chapter-title-text" id="ref-for-webvtt-chapter-title-text-1">WebVTT
+    <li>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="cue-payload">cue payload</dfn>: either <a data-link-type="dfn" href="#webvtt-caption-or-subtitle-cue-text" id="ref-for-webvtt-caption-or-subtitle-cue-text-2">WebVTT caption or subtitle cue text</a>, <a data-link-type="dfn" href="#webvtt-chapter-title-text" id="ref-for-webvtt-chapter-title-text-1">WebVTT
  chapter title text</a>, or <a data-link-type="dfn" href="#webvtt-metadata-text" id="ref-for-webvtt-metadata-text-1">WebVTT metadata text</a>, but it must not contain the substring
  "<code>--></code>" (U+002D HYPHEN-MINUS, U+002D HYPHEN-MINUS, U+003E GREATER-THAN SIGN).
     <li>A <a data-link-type="dfn" href="#webvtt-line-terminator" id="ref-for-webvtt-line-terminator-13">WebVTT line terminator</a>.
@@ -2780,7 +2780,7 @@ are more mature in HTML and CSS. <a data-link-type="biblio" href="#biblio-html">
  represents the name of the voice.
     <li><a data-link-type="dfn" href="#webvtt-cue-internal-text" id="ref-for-webvtt-cue-internal-text-7">WebVTT cue internal text</a>.
     <li>A <a data-link-type="dfn" href="#webvtt-cue-span-end-tag" id="ref-for-webvtt-cue-span-end-tag-7">WebVTT cue span end tag</a> "<code>v</code>". If this <a data-link-type="dfn" href="#webvtt-cue-voice-span" id="ref-for-webvtt-cue-voice-span-2">WebVTT cue voice span</a> is the
- only <a data-link-type="dfn" href="#webvtt-caption-or-subtitle-cue-components" id="ref-for-webvtt-caption-or-subtitle-cue-components-4">component</a> of its <a data-link-type="dfn" href="#webvtt-caption-or-subtitle-cue-text" id="ref-for-webvtt-caption-or-subtitle-cue-text-2">WebVTT caption or
+ only <a data-link-type="dfn" href="#webvtt-caption-or-subtitle-cue-components" id="ref-for-webvtt-caption-or-subtitle-cue-components-4">component</a> of its <a data-link-type="dfn" href="#webvtt-caption-or-subtitle-cue-text" id="ref-for-webvtt-caption-or-subtitle-cue-text-3">WebVTT caption or
  subtitle cue text</a> sequence, then the end tag may be omitted for brevity.
    </ol>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue-language-span">WebVTT cue language span</dfn> consists of the following components, in the order
@@ -3188,7 +3188,7 @@ for validating these types.</p>
    <h4 class="heading settled" data-level="4.6.2" id="file-using-chapter-title-text"><span class="secno">4.6.2. </span><span class="content">WebVTT file using chapter title text</span><a class="self-link" href="#file-using-chapter-title-text"></a></h4>
    <p>A <dfn data-dfn-type="dfn" data-noexport="" id="webvtt-file-using-chapter-title-text">WebVTT file using chapter title text<a class="self-link" href="#webvtt-file-using-chapter-title-text"></a></dfn> is a <a data-link-type="dfn" href="#webvtt-file-using-only-nested-cues" id="ref-for-webvtt-file-using-only-nested-cues-3">WebVTT file using only nested cues</a> whose cues all have a <a data-link-type="dfn" href="#cue-payload" id="ref-for-cue-payload-4">cue payload</a> that is <a data-link-type="dfn" href="#webvtt-chapter-title-text" id="ref-for-webvtt-chapter-title-text-2">WebVTT chapter title text</a>.</p>
    <h4 class="heading settled" data-level="4.6.3" id="file-using-cue-text"><span class="secno">4.6.3. </span><span class="content">WebVTT file using caption or subtitle cue text</span><a class="self-link" href="#file-using-cue-text"></a></h4>
-   <p>A <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file-13">WebVTT file</a> whose cues all have a <a data-link-type="dfn" href="#cue-payload" id="ref-for-cue-payload-5">cue payload</a> that is <a data-link-type="dfn" href="#webvtt-caption-or-subtitle-cue-text" id="ref-for-webvtt-caption-or-subtitle-cue-text-3">WebVTT caption or
+   <p>A <a data-link-type="dfn" href="#webvtt-file" id="ref-for-webvtt-file-13">WebVTT file</a> whose cues all have a <a data-link-type="dfn" href="#cue-payload" id="ref-for-cue-payload-5">cue payload</a> that is <a data-link-type="dfn" href="#webvtt-caption-or-subtitle-cue-text" id="ref-for-webvtt-caption-or-subtitle-cue-text-4">WebVTT caption or
 subtitle cue text</a> is said to be a <dfn data-dfn-type="dfn" data-noexport="" id="webvtt-file-using-caption-or-subtitle-cue-text">WebVTT file using caption or subtitle cue text<a class="self-link" href="#webvtt-file-using-caption-or-subtitle-cue-text"></a></dfn>.</p>
    <h2 class="heading settled" data-level="5" id="default-classes"><span class="secno">5. </span><span class="content">Default classes for WebVTT Caption or Subtitle Cue Components</span><a class="self-link" href="#default-classes"></a></h2>
    <p>Many captioning formats have simple ways of specifying a limited subset of text colors and
@@ -3976,32 +3976,32 @@ Objects</a>:</p>
   classes</a> without implying further meaning (such as italics or bold).</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT Italic Object" data-noexport="" id="webvtt-italic-object">WebVTT Italic Objects</dfn>
     <dd>
-     <p>These represent spans of italic text (a <a data-link-type="dfn" href="#webvtt-cue-italics-span" id="ref-for-webvtt-cue-italics-span-2">WebVTT cue italics span</a>) in <a data-link-type="dfn" href="#webvtt-caption-or-subtitle-cue-text" id="ref-for-webvtt-caption-or-subtitle-cue-text-4">WebVTT caption or
+     <p>These represent spans of italic text (a <a data-link-type="dfn" href="#webvtt-cue-italics-span" id="ref-for-webvtt-cue-italics-span-2">WebVTT cue italics span</a>) in <a data-link-type="dfn" href="#webvtt-caption-or-subtitle-cue-text" id="ref-for-webvtt-caption-or-subtitle-cue-text-5">WebVTT caption or
   subtitle cue text</a>.</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT Bold Object" data-noexport="" id="webvtt-bold-object">WebVTT Bold Objects</dfn>
     <dd>
-     <p>These represent spans of bold text (a <a data-link-type="dfn" href="#webvtt-cue-bold-span" id="ref-for-webvtt-cue-bold-span-2">WebVTT cue bold span</a>) in <a data-link-type="dfn" href="#webvtt-caption-or-subtitle-cue-text" id="ref-for-webvtt-caption-or-subtitle-cue-text-5">WebVTT caption or
+     <p>These represent spans of bold text (a <a data-link-type="dfn" href="#webvtt-cue-bold-span" id="ref-for-webvtt-cue-bold-span-2">WebVTT cue bold span</a>) in <a data-link-type="dfn" href="#webvtt-caption-or-subtitle-cue-text" id="ref-for-webvtt-caption-or-subtitle-cue-text-6">WebVTT caption or
   subtitle cue text</a>.</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT Underline Object" data-noexport="" id="webvtt-underline-object">WebVTT Underline Objects</dfn>
     <dd>
-     <p>These represent spans of underline text (a <a data-link-type="dfn" href="#webvtt-cue-underline-span" id="ref-for-webvtt-cue-underline-span-2">WebVTT cue underline span</a>) in <a data-link-type="dfn" href="#webvtt-caption-or-subtitle-cue-text" id="ref-for-webvtt-caption-or-subtitle-cue-text-6">WebVTT
+     <p>These represent spans of underline text (a <a data-link-type="dfn" href="#webvtt-cue-underline-span" id="ref-for-webvtt-cue-underline-span-2">WebVTT cue underline span</a>) in <a data-link-type="dfn" href="#webvtt-caption-or-subtitle-cue-text" id="ref-for-webvtt-caption-or-subtitle-cue-text-7">WebVTT
   caption or subtitle cue text</a>.</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT Ruby Object" data-noexport="" id="webvtt-ruby-object">WebVTT Ruby Objects</dfn>
     <dd>
-     <p>These represent spans of ruby (a <a data-link-type="dfn" href="#webvtt-cue-ruby-span" id="ref-for-webvtt-cue-ruby-span-3">WebVTT cue ruby span</a>) in <a data-link-type="dfn" href="#webvtt-caption-or-subtitle-cue-text" id="ref-for-webvtt-caption-or-subtitle-cue-text-7">WebVTT caption or subtitle
+     <p>These represent spans of ruby (a <a data-link-type="dfn" href="#webvtt-cue-ruby-span" id="ref-for-webvtt-cue-ruby-span-3">WebVTT cue ruby span</a>) in <a data-link-type="dfn" href="#webvtt-caption-or-subtitle-cue-text" id="ref-for-webvtt-caption-or-subtitle-cue-text-8">WebVTT caption or subtitle
   cue text</a>.</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT Ruby Text Object" data-noexport="" id="webvtt-ruby-text-object">WebVTT Ruby Text Objects</dfn>
     <dd>
-     <p>These represent spans of ruby text (a <a data-link-type="dfn" href="#webvtt-cue-ruby-text-span" id="ref-for-webvtt-cue-ruby-text-span-1">WebVTT cue ruby text span</a>) in <a data-link-type="dfn" href="#webvtt-caption-or-subtitle-cue-text" id="ref-for-webvtt-caption-or-subtitle-cue-text-8">WebVTT caption or
+     <p>These represent spans of ruby text (a <a data-link-type="dfn" href="#webvtt-cue-ruby-text-span" id="ref-for-webvtt-cue-ruby-text-span-1">WebVTT cue ruby text span</a>) in <a data-link-type="dfn" href="#webvtt-caption-or-subtitle-cue-text" id="ref-for-webvtt-caption-or-subtitle-cue-text-9">WebVTT caption or
   subtitle cue text</a>.</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT Voice Object" data-noexport="" id="webvtt-voice-object">WebVTT Voice Objects</dfn>
     <dd>
      <p>These represent spans of text associated with a specific voice (a <a data-link-type="dfn" href="#webvtt-cue-voice-span" id="ref-for-webvtt-cue-voice-span-3">WebVTT cue voice span</a>)
-  in <a data-link-type="dfn" href="#webvtt-caption-or-subtitle-cue-text" id="ref-for-webvtt-caption-or-subtitle-cue-text-9">WebVTT caption or subtitle cue text</a>. A <a data-link-type="dfn" href="#webvtt-voice-object" id="ref-for-webvtt-voice-object-1">WebVTT Voice Object</a> has a value, which is
+  in <a data-link-type="dfn" href="#webvtt-caption-or-subtitle-cue-text" id="ref-for-webvtt-caption-or-subtitle-cue-text-10">WebVTT caption or subtitle cue text</a>. A <a data-link-type="dfn" href="#webvtt-voice-object" id="ref-for-webvtt-voice-object-1">WebVTT Voice Object</a> has a value, which is
   the name of the voice.</p>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="WebVTT Language Object" data-noexport="" id="webvtt-language-object">WebVTT Language Objects</dfn>
     <dd>
-     <p>These represent spans of text (a <a data-link-type="dfn" href="#webvtt-cue-language-span" id="ref-for-webvtt-cue-language-span-2">WebVTT cue language span</a>) in <a data-link-type="dfn" href="#webvtt-caption-or-subtitle-cue-text" id="ref-for-webvtt-caption-or-subtitle-cue-text-10">WebVTT caption or
+     <p>These represent spans of text (a <a data-link-type="dfn" href="#webvtt-cue-language-span" id="ref-for-webvtt-cue-language-span-2">WebVTT cue language span</a>) in <a data-link-type="dfn" href="#webvtt-caption-or-subtitle-cue-text" id="ref-for-webvtt-caption-or-subtitle-cue-text-11">WebVTT caption or
   subtitle cue text</a>, and are used to annotate parts of the cue where the <a data-link-type="dfn" href="#webvtt-node-objects-applicable-language" id="ref-for-webvtt-node-objects-applicable-language-2">applicable language</a> might be different than the surrounding
   text’s, without implying further meaning (such as italics or bold).</p>
    </dl>
@@ -4020,7 +4020,7 @@ Objects</a>:</p>
   second, which is the time represented by the timestamp.</p>
    </dl>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="webvtt-cue-text-parsing-rules">WebVTT cue text parsing rules</dfn> consist of the following algorithm. The input is a
-string <var>input</var> supposedly containing <a data-link-type="dfn" href="#webvtt-caption-or-subtitle-cue-text" id="ref-for-webvtt-caption-or-subtitle-cue-text-11">WebVTT caption or subtitle cue text</a>, and optionally a
+string <var>input</var> supposedly containing <a data-link-type="dfn" href="#webvtt-caption-or-subtitle-cue-text" id="ref-for-webvtt-caption-or-subtitle-cue-text-12">WebVTT caption or subtitle cue text</a>, and optionally a
 fallback language <var>language</var>. This algorithm returns a <a data-link-type="dfn" href="#list-of-webvtt-node-objects" id="ref-for-list-of-webvtt-node-objects-2">list of WebVTT Node Objects</a>.</p>
    <ol class="algorithm" data-algorithm="WebVTT cue text parsing">
     <li>
@@ -4443,11 +4443,11 @@ follows:</p>
    </ol>
    <h2 class="heading settled" data-level="7" id="rendering"><span class="secno">7. </span><span class="content">Rendering</span><a class="self-link" href="#rendering"></a></h2>
    <p class="note" role="note">This section describes in some detail how to visually render <a data-link-type="dfn" href="#webvtt-caption-or-subtitle-cue" id="ref-for-webvtt-caption-or-subtitle-cue-2">WebVTT caption or
-subtitle cues</a> in a user agent. The processing model is quite tightly linked to media elements in HTML, where CSS is
-available. <a data-link-type="dfn" href="#user-agents-that-do-not-support-css" id="ref-for-user-agents-that-do-not-support-css-1">User agents that do not support CSS</a> are expected to render plain text only,
-without styling and positioning features. <a data-link-type="dfn" href="#user-agents-that-do-not-support-a-full-html-css-engine" id="ref-for-user-agents-that-do-not-support-a-full-html-css-engine-1">User agents that do not support a full HTML CSS
-engine</a> are expected to render an equivalent visual representation to what a user agent with a
-full CSS engine would render.</p>
+subtitle cues</a> in a user agent. The processing model is quite tightly linked to media elements in
+HTML, where CSS is available. <a data-link-type="dfn" href="#user-agents-that-do-not-support-css" id="ref-for-user-agents-that-do-not-support-css-1">User agents that do not support CSS</a> are expected to render
+plain text only, without styling and positioning features. <a data-link-type="dfn" href="#user-agents-that-do-not-support-a-full-html-css-engine" id="ref-for-user-agents-that-do-not-support-a-full-html-css-engine-1">User agents that do not support a full
+HTML CSS engine</a> are expected to render an equivalent visual representation to what a user agent
+with a full CSS engine would render.</p>
    <h3 class="heading settled algorithm" data-algorithm="Processing model" data-level="7.1" id="processing-model"><span class="secno">7.1. </span><span class="content">Processing model</span><a class="self-link" href="#processing-model"></a></h3>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="rules-for-updating-the-display-of-webvtt-text-tracks">rules for updating the display of WebVTT text tracks</dfn> render the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track">text tracks</a> of a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">media element</a> (specifically, a <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/media.html#video">video</a> element), or of another playback
 mechanism, by applying the steps below. All the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track">text tracks</a> that use these
@@ -7188,10 +7188,11 @@ title</a>
   <aside class="dfn-panel" data-for="webvtt-caption-or-subtitle-cue-text">
    <b><a href="#webvtt-caption-or-subtitle-cue-text">#webvtt-caption-or-subtitle-cue-text</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-webvtt-caption-or-subtitle-cue-text-1">4.1. WebVTT file structure</a>
-    <li><a href="#ref-for-webvtt-caption-or-subtitle-cue-text-2">4.2.2. WebVTT caption or subtitle cue text</a>
-    <li><a href="#ref-for-webvtt-caption-or-subtitle-cue-text-3">4.6.3. WebVTT file using caption or subtitle cue text</a>
-    <li><a href="#ref-for-webvtt-caption-or-subtitle-cue-text-4">6.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-caption-or-subtitle-cue-text-5">(2)</a> <a href="#ref-for-webvtt-caption-or-subtitle-cue-text-6">(3)</a> <a href="#ref-for-webvtt-caption-or-subtitle-cue-text-7">(4)</a> <a href="#ref-for-webvtt-caption-or-subtitle-cue-text-8">(5)</a> <a href="#ref-for-webvtt-caption-or-subtitle-cue-text-9">(6)</a> <a href="#ref-for-webvtt-caption-or-subtitle-cue-text-10">(7)</a> <a href="#ref-for-webvtt-caption-or-subtitle-cue-text-11">(8)</a>
+    <li><a href="#ref-for-webvtt-caption-or-subtitle-cue-text-1">2.1. Conformance classes</a>
+    <li><a href="#ref-for-webvtt-caption-or-subtitle-cue-text-2">4.1. WebVTT file structure</a>
+    <li><a href="#ref-for-webvtt-caption-or-subtitle-cue-text-3">4.2.2. WebVTT caption or subtitle cue text</a>
+    <li><a href="#ref-for-webvtt-caption-or-subtitle-cue-text-4">4.6.3. WebVTT file using caption or subtitle cue text</a>
+    <li><a href="#ref-for-webvtt-caption-or-subtitle-cue-text-5">6.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-caption-or-subtitle-cue-text-6">(2)</a> <a href="#ref-for-webvtt-caption-or-subtitle-cue-text-7">(3)</a> <a href="#ref-for-webvtt-caption-or-subtitle-cue-text-8">(4)</a> <a href="#ref-for-webvtt-caption-or-subtitle-cue-text-9">(5)</a> <a href="#ref-for-webvtt-caption-or-subtitle-cue-text-10">(6)</a> <a href="#ref-for-webvtt-caption-or-subtitle-cue-text-11">(7)</a> <a href="#ref-for-webvtt-caption-or-subtitle-cue-text-12">(8)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="webvtt-caption-or-subtitle-cue-components">


### PR DESCRIPTION
This actually introduces a definition for "WebVTT cue setting" and
clarifies how they provide information to position and align the cue
box and cue text.

Closes #361 