### PR TITLE
Add repo-type to w3c.json

### DIFF
--- a/w3c.json
+++ b/w3c.json
@@ -1,5 +1,6 @@
  {
     "group":      ["34314"]
 ,   "contacts":   ["plehegar"]
+,   "repo-type":  "cg-report"
 ,   "shortName":  "webvtt"
 }


### PR DESCRIPTION
This was found missing in https://w3c.github.io/validate-repos/report.html.