### PR TITLE
Remove erroneous whitespace from code example

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5245,13 +5245,13 @@ present in the <{video}> element's document tree.</p>
 
      REGION
      id:editor-comments
-     width: 40%
+     width:40%
      regionanchor:0%,100%
      viewportanchor:10%,90%
 
      REGION
      id:scroll
-     width: 40%
+     width:40%
      regionanchor:100%,100%
      viewportanchor:90%,90%
      scroll:up


### PR DESCRIPTION
The WebVTT specification contains examples that use a whitespace after the colon in a [WebVTT region width setting](https://www.w3.org/TR/webvtt1/#webvtt-region-width-setting) although the spec doesn't allow it. This PR removes these whitespace characters.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dschuessler/webvtt/pull/527.html" title="Last updated on Jan 1, 2025, 3:35 PM UTC (1024baa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webvtt/527/aeaf117...dschuessler:1024baa.html" title="Last updated on Jan 1, 2025, 3:35 PM UTC (1024baa)">Diff</a>