### PR TITLE
Update region lines parsing to round to +/- MAX_VALUE

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2859,7 +2859,19 @@ Objects</a>.</p>
 
        <li><p>Interpret |value| as an integer, and let |number| be that number.</p></li>
 
-       <li><p>Let |region|'s <a>WebVTT region lines</a> be |number|.</p></li>
+       <li><p><i>Conversion</i>: Let <var>S</var> be the set of finite IEEE 754 double-precision
+       floating-point values except −0, but with two special values added:
+       <var>2<sup>1024</sup></var> and <var>−2<sup>1024</sup></var>.</p></li>
+
+       <li><p>Let |rounded-number| be the number in |S| that is closest to |number|,
+       selecting the number with an even significand if there are two equally close
+       values. (The two special values <var>2<sup>1024</sup></var> and <var>−2<sup>1024</sup></var>
+       are considered to have even significands for this purpose.)</p>
+
+       <li><p>If |rounded-number| is <var>2<sup>1024</sup></var> or <var>−2<sup>1024</sup></var>,
+       jump to the step labeled <i>next setting</i></p></li>
+
+       <li><p>Let |region|'s <a>WebVTT region lines</a> be |rounded-number|.</p></li>
       </ol>
      </dd>
 


### PR DESCRIPTION
This would potentially require an update to the WPT.

The text is borrowed from https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#rules-for-parsing-floating-point-number-values, though, I don't think that it's a great fit here.

I haven't regenerated the index.html yet, will do so after I figure out the process around bikeshed updates.

Fixes #467.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gkatsev/webvtt/pull/470.html" title="Last updated on May 30, 2026, 4:26 PM UTC (4f11bc5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webvtt/470/f6b3eab...gkatsev:4f11bc5.html" title="Last updated on May 30, 2026, 4:26 PM UTC (4f11bc5)">Diff</a>