### PR TITLE
New ATTRIBUTES block

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -573,7 +573,7 @@ WEBVTT
 
 ATTRIBUTES
 kind: subtitles
-srclang: es-mx
+lang: es-mx
 label: Español
 
 NOTE
@@ -597,7 +597,7 @@ WEBVTT
 
 ATTRIBUTES
 kind: captions
-srclang: es-mx
+lang: es-mx
 label: Español (SDH)
 
 NOTE
@@ -718,13 +718,13 @@ this case, "music".
 
 <div class="example">
 
- <p>In this example, a WebVTT attributes object is used to indicate the text track cues represent descriptions for the blind. Unlike subtitles or captions, these are not intended to be rendered visually.</p>
+ <p>In this example, a WebVTT attributes object is used to indicate the text track cues represent audible or braille descriptions for the blind. Unlike subtitles or captions, these are not intended to be rendered visually.</p>
  <pre>
 WEBVTT
 
 ATTRIBUTES
 kind: descriptions
-srclang: en-us
+lang: en-us
 label: English (AD)
 
 NOTE
@@ -798,11 +798,6 @@ WEBVTT
 ATTRIBUTES
 kind: metadata
 
-NOTE
-The Timed Text Working Group is discussing a registry for metadata `type` 
-values, such as `type: video-thumbnails` or `type: video-flash-avoidance`. 
-See webvtt issues #511 and #512 for more info.
-
 00:00:01.959 --> 00:00:02.938
 {
  "src": "https://cdn.example.com/thumbnails.jpg#xywh=0,0,284,160",
@@ -812,6 +807,11 @@ See webvtt issues #511 and #512 for more info.
  }
 }
  </pre>
+ 
+ <p class="note">The Timed Text Working Group is discussing a registry for metadata <code>type</code> 
+values, such as <code>type: video-thumbnails</code> or <code>type: video-flash-avoidance</code>. 
+See WebVTT issues <a href="https://github.com/w3c/webvtt/issues/511">#511</a> and <a href="https://github.com/w3c/webvtt/issues/512">#512</a> for more info.</p>
+
 
 </div>
 
@@ -4294,7 +4294,7 @@ follows:</p>
    <dt>If the key name is "<code>kind</code>"</dt>
    <dd>Process the value as <a href="https://html.spec.whatwg.org/multipage/media.html#attr-track-kind">the kind attribute</a> of a track element according to the HTML Standard.</dd>
 
-   <dt>If the key name is "<code>srclang</code>"</dt>
+   <dt>If the key name is "<code>lang</code>"</dt>
    <dd>Process the value as <a href="https://html.spec.whatwg.org/multipage/media.html#attr-track-srclang">the srclang attribute</a> of a track element according to the HTML Standard.</dd>
 
    <dt>If the key name is "<code>label</code>"</dt>

--- a/index.bs
+++ b/index.bs
@@ -563,6 +563,62 @@ CSS comment (e.g. <code>/**/</code>).</p>
 
 </div>
 
+
+
+<div class="example">
+
+ <p>In this example, an optional WebVTT attributes object is used to define the source language and its label in a subtitle/caption selection menu.</p>
+ <pre>
+WEBVTT
+
+ATTRIBUTES
+kind: subtitles
+srclang: es-mx
+label: Español
+
+NOTE
+Standard subtitles (unlike CC or SDH captions) typically 
+translate spoken dialog or signage, but not audible sounds 
+effects like "dogs barking."
+
+1
+00:00:10.123 --> 00:00:15.432
+¡Hola! ¿Qué tál?
+ </pre>
+
+</div>
+
+
+<div class="example">
+
+ <p>In this example, an optional WebVTT attributes object is used to differentiate captions from standard subtitles.</p>
+ <pre>
+WEBVTT
+
+ATTRIBUTES
+kind: captions
+srclang: es-mx
+label: Español (SDH)
+
+NOTE
+Captions (SDH aka Subtitles for the Deaf and Hard-of-Hearing) 
+typically include spoken dialog as well as important audible 
+sounds such as "floor boards creak", "dogs barking", or in 
+this case, "music".
+
+1
+00:00:10.123 --> 00:00:15.432
+¡Hola! ¿Qué tál?
+
+2
+00:00:47.462 --> 00:01:04.028
+[♫ música ♫]
+ </pre>
+
+</div>
+
+
+
 <h3 id=introduction-comments>Comments in WebVTT</h3>
 
 <p><i>This section is non-normative.</i></p>
@@ -658,6 +714,32 @@ CSS comment (e.g. <code>/**/</code>).</p>
 
 </div>
 
+
+
+<div class="example">
+
+ <p>In this example, a WebVTT attributes object is used to indicate the text track cues represent video descriptions for the blind. Unlike subtitles or captions, these are not intended to be rendered visually.</p>
+ <pre>
+WEBVTT
+
+ATTRIBUTES
+kind: descriptions
+srclang: en-us
+label: English (AD)
+
+NOTE
+VTT-based descriptions are meant to render as text-to-speech audio or braille,
+for blind or deafblind audiences, not usually as visual captions on screen. 
+As such, the option/label might be displayed in an audio menu or elsewhere. 
+
+1
+00:00:10.123 --> 00:00:15.432
+A young girl tiptoes down a dark hallway.
+ </pre>
+
+</div>
+
+
 <h3 id=introduction-metadata>Metadata example</h3>
 
 <p><i>This section is non-normative.</i></p>
@@ -671,11 +753,14 @@ signifies the end of the WebVTT cue.</p>
 
 <div class="example">
 
- <p>In this example, a talk is split into each slide being a chapter.</p>
+ <p>In this example, topics mentioned in a talk are provided as URLs for reference.</p>
 
  <pre>
  WEBVTT
 
+ ATTRIBUTES
+ kind: metadata
+ 
  NOTE
  Thanks to http://output.jsbin.com/mugibo
 
@@ -700,6 +785,28 @@ signifies the end of the WebVTT cue.</p>
   "lat" : "36.198269",
   "long": "137.2315355"
  }
+ </pre>
+
+</div>
+
+<div class="example">
+
+ <p>In this example, a sequence of video thumbnails and their text alternative are made available for the playback UI.</p>
+ <pre>
+WEBVTT
+
+ATTRIBUTES
+kind: metadata
+type: video-thumbnails
+
+00:00:01.959 --> 00:00:02.938
+{
+ "src": "https://cdn.example.com/thumbnails.jpg#xywh=0,0,284,160",
+ "alt": {
+  "en-us": "Miguel crosses the marigold bridge to the land of the dead.",
+  "es-mx": "Miguel cruza el puente marigold hacia la tierra de los muertos."
+ }
+}
  </pre>
 
 </div>
@@ -1650,6 +1757,28 @@ SIGN).</p>
 
 <p>When interpreted as a number, a <a>WebVTT percentage</a> must be in the range 0..100.</p>
 
+<p>A <dfn>WebVTT attributes object</dfn> consists of the following components, in the given order:</p>
+<ol>
+ <li>The string "<code>ATTRIBUTES</code>".</li>
+ <li>
+  The following components, in the given order:
+  <ol>
+   <li>A <a>WebVTT line terminator</a>.</li>
+   <li>Zero or more key/value pairs, parsed in the given order:
+    <ol>
+     <li>A <dfn>WebVTT attribute key</dfn> consisting of any sequence of one or more (TODO: /A-Za-z/?) characters.</li>
+     <li>A single U+003A COLON character ("<code>:</code>").</li>
+     <li>Zero or one U+0020 SPACE or U+0009 CHARACTER TABULATION (tab) characters.</li>
+     <li>A <dfn>WebVTT attribute value</dfn> consisting of any sequence of zero or more characters other than U+000A LINE FEED (LF) characters and U+000D CARRIAGE RETURN (CR) characters, except that the entire resulting string must not contain the substring "<code>--></code>" (U+002D HYPHEN-MINUS, U+002D HYPHEN-MINUS, U+003E GREATER-THAN SIGN).</li>
+     <li>A <a>WebVTT line terminator</a>.</li>
+    </ol>
+   </li>
+   <li>A final <a>WebVTT line terminator</a> to complete the WebVTT attributes object.</li>
+  </ol>
+ </li>
+</ol>
+
+
 <p>A <dfn>WebVTT comment block</dfn> consists of the following components, in the given order:</p>
 
 <ol>
@@ -1687,7 +1816,7 @@ separated from the next by a <a>WebVTT line terminator</a>. (In other words, any
 have two consecutive <a lt="WebVTT line terminator">WebVTT line terminators</a> and does not start
 or end with a <a>WebVTT line terminator</a>.)</p>
 
-<p><a>WebVTT metadata text</a> cues are only useful for scripted applications (e.g. using the
+<p><a>WebVTT metadata text</a> cues were originally intended for scripted applications (e.g. using the
 <code>metadata</code> <a>text track kind</a> in a HTML <a>text track</a>).</p>
 
 

--- a/index.bs
+++ b/index.bs
@@ -578,7 +578,7 @@ label: Español
 
 NOTE
 Standard subtitles (unlike CC or SDH captions) typically 
-translate spoken dialog or signage, but not audible sounds 
+translate spoken dialog or signage, but not audible sound 
 effects like "dogs barking."
 
 1
@@ -1773,25 +1773,21 @@ SIGN).</p>
    <li>A <a>WebVTT line terminator</a>.</li>
    <li>Zero or more key/value pairs, parsed in the given order:
     <ol>
-     <li>A <dfn>WebVTT attribute key</dfn> consisting of <code>[A-Za-z_][0-9A_Za-z_]*</code>:
-      <ul>
+     <li>A <dfn>WebVTT attribute key</dfn> consisting of: (<code>[A-Za-z_][0-9A_Za-z_]*</code>)
+      <ol>
        <li>Any one of the following:
         <ul>
-         <li>U+0041 LATIN CAPITAL LETTER A through U+005A LATIN CAPITAL LETTER Z</li>
-         <li>U+0061 LATIN CAPITAL SMALL A through U+007A LATIN SMALL LETTER A</li>
-         <li>U+005F LOW LINE _ ("underscore")</li>
+         <li>Any <a href="https://infra.spec.whatwg.org/#ascii-alpha">ASCII Alpha</a> character</li>
+         <li>U+005F LOW LINE ("_" underscore)</li>
         </ul>
        </li>
        <li>Optionally followed by zero or more of the following:
         <ul>
-         <li>U+0030 DIGIT ZERO ("0") through U+0039 DIGIT NINE ("9")</li>
-         <li>U+0041 LATIN CAPITAL LETTER A through U+005A LATIN CAPITAL LETTER Z</li>
-         <li>U+0061 LATIN CAPITAL SMALL A through U+007A LATIN SMALL LETTER A</li>
+         <li>Any <a href="https://infra.spec.whatwg.org/#ascii-alphanumeric">ASCII Alphanumeric</a> character</li>
          <li>U+005F LOW LINE ("_" underscore)</li>
         </ul>
        </li>
-       <li class="ednote">Editorial Note: Should this `key` token range be an external reference to the character range for HTML TagName or ECMAScript variables? If so, which reference?</li>
-      </ul>
+      </ol>
      </li>
      <li>A single U+003A COLON character ("<code>:</code>").</li>
      <li>Zero or one U+0020 SPACE or U+0009 CHARACTER TABULATION (tab) characters.</li>
@@ -4319,9 +4315,10 @@ follows:</p>
 <ol algorithm="WebVTT type attribute attribute parsing">
  <li>TODO: This could reference a new TBD W3C Note or Evergreen list of acknowledged kind subtypes, along with a reference to the specification for each, which clarify the usage or define further parsing rules of each type. For example:
   <ul>
-   <li>metadata subtype: time-coded video poster thumbnails (common de facto use for scrubbing but no spec)</li>
+   <li>metadata subtype: time-coded video poster thumbnails (<a href="https://github.com/w3c/webvtt/issues/511#issuecomment-1487497644">common de facto use for preview scrubbing</a> but no spec exists)</li>
    <li>metadata subtype: <a href="https://github.com/w3c/webvtt/issues/512">WebVTT Issue 512: time-coded flash metadata</a></li>
-   <li>caption or description subtype: text equivalent of audio description audio track (used for braille displays)</li>
+   <li>metadata subtype: <a href="https://github.com/w3ctag/design-reviews/issues/952">video chapter times, thumbnails, and titles</a>
+   <li>caption or description subtype: text equivalent of audio description dialogue audio track (<a href="https://www.w3.org/2022/09/14-audio-descriptions-minutes.html">VTT descriptions rendered on braille displays</a> used by blind and deafblind individuals)</li>
    <li>etc.</li>
   </ul>
  </li>

--- a/index.bs
+++ b/index.bs
@@ -1585,7 +1585,7 @@ with the <a>MIME type</a> <code>text/vtt</code>. [[!RFC3629]]</p>
  <li>Two or more <a lt="WebVTT line terminator">WebVTT line terminators</a> to terminate the line
  with the file magic and separate it from the rest of the body.</li>
 
- <li>Zero or one <a lt="WebVTT attributes object">WebVTT attributes object</a> followed by one or 
+ <li>Zero or one <a lt="WebVTT attributes block">WebVTT attributes block</a> followed by one or 
  more <a lt="WebVTT line terminator">WebVTT line terminators</a>.</li>
 
  <li>Zero or more <a lt="WebVTT region definition block">WebVTT region definition blocks</a>, <a
@@ -1764,7 +1764,7 @@ SIGN).</p>
 
 <p>When interpreted as a number, a <a>WebVTT percentage</a> must be in the range 0..100.</p>
 
-<p>A <dfn>WebVTT attributes object</dfn> consists of the following components, in the given order:</p>
+<p>A <dfn>WebVTT attributes block</dfn> consists of the following components, in the given order:</p>
 <ol>
  <li>The string "<code>ATTRIBUTES</code>".</li>
  <li>
@@ -1773,17 +1773,38 @@ SIGN).</p>
    <li>A <a>WebVTT line terminator</a>.</li>
    <li>Zero or more key/value pairs, parsed in the given order:
     <ol>
-     <li>A <dfn>WebVTT attribute key</dfn> consisting of (TODO: ref HTML tagname or ECMAScript variable char ranges? or identifier regex <code>[a-zA-Z_][0-9a-zA-Z_]*</code>).</li>
+     <li>A <dfn>WebVTT attribute key</dfn> consisting of <code>[A-Za-z_][0-9A_Za-z_]*</code>:
+      <ul>
+       <li>Any one of the following:
+        <ul>
+         <li>U+0041 LATIN CAPITAL LETTER A through U+005A LATIN CAPITAL LETTER Z</li>
+         <li>U+0061 LATIN CAPITAL SMALL A through U+007A LATIN SMALL LETTER A</li>
+         <li>U+005F LOW LINE _ ("underscore")</li>
+        </ul>
+       </li>
+       <li>Optionally followed by zero or more of the following:
+        <ul>
+         <li>U+0030 DIGIT ZERO ("0") through U+0039 DIGIT NINE ("9")</li>
+         <li>U+0041 LATIN CAPITAL LETTER A through U+005A LATIN CAPITAL LETTER Z</li>
+         <li>U+0061 LATIN CAPITAL SMALL A through U+007A LATIN SMALL LETTER A</li>
+         <li>U+005F LOW LINE ("_" underscore)</li>
+        </ul>
+       </li>
+       <li class="ednote">Editorial Note: Should this `key` token range be an external reference to the character range for HTML TagName or ECMAScript variables? If so, which reference?</li>
+      </ul>
+     </li>
      <li>A single U+003A COLON character ("<code>:</code>").</li>
      <li>Zero or one U+0020 SPACE or U+0009 CHARACTER TABULATION (tab) characters.</li>
      <li>A <dfn>WebVTT attribute value</dfn> consisting of any sequence of zero or more characters other than unescaped U+000A LINE FEED (LF) characters and unescaped U+000D CARRIAGE RETURN (CR) characters, except that the entire resulting string must not contain the substring "<code>--></code>" (U+002D HYPHEN-MINUS, U+002D HYPHEN-MINUS, U+003E GREATER-THAN SIGN).</li>
      <li>A <a>WebVTT line terminator</a>.</li>
     </ol>
    </li>
-   <li>A final <a>WebVTT line terminator</a> to complete the WebVTT attributes object.</li>
+   <li>A final <a>WebVTT line terminator</a> to complete the WebVTT attributes block.</li>
   </ol>
  </li>
 </ol>
+
+<p>Process the <a>WebVTT attributes block</a> key/value pairs according to the <a>WebVTT attributes key/value parsing rules</a>.</p>
 
 
 <p>A <dfn>WebVTT comment block</dfn> consists of the following components, in the given order:</p>
@@ -4263,6 +4284,47 @@ follows:</p>
  pre-order, depth-first traversal, excluding <a lt="WebVTT Ruby Text Object">WebVTT Ruby Text
  Objects</a> and their descendants.</p></li>
 
+</ol>
+
+
+<p>The <dfn>WebVTT attributes key/value parsing rules</dfn> consist of the following algorithm.</p>
+
+<ol algorithm="WebVTT attributes block parsing">
+ <li>Let |input| be the list of key/value pairs from a <a>WebVTT attributes block</a>.</li>
+ <li>
+  How the attribute is processed depends on its key name, as follows:
+  <dl>
+
+   <dt>If the key name is "<code>kind</code>"</dt>
+   <dd>Process the value as <a href="https://html.spec.whatwg.org/multipage/media.html#attr-track-kind">the kind attribute</a> of a track element according to the HTML Standard.</dd>
+
+   <dt>If the key name is "<code>srclang</code>"</dt>
+   <dd>Process the value as <a href="https://html.spec.whatwg.org/multipage/media.html#attr-track-srclang">the srclang attribute</a> of a track element according to the HTML Standard.</dd>
+
+   <dt>If the key name is "<code>label</code>"</dt>
+   <dd>Process the value as <a href="https://html.spec.whatwg.org/multipage/media.html#attr-track-label">the label attribute</a> of a track element according to the HTML Standard.</dd>
+
+   <dt>If the key name is "<code>type</code>" (TODO: For clarity, should this be "subkind" or "kind_subtype" instead?)</dt>
+   <dd>Process the value according to the <a>WebVTT type attribute parsing rules</a>.
+
+   <dt>Otherwise</dt>
+   <dd>Ignore the key/value pair.</dd>
+
+  </dl>
+ </li>
+</ol>
+
+<p>The <dfn>WebVTT type attribute parsing rules</dfn> consist of the following algorithm.</p>
+
+<ol algorithm="WebVTT type attribute attribute parsing">
+ <li>TODO: This could reference a new TBD W3C Note or Evergreen list of acknowledged kind subtypes, along with a reference to the specification for each, which clarify the usage or define further parsing rules of each type. For example:
+  <ul>
+   <li>metadata subtype: time-coded video poster thumbnails (common de facto use for scrubbing but no spec)</li>
+   <li>metadata subtype: <a href="https://github.com/w3c/webvtt/issues/512">WebVTT Issue 512: time-coded flash metadata</a></li>
+   <li>caption or description subtype: text equivalent of audio description audio track (used for braille displays)</li>
+   <li>etc.</li>
+  </ul>
+ </li>
 </ol>
 
 

--- a/index.bs
+++ b/index.bs
@@ -797,7 +797,11 @@ WEBVTT
 
 ATTRIBUTES
 kind: metadata
-type: video-thumbnails
+
+NOTE
+The Timed Text Working Group is discussing a registry for metadata `type` 
+values, such as `video-thumbnails` or `video-flash-avoidance`. 
+See webvtt issues #511 and #512 for more info.
 
 00:00:01.959 --> 00:00:02.938
 {

--- a/index.bs
+++ b/index.bs
@@ -4300,33 +4300,12 @@ follows:</p>
    <dt>If the key name is "<code>label</code>"</dt>
    <dd>Process the value as <a href="https://html.spec.whatwg.org/multipage/media.html#attr-track-label">the label attribute</a> of a track element according to the HTML Standard.</dd>
 
-<!-- See https://github.com/w3c/webvtt/issues/525
-   <dt>If the key name is "<code>type</code>" (TODO: For clarity, should this be "subkind" or "kind_subtype" instead?)</dt>
-   <dd>Process the value according to the <a>WebVTT type attribute parsing rules</a>.
--->
-
    <dt>Otherwise</dt>
    <dd>Ignore the key/value pair.</dd>
 
   </dl>
  </li>
 </ol>
-
-<!-- See https://github.com/w3c/webvtt/issues/525
-<p>The <dfn>WebVTT type attribute parsing rules</dfn> consist of the following algorithm.</p>
-
-<ol algorithm="WebVTT type attribute attribute parsing">
- <li>TODO: This could reference a new TBD W3C Note or Evergreen list of acknowledged kind subtypes, along with a reference to the specification for each, which clarify the usage or define further parsing rules of each type. For example:
-  <ul>
-   <li>metadata subtype: time-coded video poster thumbnails (<a href="https://github.com/w3c/webvtt/issues/511#issuecomment-1487497644">common de facto use for preview scrubbing</a> but no spec exists)</li>
-   <li>metadata subtype: <a href="https://github.com/w3c/webvtt/issues/512">WebVTT Issue 512: time-coded flash metadata</a></li>
-   <li>metadata subtype: <a href="https://github.com/w3ctag/design-reviews/issues/952">video chapter times, thumbnails, and titles</a>
-   <li>caption or description subtype: text equivalent of audio description dialogue audio track (<a href="https://www.w3.org/2022/09/14-audio-descriptions-minutes.html">VTT descriptions rendered on braille displays</a> used by blind and deafblind individuals)</li>
-   <li>etc.</li>
-  </ul>
- </li>
-</ol>
--->
 
 <h2 id=rendering>Rendering</h2>
 

--- a/index.bs
+++ b/index.bs
@@ -800,7 +800,7 @@ kind: metadata
 
 NOTE
 The Timed Text Working Group is discussing a registry for metadata `type` 
-values, such as `video-thumbnails` or `video-flash-avoidance`. 
+values, such as `type: video-thumbnails` or `type: video-flash-avoidance`. 
 See webvtt issues #511 and #512 for more info.
 
 00:00:01.959 --> 00:00:02.938
@@ -1773,7 +1773,7 @@ SIGN).</p>
    <li>A <a>WebVTT line terminator</a>.</li>
    <li>Zero or more key/value pairs, parsed in the given order:
     <ol>
-     <li>A <dfn>WebVTT attribute key</dfn> consisting of any sequence of one or more (TODO: ref HTML tagname char or ECMAScript variable char ranges) characters.</li>
+     <li>A <dfn>WebVTT attribute key</dfn> consisting of (TODO: ref HTML tagname or ECMAScript variable char ranges? or identifier regex <code>[a-zA-Z_][0-9a-zA-Z_]*</code>).</li>
      <li>A single U+003A COLON character ("<code>:</code>").</li>
      <li>Zero or one U+0020 SPACE or U+0009 CHARACTER TABULATION (tab) characters.</li>
      <li>A <dfn>WebVTT attribute value</dfn> consisting of any sequence of zero or more characters other than unescaped U+000A LINE FEED (LF) characters and unescaped U+000D CARRIAGE RETURN (CR) characters, except that the entire resulting string must not contain the substring "<code>--></code>" (U+002D HYPHEN-MINUS, U+002D HYPHEN-MINUS, U+003E GREATER-THAN SIGN).</li>

--- a/index.bs
+++ b/index.bs
@@ -718,7 +718,7 @@ this case, "music".
 
 <div class="example">
 
- <p>In this example, a WebVTT attributes object is used to indicate the text track cues represent video descriptions for the blind. Unlike subtitles or captions, these are not intended to be rendered visually.</p>
+ <p>In this example, a WebVTT attributes object is used to indicate the text track cues represent descriptions for the blind. Unlike subtitles or captions, these are not intended to be rendered visually.</p>
  <pre>
 WEBVTT
 

--- a/index.bs
+++ b/index.bs
@@ -1766,10 +1766,10 @@ SIGN).</p>
    <li>A <a>WebVTT line terminator</a>.</li>
    <li>Zero or more key/value pairs, parsed in the given order:
     <ol>
-     <li>A <dfn>WebVTT attribute key</dfn> consisting of any sequence of one or more (TODO: /A-Za-z/?) characters.</li>
+     <li>A <dfn>WebVTT attribute key</dfn> consisting of any sequence of one or more (TODO: ref HTML tagname char or ECMAScript variable char ranges) characters.</li>
      <li>A single U+003A COLON character ("<code>:</code>").</li>
      <li>Zero or one U+0020 SPACE or U+0009 CHARACTER TABULATION (tab) characters.</li>
-     <li>A <dfn>WebVTT attribute value</dfn> consisting of any sequence of zero or more characters other than U+000A LINE FEED (LF) characters and U+000D CARRIAGE RETURN (CR) characters, except that the entire resulting string must not contain the substring "<code>--></code>" (U+002D HYPHEN-MINUS, U+002D HYPHEN-MINUS, U+003E GREATER-THAN SIGN).</li>
+     <li>A <dfn>WebVTT attribute value</dfn> consisting of any sequence of zero or more characters other than unescaped U+000A LINE FEED (LF) characters and unescaped U+000D CARRIAGE RETURN (CR) characters, except that the entire resulting string must not contain the substring "<code>--></code>" (U+002D HYPHEN-MINUS, U+002D HYPHEN-MINUS, U+003E GREATER-THAN SIGN).</li>
      <li>A <a>WebVTT line terminator</a>.</li>
     </ol>
    </li>

--- a/index.bs
+++ b/index.bs
@@ -4300,8 +4300,10 @@ follows:</p>
    <dt>If the key name is "<code>label</code>"</dt>
    <dd>Process the value as <a href="https://html.spec.whatwg.org/multipage/media.html#attr-track-label">the label attribute</a> of a track element according to the HTML Standard.</dd>
 
+<!-- See https://github.com/w3c/webvtt/issues/525
    <dt>If the key name is "<code>type</code>" (TODO: For clarity, should this be "subkind" or "kind_subtype" instead?)</dt>
    <dd>Process the value according to the <a>WebVTT type attribute parsing rules</a>.
+-->
 
    <dt>Otherwise</dt>
    <dd>Ignore the key/value pair.</dd>
@@ -4310,6 +4312,7 @@ follows:</p>
  </li>
 </ol>
 
+<!-- See https://github.com/w3c/webvtt/issues/525
 <p>The <dfn>WebVTT type attribute parsing rules</dfn> consist of the following algorithm.</p>
 
 <ol algorithm="WebVTT type attribute attribute parsing">
@@ -4323,7 +4326,7 @@ follows:</p>
   </ul>
  </li>
 </ol>
-
+-->
 
 <h2 id=rendering>Rendering</h2>
 

--- a/index.bs
+++ b/index.bs
@@ -1581,6 +1581,9 @@ with the <a>MIME type</a> <code>text/vtt</code>. [[!RFC3629]]</p>
  <li>Two or more <a lt="WebVTT line terminator">WebVTT line terminators</a> to terminate the line
  with the file magic and separate it from the rest of the body.</li>
 
+ <li>Zero or one <a lt="WebVTT attributes object">WebVTT attributes object</a> followed by one or 
+ more <a lt="WebVTT line terminator">WebVTT line terminators</a>.</li>
+
  <li>Zero or more <a lt="WebVTT region definition block">WebVTT region definition blocks</a>, <a
  lt="WebVTT style block">WebVTT style blocks</a> and <a lt="WebVTT comment block">WebVTT comment
  blocks</a> separated from each other by one or more <a lt="WebVTT line terminator">WebVTT line

--- a/index.bs
+++ b/index.bs
@@ -4299,13 +4299,13 @@ follows:</p>
   How the attribute is processed depends on its key name, as follows:
   <dl>
 
-   <dt>If the key name is "<code>kind</code>" (<a href="ascii-case-insensitive">ASCII case-insensitive</a>)</dt>
+   <dt>If the key name is "<code>kind</code>" (<a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">ASCII case-insensitive</a>)</dt>
    <dd>Process the value as <a href="https://html.spec.whatwg.org/multipage/media.html#attr-track-kind">the kind attribute</a> of a track element according to the HTML Standard.</dd>
 
-   <dt>If the key name is "<code>lang</code>" (<a href="ascii-case-insensitive">ASCII case-insensitive</a>)</dt>
+   <dt>If the key name is "<code>lang</code>" (<a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">ASCII case-insensitive</a>)</dt>
    <dd>Process the value as <a href="https://html.spec.whatwg.org/multipage/media.html#attr-track-srclang">the srclang attribute</a> of a track element according to the HTML Standard.</dd>
 
-   <dt>If the key name is "<code>label</code>" (<a href="ascii-case-insensitive">ASCII case-insensitive</a>)</dt>
+   <dt>If the key name is "<code>label</code>" (<a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">ASCII case-insensitive</a>)</dt>
    <dd>Process the value as <a href="https://html.spec.whatwg.org/multipage/media.html#attr-track-label">the label attribute</a> of a track element according to the HTML Standard.</dd>
 
    <dt>Otherwise</dt>

--- a/index.bs
+++ b/index.bs
@@ -650,8 +650,6 @@ A young girl tiptoes down a dark hallway.
 
 </div>
 
-
-
 <h3 id=introduction-comments>Comments in WebVTT</h3>
 
 <p><i>This section is non-normative.</i></p>

--- a/index.bs
+++ b/index.bs
@@ -455,7 +455,6 @@ A young girl tiptoes down a dark hallway.
 
 <p>WebVTT also supports some less-often used features.</p>
 
-
 <div class="example">
 
  <p>In this example, the cues have an identifier:</p>

--- a/index.bs
+++ b/index.bs
@@ -362,11 +362,99 @@ CSS comment (e.g. <code>/**/</code>).</p>
 
 </div>
 
+<h3 id=introduction-attributes-block>Attributes Block</h3>
+
+<p><i>This section is non-normative.</i></p>
+
+<p>WebVTT supports an Attributes block to provide additional information about the rendered text track, and to allow disambiguation of metadata tracks.</p>
+
+
+
+
+<div class="example">
+
+ <p>In this example, an optional WebVTT attributes object is used to define the source language and its label in a subtitle/caption selection menu.</p>
+ <pre>
+WEBVTT
+
+ATTRIBUTES
+kind: subtitles
+lang: es-mx
+label: Español
+
+NOTE
+Standard subtitles (unlike CC or SDH captions) typically 
+translate spoken dialog or signage, but not audible sound 
+effects like "dogs barking."
+
+1
+00:00:10.123 --> 00:00:15.432
+¡Hola! ¿Qué tál?
+ </pre>
+
+</div>
+
+
+<div class="example">
+
+ <p>In this example, an optional WebVTT attributes object is used to differentiate captions from standard subtitles.</p>
+ <pre>
+WEBVTT
+
+ATTRIBUTES
+kind: captions
+lang: es-mx
+label: Español (SDH)
+
+NOTE
+Captions (SDH aka Subtitles for the Deaf and Hard-of-Hearing) 
+typically include spoken dialog as well as important audible 
+sounds such as "floor boards creak", "dogs barking", or in 
+this case, "music".
+
+1
+00:00:10.123 --> 00:00:15.432
+¡Hola! ¿Qué tál?
+
+2
+00:00:47.462 --> 00:01:04.028
+[♫ música ♫]
+ </pre>
+
+</div>
+
+
+<div class="example">
+
+ <p>In this example, a WebVTT attributes object is used to indicate the text track cues represent audible or braille descriptions for the blind. Unlike subtitles or captions, these are not intended to be rendered visually.</p>
+ <pre>
+WEBVTT
+
+ATTRIBUTES
+kind: descriptions
+lang: en-us
+label: English (AD)
+
+NOTE
+VTT-based descriptions are meant to render as text-to-speech audio or braille,
+for blind or deafblind audiences, not usually as visual captions on screen. 
+As such, the option/label might be displayed in an audio menu or elsewhere. 
+
+1
+00:00:10.123 --> 00:00:15.432
+A young girl tiptoes down a dark hallway.
+ </pre>
+
+</div>
+
+
+
 <h3 id=introduction-other-features>Other caption and subtitling features</h3>
 
 <p><i>This section is non-normative.</i></p>
 
 <p>WebVTT also supports some less-often used features.</p>
+
 
 <div class="example">
 
@@ -565,60 +653,6 @@ CSS comment (e.g. <code>/**/</code>).</p>
 
 
 
-<div class="example">
-
- <p>In this example, an optional WebVTT attributes object is used to define the source language and its label in a subtitle/caption selection menu.</p>
- <pre>
-WEBVTT
-
-ATTRIBUTES
-kind: subtitles
-lang: es-mx
-label: Español
-
-NOTE
-Standard subtitles (unlike CC or SDH captions) typically 
-translate spoken dialog or signage, but not audible sound 
-effects like "dogs barking."
-
-1
-00:00:10.123 --> 00:00:15.432
-¡Hola! ¿Qué tál?
- </pre>
-
-</div>
-
-
-<div class="example">
-
- <p>In this example, an optional WebVTT attributes object is used to differentiate captions from standard subtitles.</p>
- <pre>
-WEBVTT
-
-ATTRIBUTES
-kind: captions
-lang: es-mx
-label: Español (SDH)
-
-NOTE
-Captions (SDH aka Subtitles for the Deaf and Hard-of-Hearing) 
-typically include spoken dialog as well as important audible 
-sounds such as "floor boards creak", "dogs barking", or in 
-this case, "music".
-
-1
-00:00:10.123 --> 00:00:15.432
-¡Hola! ¿Qué tál?
-
-2
-00:00:47.462 --> 00:01:04.028
-[♫ música ♫]
- </pre>
-
-</div>
-
-
-
 <h3 id=introduction-comments>Comments in WebVTT</h3>
 
 <p><i>This section is non-normative.</i></p>
@@ -715,31 +749,6 @@ this case, "music".
 </div>
 
 
-
-<div class="example">
-
- <p>In this example, a WebVTT attributes object is used to indicate the text track cues represent audible or braille descriptions for the blind. Unlike subtitles or captions, these are not intended to be rendered visually.</p>
- <pre>
-WEBVTT
-
-ATTRIBUTES
-kind: descriptions
-lang: en-us
-label: English (AD)
-
-NOTE
-VTT-based descriptions are meant to render as text-to-speech audio or braille,
-for blind or deafblind audiences, not usually as visual captions on screen. 
-As such, the option/label might be displayed in an audio menu or elsewhere. 
-
-1
-00:00:10.123 --> 00:00:15.432
-A young girl tiptoes down a dark hallway.
- </pre>
-
-</div>
-
-
 <h3 id=introduction-metadata>Metadata example</h3>
 
 <p><i>This section is non-normative.</i></p>
@@ -807,13 +816,11 @@ kind: metadata
  }
 }
  </pre>
+</div>
  
- <p class="note">The Timed Text Working Group is discussing a registry for metadata <code>type</code> 
+<p class="note">The Timed Text Working Group is discussing a registry for metadata <code>type</code> 
 values, such as <code>type: video-thumbnails</code> or <code>type: video-flash-avoidance</code>. 
 See WebVTT issues <a href="https://github.com/w3c/webvtt/issues/511">#511</a> and <a href="https://github.com/w3c/webvtt/issues/512">#512</a> for more info.</p>
-
-
-</div>
 
 
 <h2 id=conformance>Conformance</h2>
@@ -1800,7 +1807,7 @@ SIGN).</p>
  </li>
 </ol>
 
-<p>Process the <a>WebVTT attributes block</a> key/value pairs according to the <a>WebVTT attributes key/value parsing rules</a>.</p>
+<p>Process the <a>WebVTT attributes block</a> key/value pairs according to the <a>WebVTT rules for parsing attribute key/value pairs</a>.</p>
 
 
 <p>A <dfn>WebVTT comment block</dfn> consists of the following components, in the given order:</p>
@@ -4283,8 +4290,8 @@ follows:</p>
 </ol>
 
 
-<h3 id="rules-for-parsing-attr-key-values-algorithm">WebVTT Attributes key/value Parsing Rules</h3>
-<p>The <dfn>WebVTT attributes key/value parsing rules</dfn> consist of the following algorithm.</p>
+<h3 id=rules-for-parsing-attr-key-values algorithm>WebVTT rules for parsing attribute key/value pairs</h3>
+<p>The <dfn>WebVTT rules for parsing attribute key/value pairs</dfn> consist of the following algorithm.</p>
 
 <ol algorithm="WebVTT attributes block parsing">
  <li>Let |input| be the list of key/value pairs from a <a>WebVTT attributes block</a>.</li>

--- a/index.bs
+++ b/index.bs
@@ -1774,40 +1774,40 @@ SIGN).</p>
 <p>A <dfn>WebVTT attributes block</dfn> consists of the following components, in the given order:</p>
 <ol>
  <li>The string "<code>ATTRIBUTES</code>".</li>
- <li>
-  The following components, in the given order:
+ <li>Zero or more U+0020 SPACE or U+0009 CHARACTER TABULATION (tab) characters.</li>
+ <li>A <a>WebVTT line terminator</a>.</li>
+ <li>A <a>WebVTT attributes body block</a>.</li>
+ <li>A <a>WebVTT line terminator</a>.</li>
+</ol>
+
+<p>A <dfn>WebVTT attributes body block</dfn> consists of the following components, in the given order:</p>
+<ol>
+ <li>Zero or more key/value pairs, parsed in the given order:
   <ol>
-   <li>A <a>WebVTT line terminator</a>.</li>
-   <li>Zero or more key/value pairs, parsed in the given order:
+   <li>A <dfn>WebVTT attribute key</dfn> consisting of: (<code>[A-Za-z_][0-9A_Za-z_]*</code>)
     <ol>
-     <li>A <dfn>WebVTT attribute key</dfn> consisting of: (<code>[A-Za-z_][0-9A_Za-z_]*</code>)
-      <ol>
-       <li>Any one of the following:
-        <ul>
-         <li>Any <a href="https://infra.spec.whatwg.org/#ascii-alpha">ASCII Alpha</a> character</li>
-         <li>U+005F LOW LINE ("_" underscore)</li>
-        </ul>
-       </li>
-       <li>Optionally followed by zero or more of the following:
-        <ul>
-         <li>Any <a href="https://infra.spec.whatwg.org/#ascii-alphanumeric">ASCII Alphanumeric</a> character</li>
-         <li>U+005F LOW LINE ("_" underscore)</li>
-        </ul>
-       </li>
-      </ol>
+     <li>Any one of the following:
+      <ul>
+       <li>Any <a href="https://infra.spec.whatwg.org/#ascii-alpha">ASCII Alpha</a> character</li>
+       <li>U+005F LOW LINE ("_" underscore)</li>
+      </ul>
      </li>
-     <li>A single U+003A COLON character ("<code>:</code>").</li>
-     <li>Zero or one U+0020 SPACE or U+0009 CHARACTER TABULATION (tab) characters.</li>
-     <li>A <dfn>WebVTT attribute value</dfn> consisting of any sequence of zero or more characters other than unescaped U+000A LINE FEED (LF) characters and unescaped U+000D CARRIAGE RETURN (CR) characters, except that the entire resulting string must not contain the substring "<code>--></code>" (U+002D HYPHEN-MINUS, U+002D HYPHEN-MINUS, U+003E GREATER-THAN SIGN).</li>
-     <li>A <a>WebVTT line terminator</a>.</li>
+     <li>Optionally followed by zero or more of the following:
+      <ul>
+       <li>Any <a href="https://infra.spec.whatwg.org/#ascii-alphanumeric">ASCII Alphanumeric</a> character</li>
+       <li>U+005F LOW LINE ("_" underscore)</li>
+      </ul>
+     </li>
     </ol>
    </li>
-   <li>A final <a>WebVTT line terminator</a> to complete the WebVTT attributes block.</li>
+   <li>A single U+003A COLON character ("<code>:</code>").</li>
+   <li>Zero or one U+0020 SPACE or U+0009 CHARACTER TABULATION (tab) characters.</li>
+   <li>A <dfn>WebVTT attribute value</dfn> consisting of any sequence of zero or more characters other than unescaped U+000A LINE FEED (LF) characters and unescaped U+000D CARRIAGE RETURN (CR) characters, except that the entire resulting string must not contain the substring "<code>--></code>" (U+002D HYPHEN-MINUS, U+002D HYPHEN-MINUS, U+003E GREATER-THAN SIGN).</li>
+   <li>A <a>WebVTT line terminator</a>.</li>
   </ol>
  </li>
 </ol>
-
-<p>Process the <a>WebVTT attributes block</a> key/value pairs according to the <a>WebVTT rules for parsing attribute key/value pairs</a>.</p>
+<p>Process the <a>WebVTT attributes body block</a> key/value pairs according to the <a>WebVTT rules for parsing attribute key/value pairs</a>.</p>
 
 
 <p>A <dfn>WebVTT comment block</dfn> consists of the following components, in the given order:</p>

--- a/index.bs
+++ b/index.bs
@@ -4299,13 +4299,13 @@ follows:</p>
   How the attribute is processed depends on its key name, as follows:
   <dl>
 
-   <dt>If the key name is "<code>kind</code>" (case-insensitive)</dt>
+   <dt>If the key name is "<code>kind</code>" (<a href="ascii-case-insensitive">ASCII case-insensitive</a>)</dt>
    <dd>Process the value as <a href="https://html.spec.whatwg.org/multipage/media.html#attr-track-kind">the kind attribute</a> of a track element according to the HTML Standard.</dd>
 
-   <dt>If the key name is "<code>lang</code>" (case-insensitive)</dt>
+   <dt>If the key name is "<code>lang</code>" (<a href="ascii-case-insensitive">ASCII case-insensitive</a>)</dt>
    <dd>Process the value as <a href="https://html.spec.whatwg.org/multipage/media.html#attr-track-srclang">the srclang attribute</a> of a track element according to the HTML Standard.</dd>
 
-   <dt>If the key name is "<code>label</code>" (case-insensitive)</dt>
+   <dt>If the key name is "<code>label</code>" (<a href="ascii-case-insensitive">ASCII case-insensitive</a>)</dt>
    <dd>Process the value as <a href="https://html.spec.whatwg.org/multipage/media.html#attr-track-label">the label attribute</a> of a track element according to the HTML Standard.</dd>
 
    <dt>Otherwise</dt>
@@ -4314,6 +4314,9 @@ follows:</p>
   </dl>
  </li>
 </ol>
+
+<p class="note">These keys are case-insensitive to allow compatibility with large video distributors <!-- namely YouTube --> already using this pattern in production.</p>
+
 
 <h2 id=rendering>Rendering</h2>
 

--- a/index.bs
+++ b/index.bs
@@ -1802,7 +1802,15 @@ SIGN).</p>
    </li>
    <li>A single U+003A COLON character ("<code>:</code>").</li>
    <li>Zero or one U+0020 SPACE or U+0009 CHARACTER TABULATION (tab) characters.</li>
-   <li>A <dfn>WebVTT attribute value</dfn> consisting of any sequence of zero or more characters other than unescaped U+000A LINE FEED (LF) characters and unescaped U+000D CARRIAGE RETURN (CR) characters, except that the entire resulting string must not contain the substring "<code>--></code>" (U+002D HYPHEN-MINUS, U+002D HYPHEN-MINUS, U+003E GREATER-THAN SIGN).</li>
+   <li>
+    A <dfn>WebVTT attribute value</dfn> consisting of any sequence of zero or more characters other than the following:
+    <ul>
+     <li>unescaped LINE FEED (LF) characters (U+000A),</li>
+     <li>unescaped CARRIAGE RETURN (CR) characters (U+000D),</li>
+     <li>unescaped bi-directional formatting characters (U+202B, U+202C, U+202D, U+202E, U+2066, U++2067, U++2068, U+2069, U+200E, U+200F, U+061C), or</li>
+     <li>the substring "<code>--></code>" (U+002D HYPHEN-MINUS, U+002D HYPHEN-MINUS, U+003E GREATER-THAN SIGN).</li>
+    </ul>
+   </li>
    <li>A <a>WebVTT line terminator</a>.</li>
   </ol>
  </li>

--- a/index.bs
+++ b/index.bs
@@ -745,7 +745,6 @@ A young girl tiptoes down a dark hallway.
 
 </div>
 
-
 <h3 id=introduction-metadata>Metadata example</h3>
 
 <p><i>This section is non-normative.</i></p>

--- a/index.bs
+++ b/index.bs
@@ -4283,6 +4283,7 @@ follows:</p>
 </ol>
 
 
+<h3 id="rules-for-parsing-attr-key-values-algorithm">WebVTT Attributes key/value Parsing Rules</h3>
 <p>The <dfn>WebVTT attributes key/value parsing rules</dfn> consist of the following algorithm.</p>
 
 <ol algorithm="WebVTT attributes block parsing">
@@ -4291,13 +4292,13 @@ follows:</p>
   How the attribute is processed depends on its key name, as follows:
   <dl>
 
-   <dt>If the key name is "<code>kind</code>"</dt>
+   <dt>If the key name is "<code>kind</code>" (case-insensitive)</dt>
    <dd>Process the value as <a href="https://html.spec.whatwg.org/multipage/media.html#attr-track-kind">the kind attribute</a> of a track element according to the HTML Standard.</dd>
 
-   <dt>If the key name is "<code>lang</code>"</dt>
+   <dt>If the key name is "<code>lang</code>" (case-insensitive)</dt>
    <dd>Process the value as <a href="https://html.spec.whatwg.org/multipage/media.html#attr-track-srclang">the srclang attribute</a> of a track element according to the HTML Standard.</dd>
 
-   <dt>If the key name is "<code>label</code>"</dt>
+   <dt>If the key name is "<code>label</code>" (case-insensitive)</dt>
    <dd>Process the value as <a href="https://html.spec.whatwg.org/multipage/media.html#attr-track-label">the label attribute</a> of a track element according to the HTML Standard.</dd>
 
    <dt>Otherwise</dt>

--- a/index.bs
+++ b/index.bs
@@ -370,31 +370,6 @@ CSS comment (e.g. <code>/**/</code>).</p>
 
 
 
-
-<div class="example">
-
- <p>In this example, an optional WebVTT attributes object is used to define the source language and its label in a subtitle/caption selection menu.</p>
- <pre>
-WEBVTT
-
-ATTRIBUTES
-kind: subtitles
-lang: es-mx
-label: Español
-
-NOTE
-Standard subtitles (unlike CC or SDH captions) typically 
-translate spoken dialog or signage, but not audible sound 
-effects like "dogs barking."
-
-1
-00:00:10.123 --> 00:00:15.432
-¡Hola! ¿Qué tál?
- </pre>
-
-</div>
-
-
 <div class="example">
 
  <p>In this example, an optional WebVTT attributes object is used to differentiate captions from standard subtitles.</p>

--- a/index.bs
+++ b/index.bs
@@ -1550,6 +1550,70 @@ together, which is particularly important when scrolling up.</p>
  </dd>
 </dl>
 
+<h3 id=attributes-object>WebVTT attributes object</h3>
+
+<p>A <dfn>WebVTT attributes object</dfn> represents the optional file-level metadata declared in a
+<a>WebVTT attributes block</a>. It consists of:</p>
+
+<dl>
+
+ <dt><dfn lt="WebVTT attributes object kind">A kind</dfn></dt>
+ <dd>
+  <p>A string giving the text track kind. If present, must be one of "<code>subtitles</code>",
+  "<code>captions</code>", "<code>descriptions</code>", "<code>chapters</code>", or
+  "<code>metadata</code>". Defaults to the empty string.</p>
+  <p class="note">The <code>kind</code> key is the only required key. Consumers that do not
+  recognise the <code>kind</code> value should treat the entire <a>WebVTT attributes object</a>
+  as opaque.</p>
+ </dd>
+
+ <dt><dfn lt="WebVTT attributes object type">A type</dfn></dt>
+ <dd>
+  <p>A string further differentiating the subtype within a <code>kind</code> (for example,
+  distinguishing varieties of <code>metadata</code> tracks). If present, must be either
+  "<code>custom</code>" or a string beginning with "<code>custom-</code>". All other values
+  are reserved for future standardization. Defaults to the empty string.</p>
+  <p class="note">The <code>type</code> key disambiguates the track kind subtype to resolve
+  naming conflicts for the other common key names often used by different types of metadata.</p>
+  <p class="note">Authors including
+  <a lt="WebVTT attributes object custom pairs">custom pairs</a> should provide a non-empty
+  <code>type</code> value to identify the application or schema those pairs belong to.
+  A <a>WebVTT attributes block</a> with non-empty
+  <a lt="WebVTT attributes object custom pairs">custom pairs</a> and an empty
+  <code>type</code> is valid but parsers may generate a warning.</p>
+ </dd>
+
+ <dt><dfn lt="WebVTT attributes object language">A language</dfn></dt>
+ <dd>
+  <p>A string giving the BCP 47 language tag of the track content. Defaults to the empty
+  string.</p>
+ </dd>
+
+ <dt><dfn lt="WebVTT attributes object label">A label</dfn></dt>
+ <dd>
+  <p>A human-readable string intended for use in a track selection menu. Defaults to the empty
+  string.</p>
+ </dd>
+
+ <dt><dfn lt="WebVTT attributes object custom pairs">Custom pairs</dfn></dt>
+ <dd>
+  <p>An ordered list of key/value string pairs for any unrecognized attribute keys. Defaults to
+  the empty list.</p>
+  <p class="note">Custom pairs should be accompanied by a non-empty
+  <a lt="WebVTT attributes object type">type</a> value so that consumers can identify the
+  schema to which the pairs belong. If custom pairs are present and <code>type</code> is the
+  empty string, parsing continues normally, but parsers may generate a warning.</p>
+ </dd>
+
+</dl>
+
+<p class="note">The <a>WebVTT attributes object</a>'s properties are intended to be used by
+the embedding context (e.g. HTML) to populate the corresponding internal text track concepts.
+How format-provided values interact with values specified in the embedding context (e.g.
+<code>&lt;track&gt;</code> element attributes) is defined by the embedding specification. See
+<a href="https://github.com/whatwg/html/issues/11665">whatwg/html issue #11665</a> for the
+ongoing HTML integration work.</p>
+
 <h3 id=chapter-cues>WebVTT chapter cues</h3>
 
 <p>A <dfn export>WebVTT chapter cue</dfn> is a <a>WebVTT cue</a> whose <a>cue text</a> is interpreted as a
@@ -1769,49 +1833,61 @@ SIGN).</p>
 
 <p>A <dfn>WebVTT attributes block</dfn> consists of the following components, in the given order:</p>
 <ol>
- <li>The string "<code>ATTRIBUTES</code>".</li>
+ <li>The string "<code>ATTRIBUTES</code>" (U+0041, U+0054, U+0054, U+0052, U+0049, U+0042, U+0055,
+ U+0054, U+0045, U+0053).</li>
  <li>Zero or more U+0020 SPACE or U+0009 CHARACTER TABULATION (tab) characters.</li>
  <li>A <a>WebVTT line terminator</a>.</li>
- <li>A <a>WebVTT attributes body block</a>.</li>
- <li>A <a>WebVTT line terminator</a>.</li>
+ <li>Zero or more <a lt="WebVTT attribute key/value pair">WebVTT attribute key/value pairs</a>,
+ each followed by a <a>WebVTT line terminator</a>.</li>
 </ol>
 
-<p>A <dfn>WebVTT attributes body block</dfn> consists of the following components, in the given order:</p>
+<p class="note">The <a>WebVTT attributes block</a> is terminated by a blank line (two consecutive
+<a lt="WebVTT line terminator">WebVTT line terminators</a>), exactly as for
+<a lt="WebVTT region definition block">WebVTT region definition blocks</a>.</p>
+
+<p class="note">The <code>kind</code> key is the only required key in a
+<a>WebVTT attributes block</a>. It must appear in the block to disambiguate the track kind.
+Without it, consumers cannot determine whether other well-known keys such as
+<code>language</code> and <code>label</code> apply to a recognized track kind, and may treat
+them as opaque. See <a href="#rules-for-parsing-attr-key-values">WebVTT rules for parsing
+attribute key/value pairs</a>.</p>
+
+<p>A <dfn>WebVTT attribute key/value pair</dfn> consists of the following components,
+in the given order:</p>
 <ol>
- <li>Zero or more key/value pairs, parsed in the given order:
-  <ol>
-   <li>A <dfn>WebVTT attribute key</dfn> consisting of: (<code>[A-Za-z_][0-9A_Za-z_]*</code>)
-    <ol>
-     <li>Any one of the following:
-      <ul>
-       <li>Any <a href="https://infra.spec.whatwg.org/#ascii-alpha">ASCII Alpha</a> character</li>
-       <li>U+005F LOW LINE ("_" underscore)</li>
-      </ul>
-     </li>
-     <li>Optionally followed by zero or more of the following:
-      <ul>
-       <li>Any <a href="https://infra.spec.whatwg.org/#ascii-alphanumeric">ASCII Alphanumeric</a> character</li>
-       <li>U+005F LOW LINE ("_" underscore)</li>
-      </ul>
-     </li>
-    </ol>
-   </li>
-   <li>A single U+003A COLON character ("<code>:</code>").</li>
-   <li>Zero or one U+0020 SPACE or U+0009 CHARACTER TABULATION (tab) characters.</li>
-   <li>
-    A <dfn>WebVTT attribute value</dfn> consisting of any sequence of zero or more characters other than the following:
-    <ul>
-     <li>unescaped LINE FEED (LF) characters (U+000A),</li>
-     <li>unescaped CARRIAGE RETURN (CR) characters (U+000D),</li>
-     <li>unescaped bi-directional formatting characters (U+202B, U+202C, U+202D, U+202E, U+2066, U++2067, U++2068, U+2069, U+200E, U+200F, U+061C), or</li>
-     <li>the substring "<code>--></code>" (U+002D HYPHEN-MINUS, U+002D HYPHEN-MINUS, U+003E GREATER-THAN SIGN).</li>
-    </ul>
-   </li>
-   <li>A <a>WebVTT line terminator</a>.</li>
-  </ol>
+ <li>A <dfn>WebVTT attribute key</dfn> consisting of one or more
+  <a href="https://infra.spec.whatwg.org/#ascii-alphanumeric">ASCII alphanumeric</a> characters or
+  U+005F LOW LINE (<code>_</code>) characters, where the first character is either an
+  <a href="https://infra.spec.whatwg.org/#ascii-alpha">ASCII alpha</a> character or U+005F LOW
+  LINE (<code>_</code>). In other words, matching the production
+  <code>[A-Za-z_][0-9A-Za-z_]*</code>.</li>
+ <li>A single U+003A COLON character ("<code>:</code>").</li>
+ <li>Zero or one U+0020 SPACE or U+0009 CHARACTER TABULATION (tab) characters.</li>
+ <li>A <dfn>WebVTT attribute value</dfn>, which is any sequence of zero or more Unicode
+  characters, subject to the following constraints:
+  <ul>
+   <li>The characters U+000A LINE FEED (LF) and U+000D CARRIAGE RETURN (CR) must not appear
+    literally; they may be represented using the
+    <a href="https://html.spec.whatwg.org/multipage/syntax.html#character-references">numeric
+    character references</a> <code>&amp;#x000A;</code> and <code>&amp;#x000D;</code>
+    respectively.</li>
+   <li>The bidirectional formatting characters U+202B, U+202C, U+202D, U+202E, U+2066,
+    U+2067, U+2068, U+2069, U+200E, U+200F, and U+061C must not appear literally; they may
+    be represented using
+    <a href="https://html.spec.whatwg.org/multipage/syntax.html#character-references">numeric
+    character references</a> (e.g. <code>&amp;#x200E;</code>).</li>
+   <li>The resulting string, after escape processing, must not contain the substring
+    "<code>--></code>" (U+002D HYPHEN-MINUS, U+002D HYPHEN-MINUS, U+003E GREATER-THAN SIGN).</li>
+  </ul>
  </li>
 </ol>
-<p>Process the <a>WebVTT attributes body block</a> key/value pairs according to the <a>WebVTT rules for parsing attribute key/value pairs</a>.</p>
+
+<p class="note">Keys are restricted to ASCII to ensure consistent case-folding and to avoid
+ambiguity in key matching. Values may contain any Unicode characters (subject to the constraints
+above) to support multilingual labels, language tags, and other internationalized content.</p>
+
+<p class="note">The numeric character reference escape convention above is the same as that used
+in WebVTT for bidi mark characters in cue payloads (e.g."<code>&amp;#x2068;</code>").</p>
 
 
 <p>A <dfn>WebVTT comment block</dfn> consists of the following components, in the given order:</p>
@@ -2614,11 +2690,13 @@ chapters, or metadata. Most of the steps will be skipped for chapters or metadat
 <h3 id=file-parsing algorithm>WebVTT file parsing</h3>
 
 <p>A <dfn>WebVTT parser</dfn>, given an input byte stream, a <a>text track list of cues</a>
-|output|, and a collection of <a spec=cssom>CSS style sheets</a> |stylesheets|, must decode the byte
-stream using the <a lt="UTF-8 decode">UTF-8 decode</a> algorithm, and then must parse the resulting
-string according to the <a>WebVTT parser algorithm</a> below. This results in <a>WebVTT cues</a>
-being added to |output|, and <a spec=cssom>CSS style sheets</a> being added to |stylesheets|.
-[[!RFC3629]]</p>
+|output|, a collection of <a spec=cssom>CSS style sheets</a> |stylesheets|, and optionally a
+slot |attributes| for a <a>WebVTT attributes object</a>, must decode the byte stream using the
+<a lt="UTF-8 decode">UTF-8 decode</a> algorithm, and then must parse the resulting string
+according to the <a>WebVTT parser algorithm</a> below. This results in <a>WebVTT cues</a>
+being added to |output|, <a spec=cssom>CSS style sheets</a> being added to |stylesheets|, and
+if a <a>WebVTT attributes block</a> is present, a <a>WebVTT attributes object</a> being set in
+|attributes|. [[!RFC3629]]</p>
 
 <p>A <a>WebVTT parser</a>, specifically its conversion and parsing steps, is typically run
 asynchronously, with the input byte stream being updated incrementally as the resource is
@@ -2713,6 +2791,9 @@ stream lacks this WebVTT file signature, then the parser aborts.</p>
 
    <li><p>Otherwise, if |block| is a <a>WebVTT region object</a>, add |block| to |regions|.</p></li>
 
+   <li><p>Otherwise, if |block| is a <a>WebVTT attributes object</a>, and |attributes| has been
+   provided to this invocation of the <a>WebVTT parser</a>, let |attributes| be |block|.</p></li>
+
    <!-- handle new block types here -->
 
    <li><p><a>collect a sequence of code points</a> that are U+000A LINE FEED (LF)
@@ -2752,6 +2833,8 @@ header</i> set, the user agent must run the following steps:</p>
  <li><p>Let |stylesheet| be null.</p></li>
 
  <li><p>Let |region| be null.</p></li>
+
+ <li><p>Let |attributes| be null.</p></li>
 
  <li>
 
@@ -2934,7 +3017,40 @@ header</i> set, the user agent must run the following steps:</p>
 
        </li>
 
-       <!-- <li><p>Otherwise, (check for new block types here)</p></li> -->
+        <li>
+
+         <p>Otherwise, if |seen cue| is false and |buffer| starts with the substring
+         "<code>ATTRIBUTES</code>" (U+0041, U+0054, U+0054, U+0052, U+0049, U+0042, U+0055, U+0054,
+         U+0045, U+0053), and the remaining characters in |buffer| (if any) are all <a>ASCII
+         whitespace</a>, then run these substeps:</p>
+
+         <ol>
+
+          <li><p><i>Attributes creation</i>: Let |attributes| be a new <a>WebVTT attributes
+          object</a>.</p></li>
+
+          <li><p>Let |attributes|'s <a lt="WebVTT attributes object kind">kind</a> be the empty
+          string.</p></li>
+
+          <li><p>Let |attributes|'s <a lt="WebVTT attributes object type">type</a> be the empty
+          string.</p></li>
+
+          <li><p>Let |attributes|'s <a lt="WebVTT attributes object language">language</a> be the
+          empty string.</p></li>
+
+          <li><p>Let |attributes|'s <a lt="WebVTT attributes object label">label</a> be the empty
+          string.</p></li>
+
+          <li><p>Let |attributes|'s <a lt="WebVTT attributes object custom pairs">custom pairs</a>
+          be an empty list.</p></li>
+
+          <li><p>Let |buffer| be the empty string.</p></li>
+
+         </ol>
+
+        </li>
+
+        <!-- <li><p>Otherwise, (check for new block types here)</p></li> -->
 
       </ol>
 
@@ -2968,6 +3084,9 @@ header</i> set, the user agent must run the following steps:</p>
  <li><p>Otherwise, if |region| is not null, then <a>collect WebVTT region settings</a> from |buffer|
  using |region| for the results. Construct a <a>WebVTT Region Object</a> from |region|, and return
  it.</p></li>
+
+ <li><p>Otherwise, if |attributes| is not null, then <a>collect WebVTT attribute settings</a> from
+ |buffer| using |attributes| for the results, and return |attributes|.</p></li>
 
  <!-- return new block types here -->
 
@@ -3105,6 +3224,56 @@ means that it is aborted at that point and returns nothing.</p>
  <li><p>Return |percentage|.</p></li>
 </ol>
 
+
+
+<h3 id=attributes-settings-parsing algorithm>WebVTT attributes settings parsing</h3>
+
+<p>When the <a>WebVTT parser algorithm</a> says to <dfn>collect WebVTT attribute settings</dfn>
+from a string |input| for a <a>WebVTT attributes object</a> |attributes|, the user agent must
+run the following steps:</p>
+
+<ol algorithm="collect WebVTT attribute settings">
+
+ <li><p>Let |lines| be the result of splitting |input| on U+000A LINE FEED (LF) characters.</p></li>
+
+ <li>
+  <p>For each string |line| in |lines|, run the following substeps:</p>
+  <ol>
+
+   <li><p>If |line| does not contain a U+003A COLON character (<code>:</code>), then jump to
+   the step labeled <i>next line</i>.</p></li>
+
+   <li><p>Let |name| be the leading substring of |line| up to and excluding the first U+003A
+   COLON character.</p></li>
+
+   <li><p>If |name| is not a valid <a>WebVTT attribute key</a>, then jump to the step labeled
+   <i>next line</i>.</p></li>
+
+   <li><p>Let |value| be the trailing substring of |line| starting from the character
+   immediately after the first U+003A COLON character.</p></li>
+
+   <li><p>If |value| is not empty and its first character is a U+0020 SPACE or U+0009
+   CHARACTER TABULATION (tab) character, remove that first character from |value|.</p></li>
+
+   <li><p>Let |value| be the result of
+   <a href="https://html.spec.whatwg.org/multipage/syntax.html#character-references">parsing
+   character references</a> in |value|, with no <i>additional allowed character</i>.</p></li>
+
+   <li><p>Run the <a>WebVTT rules for parsing attribute key/value pairs</a> for |name| and
+   |value| against |attributes|.</p></li>
+
+   <li><p><i>Next line</i>: Continue.</p></li>
+
+  </ol>
+ </li>
+
+ <li>
+  <p>If |attributes|'s <a lt="WebVTT attributes object custom pairs">custom pairs</a> is not
+  empty and |attributes|'s <a lt="WebVTT attributes object type">type</a> is the empty string,
+  then, parsers may generate a warning.</p>
+ </li>
+
+</ol>
 
 <h3 id=cue-timings-and-settings-parsing algorithm>WebVTT cue timings and settings parsing</h3>
 
@@ -4294,32 +4463,81 @@ follows:</p>
 </ol>
 
 
-<h3 id=rules-for-parsing-attr-key-values algorithm>WebVTT rules for parsing attribute key/value pairs</h3>
-<p>The <dfn>WebVTT rules for parsing attribute key/value pairs</dfn> consist of the following algorithm.</p>
+<h3 id="rules-for-parsing-attr-key-values" algorithm>WebVTT rules for parsing attribute key/value pairs</h3>
 
-<ol algorithm="WebVTT attributes block parsing">
- <li>Let |input| be the list of key/value pairs from a <a>WebVTT attributes block</a>.</li>
+<p>The <dfn>WebVTT rules for parsing attribute key/value pairs</dfn> for a |name|/|value| pair
+against a <a>WebVTT attributes object</a> |attributes| are as follows:</p>
+
+<ol algorithm="WebVTT rules for parsing attribute key/value pairs">
  <li>
-  How the attribute is processed depends on its key name, as follows:
+  How the pair is processed depends on |name|, as follows:
   <dl>
 
-   <dt>If the key name is "<code>kind</code>" (<a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">ASCII case-insensitive</a>)</dt>
-   <dd>Process the value as <a href="https://html.spec.whatwg.org/multipage/media.html#attr-track-kind">the kind attribute</a> of a track element according to the HTML Standard.</dd>
+   <dt>If |name| is an <a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">ASCII
+   case-insensitive</a> match for "<code>kind</code>"</dt>
+   <dd>
+    <p>Let |normalized| be the result of
+    <a href="https://infra.spec.whatwg.org/#ascii-lowercase">converting |value| to ASCII
+    lowercase</a>.</p>
+    <p>If |normalized| is one of "<code>subtitles</code>", "<code>captions</code>",
+    "<code>descriptions</code>", "<code>chapters</code>", or "<code>metadata</code>", set
+    |attributes|'s <a lt="WebVTT attributes object kind">kind</a> to |normalized|.</p>
+    <p>Otherwise, ignore the pair.</p>
+   </dd>
 
-   <dt>If the key name is "<code>lang</code>" (<a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">ASCII case-insensitive</a>)</dt>
-   <dd>Process the value as <a href="https://html.spec.whatwg.org/multipage/media.html#attr-track-srclang">the srclang attribute</a> of a track element according to the HTML Standard.</dd>
+   <dt>If |name| is an <a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">ASCII
+   case-insensitive</a> match for "<code>type</code>"</dt>
+   <dd>
+    <p>Let |normalized| be the result of
+    <a href="https://infra.spec.whatwg.org/#ascii-lowercase">converting |value| to ASCII
+    lowercase</a>.</p>
+    <p>If |normalized| is "<code>custom</code>" or starts with the prefix
+    "<code>custom-</code>" (U+0063, U+0075, U+0073, U+0074, U+006F, U+006D, U+002D), set
+    |attributes|'s <a lt="WebVTT attributes object type">type</a> to |normalized|.</p>
+    <p>Otherwise, if |normalized| is not the empty string, ignore the pair. All non-custom
+    type values are reserved for future standardization.</p>
+   </dd>
 
-   <dt>If the key name is "<code>label</code>" (<a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">ASCII case-insensitive</a>)</dt>
-   <dd>Process the value as <a href="https://html.spec.whatwg.org/multipage/media.html#attr-track-label">the label attribute</a> of a track element according to the HTML Standard.</dd>
+   <dt>If |name| is an <a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">ASCII
+   case-insensitive</a> match for "<code>language</code>"</dt>
+   <dd>Set |attributes|'s <a lt="WebVTT attributes object language">language</a> to
+   |value|.</dd>
+
+   <dt>If |name| is an <a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">ASCII
+   case-insensitive</a> match for "<code>label</code>"</dt>
+   <dd>Set |attributes|'s <a lt="WebVTT attributes object label">label</a> to |value|.</dd>
 
    <dt>Otherwise</dt>
-   <dd>Ignore the key/value pair.</dd>
+   <dd>Append the pair (|name|, |value|) to |attributes|'s
+   <a lt="WebVTT attributes object custom pairs">custom pairs</a>.</dd>
 
   </dl>
  </li>
 </ol>
 
-<p class="note">These keys are case-insensitive to allow compatibility with large video distributors <!-- namely YouTube --> already using this pattern in production.</p>
+<p class="note">The <code>kind</code> key is the only required key in a
+<a>WebVTT attributes block</a>. It disambiguates the track kind and guards against naming
+conflicts: consumers that do not recognise a given <code>kind</code> value should treat the
+entire <a>WebVTT attributes object</a> as opaque. The <code>type</code> key further
+differentiates subtypes within a <code>kind</code> (for example, distinguishing varieties of
+<code>metadata</code> tracks). All non-custom <code>type</code> values are reserved for future
+standardization; authors needing custom subtypes must use "<code>custom</code>" or a value
+beginning with "<code>custom-</code>".</p>
+
+<p class="note">The <code>kind</code>, <code>type</code>, <code>language</code>, and
+<code>label</code> keys are matched
+<a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">ASCII case-insensitively</a>
+to allow compatibility with implementations already using this pattern in production.
+Unrecognized keys are preserved in the
+<a lt="WebVTT attributes object custom pairs">custom pairs</a> list for use by consuming
+applications.</p>
+
+<p class="note">The <a>WebVTT attributes object</a>'s properties are consumed by the embedding
+context. How <a lt="WebVTT attributes object kind">kind</a>,
+<a lt="WebVTT attributes object language">language</a>, and
+<a lt="WebVTT attributes object label">label</a> relate to the corresponding attributes of an
+HTML <code>&lt;track&gt;</code> element is defined by the HTML specification. See
+<a href="https://github.com/whatwg/html/issues/11665">whatwg/html issue #11665</a>.</p>
 
 
 <h2 id=rendering>Rendering</h2>

--- a/index.bs
+++ b/index.bs
@@ -1847,7 +1847,7 @@ SIGN).</p>
 
 <p class="note">The <code>kind</code> key is the only required key in a
 <a>WebVTT attributes block</a>. It must appear in the block to disambiguate the track kind.
-Without it, consumers cannot determine whether other well-known keys such as
+Without it, consumers cannot determine whether other common key names such as
 <code>language</code> and <code>label</code> apply to a recognized track kind, and may treat
 them as opaque. See <a href="#rules-for-parsing-attr-key-values">WebVTT rules for parsing
 attribute key/value pairs</a>.</p>
@@ -3085,7 +3085,7 @@ header</i> set, the user agent must run the following steps:</p>
  using |region| for the results. Construct a <a>WebVTT Region Object</a> from |region|, and return
  it.</p></li>
 
- <li><p>Otherwise, if |attributes| is not null, then <a>collect WebVTT attribute settings</a> from
+ <li><p>Otherwise, if |attributes| is not null, then <a>collect WebVTT attributes</a> from
  |buffer| using |attributes| for the results, and return |attributes|.</p></li>
 
  <!-- return new block types here -->
@@ -3228,11 +3228,11 @@ means that it is aborted at that point and returns nothing.</p>
 
 <h3 id=attributes-settings-parsing algorithm>WebVTT attributes settings parsing</h3>
 
-<p>When the <a>WebVTT parser algorithm</a> says to <dfn>collect WebVTT attribute settings</dfn>
+<p>When the <a>WebVTT parser algorithm</a> says to <dfn>collect WebVTT attributes</dfn>
 from a string |input| for a <a>WebVTT attributes object</a> |attributes|, the user agent must
 run the following steps:</p>
 
-<ol algorithm="collect WebVTT attribute settings">
+<ol algorithm="collect WebVTT attributes">
 
  <li><p>Let |lines| be the result of splitting |input| on U+000A LINE FEED (LF) characters.</p></li>
 


### PR DESCRIPTION
Closes #511

Add new ATTRIBUTES block parsing rules and examples as discussed in #511.

This is also a prerequisite for:
- https://github.com/w3c/webvtt/issues/512

…and its duplicate in the WHATWG repo:
https://github.com/whatwg/html/issues/11333


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cookiecrook/webvtt/pull/523.html" title="Last updated on Mar 9, 2026, 7:24 PM UTC (b60d4b9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webvtt/523/bd70b0a...cookiecrook:b60d4b9.html" title="Last updated on Mar 9, 2026, 7:24 PM UTC (b60d4b9)">Diff</a>