### PR TITLE
[Editorial] Add "noexport" to :past and :future dfns

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5480,7 +5480,7 @@ would have been applied to the <a>list of WebVTT Node Objects</a>, must instead 
 <p>The '':past'' and '':future'' pseudo-classes sometimes match <a lt="WebVTT Node Object">WebVTT
 Node Objects</a>. [[!SELECTORS4]]</p>
 
-<p>The <dfn selector>:past</dfn> pseudo-class only matches <a lt="WebVTT Node Object">WebVTT Node Objects</a>
+<p>The <dfn selector noexport>:past</dfn> pseudo-class only matches <a lt="WebVTT Node Object">WebVTT Node Objects</a>
 that are <i>in the past</i>.</p>
 
 <p algorithm="in the past">A <a>WebVTT Node Object</a> |c| is <dfn abstract-op>in the past</dfn> if, in a
@@ -5489,7 +5489,7 @@ there exists a <a>WebVTT Timestamp Object</a> whose value is less than the <a>cu
 position</a> of the <a>media element</a> that is the <i>matched element</i>, entirely after the
 <a>WebVTT Node Object</a> |c|.</p>
 
-<p>The <dfn selector>:future</dfn> pseudo-class only matches <a lt="WebVTT Node Object">WebVTT Node
+<p>The <dfn selector noexport>:future</dfn> pseudo-class only matches <a lt="WebVTT Node Object">WebVTT Node
 Objects</a> that are <i>in the future</i>.</p>
 
 <p algorithm="in the future">A <a>WebVTT Node Object</a> |c| is <dfn abstract-op>in the future</dfn> if, in a


### PR DESCRIPTION
The `:past` and `:future` pseudo-classes are formally defined in Selectors 4, which the WebVTT spec correctly references. It is fine to re-define these terms locally. The problem is that previous commit flagged these definitions as being selectors, which is correct as well but also made Bikeshed export them.

In other words, these definitions now conflict with those in Selectors 4.

This update flags these definitions with a `noexport` attribute to tell Bikeshed to keep these definitions local.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/webvtt/pull/510.html" title="Last updated on Feb 27, 2023, 6:05 PM UTC (41d5e42)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webvtt/510/f6b3eab...tidoust:41d5e42.html" title="Last updated on Feb 27, 2023, 6:05 PM UTC (41d5e42)">Diff</a>