### PR TITLE
Editorial: Clarify ::cue(*) and ::cue(:root) and WebVTT Leaf Node Objects

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5043,8 +5043,7 @@ present in the <{video}> element's document tree.</p>
      </pre>
     </td>
     <td class=long>
-     <p><a>WebVTT Internal Node Objects</a> (except the root <a>list of WebVTT Node Objects</a>)
-     with the given name.</p>
+     <p><a>WebVTT Internal Node Objects</a> with the given name.</p>
 
      <pre>
      WEBVTT
@@ -5058,6 +5057,30 @@ present in the <{video}> element's document tree.</p>
      &lt;ruby>Yellow! &lt;rt>Yellow!&lt;/rt>&lt;/ruby>
      &lt;v Kathryn>Yellow!&lt;/v>
      &lt;lang en>Yellow!&lt;/lang>
+     </pre>
+    </td>
+   </tr>
+   <tr>
+    <td class=long>
+     <p><a>Universal selector</a> in ''::cue()''</p>
+
+     <pre>
+     video::cue(*:not(:root)) {
+       color: yellow;
+     }
+     </pre>
+    </td>
+    <td class=long>
+     <p>All <a>WebVTT Internal Node Objects</a></p>
+
+     <pre>
+     WEBVTT
+
+     00:00:00.000 --> 00:00:08.000
+     White!
+     &lt;c>Yellow!&lt;/c>
+     &lt;i>Yellow!&lt;/i>
+     &lt;u>Yellow!&lt;/u>
      </pre>
     </td>
    </tr>
@@ -5405,6 +5428,11 @@ being treated as follows:</p>
  <li><p>For the purposes of element type and universal selectors, <a lt="WebVTT Internal Node
  Object">WebVTT Internal Node Objects</a> are considered as being in the namespace expressed as the
  empty string.</p></li>
+
+ <li><p class=note>The <a>universal selector</a> matches all <a>WebVTT Internal Node Objects</a>, including the
+ root <a>list of WebVTT Node Objects</a>.</p></li>
+
+ <li><p class=note>''::cue(:root)'' is equivalent to ''::cue''.</p></li>
 
  <li><p>For the purposes of attribute selector matching, <a lt="WebVTT Internal Node Object">WebVTT
  Internal Node Objects</a> have no attributes, except for <a lt="WebVTT Voice Object">WebVTT Voice


### PR DESCRIPTION
This PR addresses https://github.com/w3c/webvtt/issues/533

Add notes and examples to clarify that `::cue(*)` matches all WebVTT internal node objects, including the root list of WebVTT node objects, and to clarify that `::cue(:root)` is a valid selector and it matches the same elements as `::cue`.  

Because a universal selector is within the class of type selectors, delete the parenthical note in Example 22 that makes it seem that type selectors can never match the root.

Also add spacing around the section of Leaf Node Objects. The current spacing makes it easy to confuse it as a subclass of WebVTT Internal Node Objects.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/danae404/webvtt/pull/534.html" title="Last updated on Oct 8, 2025, 8:20 PM UTC (898f395)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webvtt/534/7ff8d0a...danae404:898f395.html" title="Last updated on Oct 8, 2025, 8:20 PM UTC (898f395)">Diff</a>