### PR TITLE
Added unbounded TextTrackCue.endTime

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5569,7 +5569,8 @@ interface VTTCue : TextTrackCue {
  <dd>
   <p>Returns a new {{VTTCue}} object, for use with the {{TextTrack/addCue()}} method.</p>
   <p>The |startTime| argument sets the <a>text track cue start time</a>.</p>
-  <p>The |endTime| argument sets the <a>text track cue end time</a>.</p>
+  <p>The |endTime| argument sets the <a>text track cue end time</a>. In the case of the value being
+  positive Infinity, the {{VTTCue}} object represents an <a>unbounded text track cue</a>.</p>
   <p>The |text| argument sets the <a>cue text</a>.</p>
  </dd>
 

--- a/index.bs
+++ b/index.bs
@@ -54,6 +54,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/
             text: rules for extracting the chapter title
             text: text track cue start time
             text: text track cue end time
+            text: unbounded text track cue
             text: expose a user interface to the user
             text: text track cue order
             text: honor user preferences for automatic text track selection
@@ -5544,7 +5545,8 @@ enum DirectionSetting { "" /* horizontal */, "rl", "lr" };
 enum LineAlignSetting { "start", "center", "end" };
 enum PositionAlignSetting { "line-left", "center", "line-right", "auto" };
 enum AlignSetting { "start", "center", "end", "left", "right" };
-[Exposed=Window]
+[Exposed=Window,
+ Constructor(double startTime, unrestricted double endTime, DOMString text)]
 interface VTTCue : TextTrackCue {
   constructor(double startTime, double endTime, DOMString text);
   attribute VTTRegion? region;
@@ -5693,7 +5695,7 @@ interface VTTCue : TextTrackCue {
  interpreted as a time in seconds.</p></li>
 
  <li><p>Let |cue|'s <a>text track cue end time</a> be the value of the |endTime| argument,
- interpreted as a time in seconds.</p></li>
+ interpreted as a time in seconds or positive Infinity for an <a>unbounded text track cue</a>.</p></li>
 
  <li><p>Let |cue|'s <a>cue text</a> be the value of the |text| argument, and let the <a>rules for
  extracting the chapter title</a> be the <a>WebVTT rules for extracting the chapter

--- a/index.bs
+++ b/index.bs
@@ -5548,7 +5548,7 @@ enum AlignSetting { "start", "center", "end", "left", "right" };
 [Exposed=Window,
  Constructor(double startTime, unrestricted double endTime, DOMString text)]
 interface VTTCue : TextTrackCue {
-  constructor(double startTime, double endTime, DOMString text);
+  constructor(double startTime, unrestricted double endTime, DOMString text);
   attribute VTTRegion? region;
   attribute DirectionSetting vertical;
   attribute boolean snapToLines;
@@ -5734,6 +5734,13 @@ interface VTTCue : TextTrackCue {
  <li><p>Return the {{VTTCue}} object representing |cue|.</p></li>
 
 </ol>
+
+<p>The <dfn attribute for=VTTCue>endTime</dfn> attribute, on getting, must return the <a>text track
+cue end time</a> of the <a>WebVTT cue</a> that the {{VTTCue}} object represents, in seconds or
+positive Infinity. On setting, if the new value is negative Infinity or a Not-a-Number (NaN) value,
+then throw a <a
+href="https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError
+</a> exception. Otherwise, the <a>text track cue end time</a> must be set to the new value.</p>
 
 <p>The <dfn attribute for=VTTCue>region</dfn> attribute, on getting, must return the {{VTTRegion}}
 object representing the <a>WebVTT cue region</a> of the <a>WebVTT cue</a> that the {{VTTCue}} object

--- a/index.bs
+++ b/index.bs
@@ -5545,8 +5545,7 @@ enum DirectionSetting { "" /* horizontal */, "rl", "lr" };
 enum LineAlignSetting { "start", "center", "end" };
 enum PositionAlignSetting { "line-left", "center", "line-right", "auto" };
 enum AlignSetting { "start", "center", "end", "left", "right" };
-[Exposed=Window,
- Constructor(double startTime, unrestricted double endTime, DOMString text)]
+[Exposed=Window]
 interface VTTCue : TextTrackCue {
   constructor(double startTime, unrestricted double endTime, DOMString text);
   attribute VTTRegion? region;
@@ -5694,8 +5693,11 @@ interface VTTCue : TextTrackCue {
  <li><p>Let |cue|'s <a>text track cue start time</a> be the value of the |startTime| argument,
  interpreted as a time in seconds.</p></li>
 
- <li><p>Let |cue|'s <a>text track cue end time</a> be the value of the |endTime| argument,
- interpreted as a time in seconds or positive Infinity for an <a>unbounded text track
+ <li><p>If the value of the |endTime| argument is negative Infinity or a Not-a-Number (NaN) value,
+ then throw a <a
+ href="https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError
+ </a> exception. Otherwise, let |cue|'s <a>text track cue end time</a> be the value of the |endTime|
+ argument, interpreted as a time in seconds or positive Infinity for an <a>unbounded text track
  cue</a>.</p></li>
 
  <li><p>Let |cue|'s <a>cue text</a> be the value of the |text| argument, and let the <a>rules for
@@ -5734,13 +5736,6 @@ interface VTTCue : TextTrackCue {
  <li><p>Return the {{VTTCue}} object representing |cue|.</p></li>
 
 </ol>
-
-<p>The <dfn attribute for=VTTCue>endTime</dfn> attribute, on getting, must return the <a>text track
-cue end time</a> of the <a>WebVTT cue</a> that the {{VTTCue}} object represents, in seconds or
-positive Infinity. On setting, if the new value is negative Infinity or a Not-a-Number (NaN) value,
-then throw a <a
-href="https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError
-</a> exception. Otherwise, the <a>text track cue end time</a> must be set to the new value.</p>
 
 <p>The <dfn attribute for=VTTCue>region</dfn> attribute, on getting, must return the {{VTTRegion}}
 object representing the <a>WebVTT cue region</a> of the <a>WebVTT cue</a> that the {{VTTCue}} object

--- a/index.bs
+++ b/index.bs
@@ -5690,15 +5690,14 @@ interface VTTCue : TextTrackCue {
 
  <li><p>Create a new <a>WebVTT cue</a>. Let |cue| be that <a>WebVTT cue</a>.</p></li>
 
- <li><p>Let |cue|'s <a>text track cue start time</a> be the value of the |startTime| argument,
- interpreted as a time in seconds.</p></li>
+ <li><p>Let |cue|'s <a>text track cue start time</a> be the value of the |startTime|
+ argument.</p></li>
 
  <li><p>If the value of the |endTime| argument is negative Infinity or a Not-a-Number (NaN) value,
  then throw a <a
  href="https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError
  </a> exception. Otherwise, let |cue|'s <a>text track cue end time</a> be the value of the |endTime|
- argument, interpreted as a time in seconds or positive Infinity for an <a>unbounded text track
- cue</a>.</p></li>
+ argument.</p></li>
 
  <li><p>Let |cue|'s <a>cue text</a> be the value of the |text| argument, and let the <a>rules for
  extracting the chapter title</a> be the <a>WebVTT rules for extracting the chapter

--- a/index.bs
+++ b/index.bs
@@ -5695,7 +5695,8 @@ interface VTTCue : TextTrackCue {
  interpreted as a time in seconds.</p></li>
 
  <li><p>Let |cue|'s <a>text track cue end time</a> be the value of the |endTime| argument,
- interpreted as a time in seconds or positive Infinity for an <a>unbounded text track cue</a>.</p></li>
+ interpreted as a time in seconds or positive Infinity for an <a>unbounded text track
+ cue</a>.</p></li>
 
  <li><p>Let |cue|'s <a>cue text</a> be the value of the |text| argument, and let the <a>rules for
  extracting the chapter title</a> be the <a>WebVTT rules for extracting the chapter


### PR DESCRIPTION
Added support for unbounded TextTrackCue - see https://github.com/whatwg/html/pull/5953
Whitespace removed by Atom


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/away-team-software/webvtt/pull/493.html" title="Last updated on Apr 28, 2021, 4:01 PM UTC (0f46a24)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webvtt/493/6befe1d...away-team-software:0f46a24.html" title="Last updated on Apr 28, 2021, 4:01 PM UTC (0f46a24)">Diff</a>