### PR TITLE
Replace api.csswg.org with spec-generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,5 +4,5 @@ all: index.html
 
 # build using spec-generator but not local bikeshed
 index.html: index.bs
-	curl https://www.w3.org/publications/spec-generator/ -F file=@index.bs -F type=bikeshed-spec -F output=error
+	curl https://www.w3.org/publications/spec-generator/ -F file=@index.bs -F type=bikeshed-spec -F output=messages
 	curl https://www.w3.org/publications/spec-generator/ -F file=@index.bs -F type=bikeshed-spec -F die-on=nothing > index.html | tee

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 all: index.html
 
-# build using api.csswg.org but not local bikeshed
+# build using spec-generator but not local bikeshed
 index.html: index.bs
-	curl https://api.csswg.org/bikeshed/ -F file=@index.bs -F output=err
-	curl https://api.csswg.org/bikeshed/ -F file=@index.bs -F force=1 > index.html | tee
+	curl https://www.w3.org/publications/spec-generator/ -F file=@index.bs -F type=bikeshed-spec -F output=error
+	curl https://www.w3.org/publications/spec-generator/ -F file=@index.bs -F type=bikeshed-spec -F die-on=nothing > index.html | tee


### PR DESCRIPTION
The Bikeshed service at api.csswg.org has been deprecated in favor of spec-generator. The former URL redirects to a documentation that explains how to migrate:
https://github.com/w3c/spec-generator/wiki/Migrating-Bikeshed-HTTP-API-usage-to-spec%E2%80%90generator

That redirection unfortunately makes the build somewhat succeeds without error, creating an unhelpful 302 document instead of the actual spec.

This update makes the Makefile use the spec-generator service.