### PR TITLE
Cue settings should require colon and value in the syntax

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1624,8 +1624,8 @@ following components, in the order given:</p>
 
 <ol>
  <li>A <a lt="WebVTT cue setting name">WebVTT cue setting name</a>.</li>
- <li>An optional U+003A COLON (colon) character.</li>
- <li>An optional <a lt="WebVTT cue setting value">WebVTT cue setting value</a>.</li>
+ <li>A U+003A COLON (colon) character.</li>
+ <li>A <a lt="WebVTT cue setting value">WebVTT cue setting value</a>.</li>
 </ol>
 
 <p>A <dfn>WebVTT cue setting name</dfn> and a <dfn>WebVTT cue setting value</dfn> each consist of


### PR DESCRIPTION
Fixes #541


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/zcorpan/webvtt-spec/pull/542.html" title="Last updated on Mar 18, 2026, 12:59 PM UTC (f4429f1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webvtt/542/429ed00...zcorpan:f4429f1.html" title="Last updated on Mar 18, 2026, 12:59 PM UTC (f4429f1)">Diff</a>